### PR TITLE
docs: fix accuracy gaps across architecture and sequence docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cp pi-web ~/.pi/agent/bin/
 sudo cp pi-web /usr/local/bin/
 ```
 
-The frontend bundle is embedded via `//go:embed web/dist`, so `go build` needs
+The frontend bundle is embedded via `//go:embed all:web/dist`, so `go build` needs
 `web/dist` to exist first. `make build` does both steps in order; if you build
 by hand, run `npm --prefix web install && npm --prefix web run build` before
 `go build`.

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -21,6 +21,7 @@ pi-web/
 │   ├── rpc/
 │   │   ├── client.go           # JSONL RPC command builders
 │   │   ├── worker.go           # pi --mode rpc subprocess worker
+│   │   ├── stream.go           # SSE chat-preview stream accumulator
 │   │   └── oneshot.go          # One-shot RPC for model enumeration
 │   ├── server/
 │   │   ├── server.go           # Server type, deps, SSE client registry
@@ -52,15 +53,22 @@ Central state holder. Created once at startup, lives for the process lifetime.
 type Server struct {
     sessionsDir   string          // ~/.pi/agent/sessions
     clients       []*sseClient    // active SSE connections
+    clientsMu     sync.RWMutex
     fileMod       map[string]time.Time  // last seen modtime per session
+    fileModMu     sync.RWMutex
     chatSender    ChatSender      // workers.Manager
     cache         *sessions.Cache // modtime-aware parse cache
     auth          *auth.Middleware
-    renderIndex   func(w io.Writer, sessions []sessions.Session) error
+    shareRunner   shareCmdRunner  // overridable in tests
+    now           func() time.Time
+    renderIndex   func(w io.Writer, summaries []sessions.SessionSummary) error
     renderSession func(s sessions.Session, showButtons bool) string
     models        func(ctx context.Context) (json.RawMessage, error)
     lastKnown     map[string]struct{} // sessions currently broadcast as running
+    lastKnownMu   sync.Mutex
     stopCh        chan struct{}
+    stopOnce      sync.Once
+    wg            sync.WaitGroup
 }
 ```
 
@@ -90,9 +98,12 @@ Manages `pi --mode rpc` subprocesses per session.
 
 ```go
 type Manager struct {
-    workers map[string]ChatWorker  // sessionID → worker
-    factory Factory                // sessionPath → ChatWorker
-    idleTTL time.Duration          // default 30m
+    mu         sync.Mutex
+    workers    map[string]ChatWorker  // sessionID → worker
+    factory    Factory                // (sessionID, sessionPath) → ChatWorker
+    idleTTL    time.Duration          // default 30m
+    reaperStop chan struct{}
+    reaperDone chan struct{}
 }
 ```
 
@@ -102,14 +113,22 @@ A single `pi --mode rpc` subprocess. Communicates via JSONL on stdin/stdout.
 
 ```go
 type piRPCWorker struct {
-    sessionPath    string
-    cmd            *exec.Cmd
-    stdin          io.WriteCloser
-    status         workers.WorkerStatus
-    pending        map[string]chan response  // in-flight RPC calls
-    currentModel   string
-    currentProvider string
+    mu                   sync.Mutex
+    writeMu              sync.Mutex
+    sessionPath          string
+    cmd                  *exec.Cmd
+    stdin                io.WriteCloser
+    status               workers.WorkerStatus
+    seq                  atomic.Uint64
+    pending              map[string]chan response  // in-flight RPC calls
+    currentModel         string
+    currentProvider      string
     currentThinkingLevel string
+    stderrBuf            *strings.Builder
+    lastActive           atomic.Int64 // unix nanos; user-initiated actions
+    lastStreamActivity   atomic.Int64 // unix nanos; stream events keep worker visually running
+    streamSink           StreamEventSink
+    streamPreview        *streamPreviewAccumulator
 }
 ```
 
@@ -121,6 +140,7 @@ type piRPCWorker struct {
 | `/session` | GET | `handleSession` | Render single session as embedded HTML |
 | `/api/session` | GET | `handleApiSession` | JSON session data |
 | `/api/chat` | POST | `handleChat` | Send chat message (multipart) |
+| `/api/chat/cancel` | POST | `handleCancelChat` | Abort running chat worker |
 | `/api/set-model` | POST | `handleSetModel` | Change model for session |
 | `/api/set-thinking-level` | POST | `handleSetThinkingLevel` | Change thinking level |
 | `/api/models` | GET | `handleAvailableModels` | List available AI models |
@@ -146,7 +166,7 @@ Request ──▶ auth.Wrap(handler)
         │               │
         ▼               ▼
    extract token    pass through
-   (query → cookie → header → X-Pi-Token)
+   (query → Authorization: Bearer → X-Pi-Token → cookie)
         │
         ▼
    constant-time compare
@@ -166,7 +186,7 @@ The server maintains a slice of `sseClient` structs. Each client subscribes to a
 - `__all__` — index page subscribes here; receives `new-session`, `status-snapshot`, `status-delta`
 - Specific session ID — session page subscribes here; receives `reload` when the file changes
 
-Broadcasting is fire-and-forget with a small buffered channel (4). If the client is slow, events are dropped rather than blocking.
+Broadcasting is fire-and-forget with a buffered channel (16). If the client is slow, keyless events are dropped rather than blocking. Duplicate `reload` and `new-session` events are coalesced per-client while pending.
 
 ## Running-Status Computation
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -76,8 +76,8 @@ LoadAll(dir)
     │
     ├──▶ For each .jsonl file:
     │         ├──▶ Check modtime against cache
-    │         ├──▶ MATCH → return cached Session
-    │         └──▶ MISMATCH → ParseFile + store in cache
+    │         ├──▶ MATCH → return cached SessionSummary
+    │         └──▶ MISMATCH → ParseSummary + store in cache
     │
     ├──▶ Evict files no longer on disk
     │
@@ -123,7 +123,7 @@ Browser POST /api/chat?id=<id>
            ├──▶ workers.Manager.Send(ctx, sessionID, sessionPath, chatReq)
            │         │
            │         ├──▶ Get or create ChatWorker for session
-           │         │         └──▶ rpc.NewPiWorker(sessionPath)
+           │         │         └──▶ rpc.NewPiWorkerWithStream(sessionPath, streamSink)
            │         │               ├──▶ exec.Command("pi", "--mode", "rpc")
            │         │               ├──▶ Start subprocess
            │         │               ├──▶ switch_session RPC
@@ -173,7 +173,7 @@ Browser POST /share?id=<id>
            │
            ├──▶ gh auth status → verify login
            │
-           ├──▶ loadSessions → find matching session
+           ├──▶ deps.Resolve(id) → find matching session
            │
            ├──▶ generateExportHtml(session, false)  (no buttons)
            │
@@ -182,4 +182,26 @@ Browser POST /share?id=<id>
            ├──▶ gh gist create --public=false <tmpfile>
            │
            └──▶ Return {gistUrl, gistId, previewUrl}
+```
+
+## Data Flow: Create New Session
+
+```
+Browser POST /api/new-session
+           │
+           ▼
+    server.handleNewSession
+           │
+           ├──▶ Decode JSON body → extract path
+           │
+           ├──▶ Validate path (absolute, exists or create)
+           │
+           ├──▶ Encode project name → create directory under sessionsDir
+           │
+           ├──▶ Generate UUID + timestamp → write header JSONL
+           │
+           ├──▶ Pre-initialize chat worker (EnsureWorker)
+           │         └──▶ So the session page can read default model/thinking level immediately
+           │
+           └──▶ Return {"ok": true, "id": <filename>}
 ```

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -10,8 +10,10 @@ Built with **Vite** + **Alpine.js**, embedded into the Go binary.
 
 ```
 web/src/index/index.js    ──┐
+web/src/session/session.js  │
 web/src/shared/api.js       ├──▶  vite build  ──▶  web/dist/  ──▶  //go:embed
 web/src/shared/storage.js   │                      │              (dist_embed.go)
+web/src/shared/escape.js    │                      │
 web/src/live/live.js        │                      │
                             │                      ▼
                         .vite/manifest.json    assets/index-*.js
@@ -25,7 +27,7 @@ The index page (`templates/index.html`) is rendered by `indexTmpl` with these he
 
 - `fmtTime` — format RFC3339 to human-readable
 - `fmtTokens` — abbreviate large numbers (1.2k, 3.4M)
-- `fmtCost` — format cost as `$0.0012` or `—`
+- `fmtCost` — format cost as `$0.0001` or `—`
 - `sessionName` — derive display name from header or first user message
 - `indexScript` — inject the correct Vite bundle path
 
@@ -117,8 +119,15 @@ HTML escape utility for safely rendering user content.
 
 Colors are defined in `computeThemeVars()` in `export.go` as CSS custom properties. The session page injects them into `:root`.
 
-Key color tokens:
+Key color tokens (full list in `computeThemeVars()` in `export.go`):
 - `--cyan`, `--blue`, `--green`, `--red`, `--yellow` — semantic colors
 - `--userMessageBg` — user chat bubble
 - `--toolSuccessBg` / `--toolErrorBg` — tool result states
 - `--thinkingLow` → `--thinkingXhigh` — thinking level indicator gradient
+- `--bodyBg`, `--containerBg`, `--infoBg` — replaced at render time
+- `--accent`, `--selectedBg`, `--customMessageBg`, `--customMessageLabel`
+- `--mdHeading`, `--mdLink`, `--mdCode`, `--mdCodeBlock`, `--mdQuote`
+- `--toolDiffAdded`, `--toolDiffRemoved`, `--toolDiffContext`
+- `--syntaxComment`, `--syntaxKeyword`, `--syntaxFunction`, `--syntaxVariable`, `--syntaxString`
+- `--bashMode`, `--success`, `--error`, `--warning`, `--muted`, `--dim`, `--text`
+- `--border`, `--borderAccent`, `--borderMuted`, `--toolOutput`

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -44,6 +44,7 @@ pi-web is a local HTTP server that lets you browse and interact with your pi cod
 │   GET  /session       →  handleSession    (embedded HTML)                │
 │   GET  /api/session   →  handleApiSession  (JSON)                        │
 │   POST /api/chat      →  handleChat        (multipart or JSON)           │
+│   POST /api/chat/cancel → handleCancelChat                               │
 │   POST /api/set-model →  handleSetModel                                  │
 │   POST /api/set-thinking-level → handleSetThinkingLevel                  │
 │   GET  /api/models    →  handleAvailableModels                           │
@@ -118,7 +119,7 @@ pi-web is a local HTTP server that lets you browse and interact with your pi cod
 6. Create `Server` → starts file watcher + status watcher + sweeper
 7. Register routes on `http.ServeMux`
 8. Load Vite manifest and register static assets
-9. Write pidfile to `~/.pi/agent/pi-web-state.json`
+9. Write state file to `~/.pi/agent/pi-web-state.json` (with flock)
 10. Optionally open browser
 11. Warm models cache (async)
-12. `http.ListenAndServe`
+12. Start `http.Server` with timeouts; graceful shutdown on `SIGINT`/`SIGTERM`

--- a/docs/sequence-flows/chat.md
+++ b/docs/sequence-flows/chat.md
@@ -44,7 +44,7 @@ This flow covers a user typing a message (with optional image attachment) in the
      │             │              │                  │                  │       │       │
      │             │              │                  │                  │   no  │       │
      │             │              │                  │                  │   ▼   │       │
-     │             │              │                  │                  │─── factory(path)──▶│
+     │             │              │                  │                  │─── factory(id, path)──▶│
      │             │              │                  │                  │       │       │
      │             │              │                  │                  │       │─── exec.Command("pi", "--mode", "rpc")
      │             │              │                  │                  │       │─── Start()
@@ -87,7 +87,7 @@ This flow covers a user typing a message (with optional image attachment) in the
      │             │              │                  │                  ├─── Status()
      │             │              │                  │                  │   (may return running)
      │             │              │                  │                  │               │
-     │◀──────────── {state: "running", model: "…"} ─│                  │               │
+     │◀──────────── {state: "running", model: "…", thinkingLevel: "…"} ─│                  │               │
      │             │              │                  │                  │               │
      │             │              │                  │                  │               │
      │  [Later]    │              │                  │                  │               │
@@ -145,8 +145,8 @@ Lock mutex
     If exists and error → close and delete
 Unlock mutex
 
-Create new worker: factory(sessionPath)
-  → rpc.NewPiWorker(sessionPath)
+Create new worker: factory(sessionID, sessionPath)
+  → rpc.NewPiWorkerWithStream(sessionPath, streamSink)
 
 Lock mutex
   Double-check no race winner created one
@@ -204,3 +204,11 @@ These update `lastStreamActivity` so `Status()` continues to report `running` un
 ### 8. Worker Lifecycle
 
 After 30 minutes of idle time (no user-initiated actions), the reaper goroutine closes idle workers to free resources.
+
+### 9. Cancelling a Chat
+
+`POST /api/chat/cancel?id=<id>` aborts the running worker, removes the terminal's session-status file, broadcasts a `reload` event, and returns `{"ok": true, "status": "cancelled"}`.
+
+### 10. Model Switch Side Effect
+
+`handleSetModel` updates the worker model via RPC. On success, the worker automatically refreshes its thinking level (`refreshThinkingLevel`) so the UI stays consistent.

--- a/docs/sequence-flows/live-reload.md
+++ b/docs/sequence-flows/live-reload.md
@@ -111,7 +111,7 @@ Polling scans all `.jsonl` files and compares modtimes against `fileMod` map.
        │ writes status    │                    │                │             │
        │─────────────────▶│                    │                │             │
        │                  │                    │                │             │
-       │                  │ Create/Write event │                │             │
+       │                  │ Create/Write/Rename event │                │             │
        │                  │───────────────────▶│                │             │
        │                  │                    │                │             │
        │                  │                    │─── recomputeAndBroadcastStatus

--- a/docs/sequence-flows/server-startup.md
+++ b/docs/sequence-flows/server-startup.md
@@ -44,7 +44,7 @@ This document traces the execution from `go run .` to the first HTTP request.
    │           │             │              │              │            │
    │           │─── mux.HandleFunc(/static/assets/…) ───────────────────▶│
    │           │             │              │              │            │
-   │           │─── writePidfile() ────────▶│              │            │
+   │           │─── writeStateFile() ────────▶│              │            │
    │           │             │              │              │            │
    │           │─── warmModelsCache() ─────▶│              │            │
    │           │             │              │              │            │
@@ -61,7 +61,7 @@ This document traces the execution from `go run .` to the first HTTP request.
 ### 1. CLI Flag Parsing
 
 ```go
-port := flag.String("p", "31483", "port to listen on")
+port := flag.String("p", "31415", "port to listen on")
 hostOverride := flag.String("host", "", "host/IP to bind")
 open := flag.Bool("o", false, "auto-open browser")
 insecure := flag.Bool("insecure", false, "allow non-loopback bind without PI_WEB_TOKEN")
@@ -103,9 +103,15 @@ Non-loopback binds **require** `PI_WEB_TOKEN` to prevent unauthorized access ove
 srv := server.New(server.Deps{
     SessionsDir:   sessionsDir,
     Auth:          authMiddleware,
-    ChatSender:    workers.NewManager(rpc.NewPiWorker),
+    ChatSender:    workers.NewManager(func(sessionID, sessionPath string) (workers.ChatWorker, error) {
+        return rpc.NewPiWorkerWithStream(sessionPath, func(preview rpc.StreamPreview) {
+            if srv != nil {
+                srv.BroadcastChatPreview(sessionID, preview)
+            }
+        })
+    }),
     Cache:         sessions.NewCache(),
-    RenderIndex:   func(w io.Writer, ss []sessions.Session) error { … },
+    RenderIndex:   func(w io.Writer, ss []sessions.SessionSummary) error { … },
     RenderSession: generateExportHtml,
     Models:        func(ctx context.Context) (json.RawMessage, error) { … },
 })
@@ -142,7 +148,7 @@ Reads Vite manifest to discover the hashed filename of the index bundle.
 ### 8. Pidfile
 
 ```go
-writePidfile(bindHost, port, usedTailscale)
+writeStateFile(bindHost, port, usedTailscale)
 // → ~/.pi/agent/pi-web-state.json
 ```
 
@@ -159,7 +165,13 @@ Spawns `pi --mode rpc` once to fetch the model list, so the first session page l
 ### 10. Listen
 
 ```go
-http.ListenAndServe(addr, mux)
+httpServer := &http.Server{
+    Addr:              addr,
+    Handler:           mux,
+    ReadHeaderTimeout: 10 * time.Second,
+    IdleTimeout:       120 * time.Second,
+}
+httpServer.ListenAndServe()
 ```
 
-Blocks forever (or until error).
+Blocks until interrupted. On `SIGINT`/`SIGTERM` the server performs a graceful shutdown (5s timeout) and calls `srv.Shutdown()` to stop background goroutines.

--- a/docs/sequence-flows/session-viewing.md
+++ b/docs/sequence-flows/session-viewing.md
@@ -113,6 +113,9 @@ func generateExportHtml(session sessions.Session, showButtons bool) string {
 
     // 2. Build CSS with theme variables injected
     css := strings.Replace(templateCss, "{{THEME_VARS}}", precomputedThemeVars, 1)
+    css = strings.Replace(css, "{{BODY_BG}}", bodyBg, 1)
+    css = strings.Replace(css, "{{CONTAINER_BG}}", cardBg, 1)
+    css = strings.Replace(css, "{{INFO_BG}}", infoBg, 1)
 
     // 3. Assemble HTML
     html := templateHtml
@@ -124,6 +127,7 @@ func generateExportHtml(session sessions.Session, showButtons bool) string {
     html = strings.Replace(html, "{{HIGHLIGHT_JS}}", hljsJs, 1)
 
     if showButtons {
+        // actionButtons = back link + share button + terminal button
         html = strings.Replace(html, "<body>", "<body>"+actionButtons, 1)
         html = strings.Replace(html, "{{CHAT_COMPOSER}}", chatComposerHtml, 1)
         html = strings.Replace(html, "</body>", liveReloadJs+"</body>", 1)
@@ -150,4 +154,6 @@ When the session file changes, the file watcher calls `broadcast(sessID, "reload
 
 ## Caching Behavior
 
-If the same session is viewed multiple times in quick succession, `sessions.Cache` may return a cached `Session` without re-parsing, provided the file's `modTime` hasn't changed.
+Single-session views (`/session`, `/api/session`) always parse the full file on demand via `sessions.ResolveByID` → `ParseFile`. There is no caching at this layer.
+
+`sessions.Cache` (via `LoadAll`) is used **only** by the index page (`/`) to avoid re-parsing summaries for the session list. It returns `SessionSummary` structs (lightweight, no full entry list) keyed by file modtime.

--- a/docs/sequence-flows/share.md
+++ b/docs/sequence-flows/share.md
@@ -21,7 +21,7 @@ This flow covers a user clicking the **Share** button on a session page, which c
      │             │              │─── gh auth status│               │              │
      │             │              │   (verify logged in)              │               │
      │             │              │                  │               │              │
-     │             │              │─── loadSessions()│               │              │
+     │             │              │─── deps.Resolve(id)│               │              │
      │             │              │   (find matching session)         │               │
      │             │              │                  │               │              │
      │             │              │─── generateExportHtml(session, false)
@@ -88,7 +88,7 @@ If not logged in → `400` error: `"GitHub CLI not logged in. Run 'gh auth login
 
 ### 4. Find and Render Session
 
-The handler loads all sessions and finds the matching one by ID. It then calls:
+The handler resolves the session by ID and then calls:
 
 ```go
 generateExportHtml(session, false)


### PR DESCRIPTION
Audit found ~25 discrepancies between docs and current codebase. See commit message for full details.

Key fixes:
- default port: 31483 → 31415
- add missing POST /api/chat/cancel route
- Server.renderIndex takes []SessionSummary, not []Session
- Cache returns SessionSummary (ParseSummary), not full Session
- Factory signature: sessionPath → (sessionID, sessionPath)
- rpc.NewPiWorker → rpc.NewPiWorkerWithStream
- SSE buffer size: 4 → 16; document event-key deduplication
- Auth token order corrected
- startup: writePidfile → writeStateFile; add graceful shutdown + timeouts
- status watcher handles Rename events
- session page: add Terminal button, CSS bg placeholders
- share flow: loadSessions → deps.Resolve(id)
- add missing New Session data-flow section
- add missing Cancel Chat and Model Switch Side Effect sections
- expand theme token list
- README: go:embed web/dist → go:embed all:web/dist
- fix fmtCost example