### PR TITLE
refactor: add AgentDir plumbing, consolidate pi-web data under pi-web/ subdirectory

### DIFF
--- a/.pi/extensions/pi-web.ts
+++ b/.pi/extensions/pi-web.ts
@@ -26,6 +26,12 @@ interface PiWebState {
   startedAt: string;
 }
 
+function agentDir(): string {
+  const env = process.env["PI_CODING_AGENT_DIR"];
+  if (env) return env;
+  return `${homedir()}/.pi/agent`;
+}
+
 async function detectHostPort(
   pi: ExtensionAPI,
 ): Promise<{
@@ -34,27 +40,32 @@ async function detectHostPort(
   tailscale: boolean;
   tailscaleUrl?: string;
 } | null> {
-  // 1. Try pidfile
-  try {
-    const path = `${homedir()}/.pi/agent/pi-web-state.json`;
-    const raw = readFileSync(path, "utf-8");
-    const state: PiWebState = JSON.parse(raw);
-
-    // Validate PID is still alive
+  // 1. Try pidfile (new path first, then old for migration compat)
+  const candidates = [
+    `${agentDir()}/pi-web/pi-web-state.json`,
+    `${agentDir()}/pi-web-state.json`,
+  ];
+  for (const path of candidates) {
     try {
-      process.kill(state.pid, 0);
-    } catch {
-      throw new Error("stale pi-web pidfile");
-    }
+      const raw = readFileSync(path, "utf-8");
+      const state: PiWebState = JSON.parse(raw);
 
-    return {
-      host: state.host,
-      port: state.port,
-      tailscale: state.tailscale,
-      tailscaleUrl: state.tailscaleUrl,
-    };
-  } catch {
-    // fall through
+      // Validate PID is still alive
+      try {
+        process.kill(state.pid, 0);
+      } catch {
+        continue;
+      }
+
+      return {
+        host: state.host,
+        port: state.port,
+        tailscale: state.tailscale,
+        tailscaleUrl: state.tailscaleUrl,
+      };
+    } catch {
+      // try next candidate
+    }
   }
 
   // 2. Process fallback (macOS / Linux)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,4 +97,4 @@ make check    # test + build + vet
 2. **Existing session data is append-only for rename.** Browser chat goes to a `pi --mode rpc` worker, which writes conversation entries. pi-web otherwise watches and broadcasts; its only direct write to existing session files is appending `session_info` for browser rename. New-session creation may write initial implicit `model_change` / `thinking_level_change` entries in the fresh file.
 3. **One worker per session.** Reused for subsequent messages. Crashed = evicted + replaced. Idle workers reaped after 10 min.
 4. **SSE topics:** `globalSessID = "__all__"` for index-wide events; session ID for per-session events.
-5. **Default port:** `31415`. State file: `~/.pi/agent/pi-web-state.json`.
+5. **Default port:** `31415`. State file: `~/.pi/agent/pi-web/pi-web-state.json`.

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -51,6 +51,7 @@ Central state holder. Created once at startup, lives for the process lifetime.
 
 ```go
 type Server struct {
+    agentDir      string          // ~/.pi/agent (respects PI_CODING_AGENT_DIR)
     sessionsDir   string          // ~/.pi/agent/sessions
     clients       []*sseClient    // active SSE connections
     clientsMu     sync.RWMutex
@@ -196,7 +197,7 @@ Broadcasting is fire-and-forget with a buffered channel (16). If the client is s
 
 Three signals are OR'd together to determine if a session is "running":
 
-1. **session-status file** (`~/.pi/agent/sessions/../session-status/<id>`): written by the terminal pi process
+1. **session-status file** (`~/.pi/agent/session-status/<id>`): written by the terminal pi process
 2. **In-process chat worker**: `chatSender.Status(id).State == running`
 3. **Recent file activity**: modtime within 3 seconds
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -106,16 +106,19 @@ name, while pi-web itself continues listening only on localhost.
 ## Session Directory Layout
 
 ```
-~/.pi/agent/sessions/
-├── --project-name--/
-│   ├── 2026-01-15T10-30-00.000Z_a1b2c3d4.jsonl
-│   ├── 2026-01-15T11-00-00.000Z_e5f6g7h8.jsonl
+~/.pi/agent/
+├── sessions/
+│   ├── --project-name--/
+│   │   ├── 2026-01-15T10-30-00.000Z_a1b2c3d4.jsonl
+│   │   ├── 2026-01-15T11-00-00.000Z_e5f6g7h8.jsonl
+│   │   └── …
+│   └── --another--project--/
+│       └── …
+├── session-status/
+│   ├── 2026-01-15T10-30-00.000Z_a1b2c3d4.jsonl   ← terminal writes here
 │   └── …
-├── --another--project--/
-│   └── …
-└── session-status/
-    ├── 2026-01-15T10-30-00.000Z_a1b2c3d4.jsonl   ← terminal writes here
-    └── …
+└── pi-web/
+    └── pi-web-state.json   ← server state file
 ```
 
 ## Startup Order
@@ -129,7 +132,7 @@ name, while pi-web itself continues listening only on localhost.
 7. Register routes on `http.ServeMux`
 8. Load Vite manifest and register static assets
 9. Optionally configure Tailscale Serve HTTPS for localhost
-10. Write state file to `~/.pi/agent/pi-web-state.json` (with flock)
+10. Write state file to `~/.pi/agent/pi-web/pi-web-state.json` (with flock)
 11. Optionally open browser
 12. Warm models cache (async)
 13. Start `http.Server` with timeouts; graceful shutdown on `SIGINT`/`SIGTERM`

--- a/docs/sequence-flows/server-startup.md
+++ b/docs/sequence-flows/server-startup.md
@@ -67,17 +67,18 @@ open := flag.Bool("o", false, "auto-open browser")
 insecure := flag.Bool("insecure", false, "allow non-loopback bind without PI_WEB_TOKEN")
 ```
 
-### 2. Sessions Directory Validation
+### 2. Agent & Sessions Directory
 
 ```go
-sessionsDir := filepath.Join(os.Getenv("HOME"), ".pi", "agent", "sessions")
+agentDir := piAgentDir()  // respects PI_CODING_AGENT_DIR, falls back to ~/.pi/agent
+sessionsDir := filepath.Join(agentDir, "sessions")
 if _, err := os.Stat(sessionsDir); os.IsNotExist(err) {
     fmt.Fprintf(os.Stderr, "sessions directory not found: %s\n", sessionsDir)
     os.Exit(1)
 }
 ```
 
-Exits early if the user hasn't run `pi` yet (which creates this directory).
+`piAgentDir()` checks `PI_CODING_AGENT_DIR` first, then falls back to `~/.pi/agent`. Exits early if the sessions directory doesn't exist (the user hasn't run `pi` yet).
 
 ### 3. Host Selection
 
@@ -108,6 +109,7 @@ Non-loopback binds **require** `PI_WEB_TOKEN` to prevent unauthorized access ove
 
 ```go
 srv := server.New(server.Deps{
+    AgentDir:      agentDir,
     SessionsDir:   sessionsDir,
     Auth:          authMiddleware,
     ChatSender:    workers.NewManager(func(sessionID, sessionPath string) (workers.ChatWorker, error) {
@@ -153,14 +155,14 @@ if scriptPath, js, err := loadIndexScript(distFS()); err == nil {
 
 Reads Vite manifest to discover the hashed filename of the index bundle.
 
-### 8. Pidfile
+### 8. State File
 
 ```go
-writeStateFile(bindHost, port, tailscaleServe, tailscaleURL)
-// → ~/.pi/agent/pi-web-state.json
+writeStateFile(agentDir, bindHost, port, tailscaleServe, tailscaleURL)
+// → ~/.pi/agent/pi-web/pi-web-state.json
 ```
 
-Contains PID, port, host, Tailscale Serve flag/URL, and start time. Cleaned up on shutdown.
+Contains PID, port, host, Tailscale Serve flag/URL, and start time. Cleaned up on shutdown. On first run, migrates from the old `~/.pi/agent/pi-web-state.json` location.
 
 ### 9. Model Cache Warming
 

--- a/install.sh
+++ b/install.sh
@@ -238,7 +238,7 @@ setup_macos() {
     while IFS='=' read -r key value; do
       [[ -z "$key" || "$key" == \#* ]] && continue
       case "$key" in
-        PI_WEB_TOKEN|PATH) ;;
+        PI_WEB_TOKEN|PI_CODING_AGENT_DIR|PATH) ;;
         *) continue ;;
       esac
       value="$(printf '%s' "$value" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g')"
@@ -356,6 +356,11 @@ setup_env() {
     set_env_var "$env_file" "PI_WEB_TOKEN" "$token"
     info "Generated PI_WEB_TOKEN in ${env_file}"
     warn "Use this token when opening pi-web from another device: ${token}"
+  fi
+
+  # Persist PI_CODING_AGENT_DIR so auto-started pi-web finds the right sessions.
+  if [[ -n "${PI_CODING_AGENT_DIR:-}" ]]; then
+    set_env_var "$env_file" "PI_CODING_AGENT_DIR" "${PI_CODING_AGENT_DIR}"
   fi
 
   # Services launched by systemd/launchd often have a minimal PATH. Preserve the

--- a/internal/server/bench_test.go
+++ b/internal/server/bench_test.go
@@ -47,6 +47,7 @@ func newBenchServer(b *testing.B, numSessions, messagesPerSession int) (*Server,
 	}
 
 	srv := New(Deps{
+		AgentDir:    dir,
 		SessionsDir: dir,
 		Auth:        auth.New(""),
 		Cache:       sessions.NewCache(),

--- a/internal/server/chat_preview_test.go
+++ b/internal/server/chat_preview_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBroadcastChatPreviewSendsNamedSSEToSession(t *testing.T) {
-	s := New(Deps{})
+	s := New(Deps{AgentDir: t.TempDir()})
 	defer s.Shutdown()
 	client := s.addClient("a.jsonl")
 	defer s.removeClient(client)
@@ -29,7 +29,7 @@ func TestBroadcastChatPreviewSendsNamedSSEToSession(t *testing.T) {
 }
 
 func TestBroadcastChatPreviewDoesNotSendToGlobalTopic(t *testing.T) {
-	s := New(Deps{})
+	s := New(Deps{AgentDir: t.TempDir()})
 	defer s.Shutdown()
 	client := s.addClient(globalSessID)
 	defer s.removeClient(client)

--- a/internal/server/chat_test.go
+++ b/internal/server/chat_test.go
@@ -318,7 +318,7 @@ func TestHandleWorkerStatusUsesSessionStatusFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := &Server{sessionsDir: sessionsDir, chatSender: &fakeSender{}}
+	s := &Server{agentDir: root, sessionsDir: sessionsDir, chatSender: &fakeSender{}}
 	req := httptest.NewRequest(http.MethodGet, "/api/worker-status?id="+sessionID, nil)
 	w := httptest.NewRecorder()
 	s.handleWorkerStatus(w, req)
@@ -380,7 +380,7 @@ func TestHandleWorkerStatusFallsThroughForIdleStatusFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := &Server{sessionsDir: sessionsDir, chatSender: &fakeSender{}}
+	s := &Server{agentDir: root, sessionsDir: sessionsDir, chatSender: &fakeSender{}}
 	req := httptest.NewRequest(http.MethodGet, "/api/worker-status?id="+sessionID, nil)
 	w := httptest.NewRecorder()
 	s.handleWorkerStatus(w, req)

--- a/internal/server/push.go
+++ b/internal/server/push.go
@@ -39,16 +39,28 @@ type vapidFile struct {
 }
 
 // NewPushManager loads/creates VAPID keys and subscription store under
-// ~/.pi/agent/web/. Returns a manager ready to register HTTP handlers.
-func NewPushManager() (*PushManager, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-	dir := filepath.Join(home, ".pi", "agent", "web")
+// <agentDir>/pi-web/. Returns a manager ready to register HTTP handlers.
+func NewPushManager(agentDir string) (*PushManager, error) {
+	dir := filepath.Join(agentDir, "pi-web")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, err
 	}
+
+	// Migrate old push data from pre-pi-web directory layout.
+	oldDir := filepath.Join(agentDir, "web")
+	if info, err := os.Stat(oldDir); err == nil && info.IsDir() {
+		for _, name := range []string{"vapid.json", "push-subs.json"} {
+			oldPath := filepath.Join(oldDir, name)
+			newPath := filepath.Join(dir, name)
+			if _, err := os.Stat(oldPath); err == nil {
+				if _, err := os.Stat(newPath); os.IsNotExist(err) {
+					_ = os.Rename(oldPath, newPath)
+				}
+			}
+		}
+		_ = os.Remove(oldDir)
+	}
+
 	m := &PushManager{
 		storeDir: dir,
 		subs:     make(map[string]pushSub),

--- a/internal/server/push_test.go
+++ b/internal/server/push_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewPushManager_CreatesDirUnderAgentPath(t *testing.T) {
+	tmp := t.TempDir()
+	pm, err := NewPushManager(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(tmp, "pi-web")
+	if pm.storeDir != want {
+		t.Fatalf("storeDir = %s, want %s", pm.storeDir, want)
+	}
+	if _, err := os.Stat(pm.storeDir); err != nil {
+		t.Fatalf("dir not created: %v", err)
+	}
+}
+
+func TestNewPushManager_PersistsVapidKeys(t *testing.T) {
+	tmp := t.TempDir()
+	pm1, err := NewPushManager(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub1 := pm1.PublicKey()
+	if pub1 == "" {
+		t.Fatal("expected non-empty public key")
+	}
+
+	// Second instance should load existing keys
+	pm2, err := NewPushManager(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pm2.PublicKey() != pub1 {
+		t.Fatal("expected same public key after reload")
+	}
+}
+
+func TestNewPushManager_MigratesOldWebDir(t *testing.T) {
+	tmp := t.TempDir()
+	oldDir := filepath.Join(tmp, "web")
+	newDir := filepath.Join(tmp, "pi-web")
+
+	if err := os.MkdirAll(oldDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	// Write old VAPID keys
+	oldVapid := []byte(`{"publicKey":"pub","privateKey":"priv"}`)
+	if err := os.WriteFile(filepath.Join(oldDir, "vapid.json"), oldVapid, 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Write old subscriptions
+	oldSubs := []byte(`{"sub1":{"endpoint":"e","keys":{"p256dh":"p","auth":"a"}}}`)
+	if err := os.WriteFile(filepath.Join(oldDir, "push-subs.json"), oldSubs, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	pm, err := NewPushManager(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pm.storeDir != newDir {
+		t.Fatalf("storeDir = %s, want %s", pm.storeDir, newDir)
+	}
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatal("old web dir should have been removed")
+	}
+	if pm.PublicKey() != "pub" {
+		t.Fatalf("expected migrated public key pub, got %s", pm.PublicKey())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -29,6 +30,7 @@ const globalSessID = "__all__"
 // list (which depends on a process-wide cache), and the chat sender (which
 // owns rpc workers).
 type Deps struct {
+	AgentDir            string
 	SessionsDir         string
 	Auth                *auth.Middleware
 	ChatSender          ChatSender
@@ -43,6 +45,7 @@ type Deps struct {
 // Server holds runtime state — connected SSE clients and last-seen modtimes
 // per session file. Construct via New; register HTTP routes via Register.
 type Server struct {
+	agentDir            string
 	sessionsDir         string
 	clients             []*sseClient
 	clientsMu           sync.RWMutex
@@ -70,7 +73,12 @@ func New(deps Deps) *Server {
 	if now == nil {
 		now = time.Now
 	}
+	agentDir := deps.AgentDir
+	if agentDir == "" {
+		agentDir = filepath.Join(os.Getenv("HOME"), ".pi", "agent")
+	}
 	s := &Server{
+		agentDir:            agentDir,
 		sessionsDir:         deps.SessionsDir,
 		clients:             make([]*sseClient, 0),
 		fileMod:             make(map[string]time.Time),
@@ -85,7 +93,7 @@ func New(deps Deps) *Server {
 		lastKnown:           make(map[string]struct{}),
 		stopCh:              make(chan struct{}),
 	}
-	if pm, err := NewPushManager(); err != nil {
+	if pm, err := NewPushManager(agentDir); err != nil {
 		fmt.Fprintf(os.Stderr, "push notifications unavailable: %v\n", err)
 	} else {
 		s.push = pm

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,6 +15,7 @@ func newTestServer(t *testing.T) *Server {
 	t.Helper()
 	dir := t.TempDir()
 	return New(Deps{
+		AgentDir:      dir,
 		SessionsDir:   dir,
 		Auth:          auth.New(""),
 		Cache:         sessions.NewCache(),

--- a/internal/server/status_test.go
+++ b/internal/server/status_test.go
@@ -25,7 +25,7 @@ func TestComputeRunningStatusFromStatusFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := &Server{sessionsDir: sessionsDir, chatSender: &fakeSender{}}
+	s := &Server{agentDir: root, sessionsDir: sessionsDir, chatSender: &fakeSender{}}
 	if !s.computeRunningStatus("session.jsonl") {
 		t.Fatalf("expected running=true from session-status file")
 	}

--- a/internal/server/status_watcher.go
+++ b/internal/server/status_watcher.go
@@ -12,7 +12,7 @@ import (
 // status files into. Mirrors readSessionStatus's path computation so a
 // single change keeps both callers consistent.
 func (s *Server) sessionStatusDir() string {
-	return filepath.Join(s.sessionsDir, "..", "session-status")
+	return filepath.Join(s.agentDir, "session-status")
 }
 
 // startSessionStatusWatcher watches the session-status/ directory for

--- a/internal/server/status_watcher_test.go
+++ b/internal/server/status_watcher_test.go
@@ -21,6 +21,7 @@ func TestSessionStatusWatcherEmitsDelta(t *testing.T) {
 	}
 
 	s := &Server{
+		agentDir:    root,
 		sessionsDir: sessionsDir,
 		clients:     make([]*sseClient, 0),
 		lastKnown:   make(map[string]struct{}),

--- a/main.go
+++ b/main.go
@@ -50,7 +50,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	sessionsDir := filepath.Join(os.Getenv("HOME"), ".pi", "agent", "sessions")
+	agentDir := piAgentDir()
+	sessionsDir := filepath.Join(agentDir, "sessions")
 	if _, err := os.Stat(sessionsDir); os.IsNotExist(err) {
 		fmt.Fprintf(os.Stderr, "sessions directory not found: %s\n", sessionsDir)
 		os.Exit(1)
@@ -77,6 +78,7 @@ func main() {
 		})
 	})
 	srv = server.New(server.Deps{
+		AgentDir:            agentDir,
 		SessionsDir:         sessionsDir,
 		Auth:                authMiddleware,
 		ChatSender:          manager,
@@ -134,7 +136,7 @@ func main() {
 		fmt.Printf("Auth: disabled — set %s to require a token for access.\n", tokenEnvVar)
 	}
 
-	stateFilePath, err := writeStateFile(bindHost, *port, tailscaleServe, tailscaleURL)
+	stateFilePath, err := writeStateFile(agentDir, bindHost, *port, tailscaleServe, tailscaleURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
@@ -198,20 +200,42 @@ func openBrowser(url string) {
 	exec.Command(cmd, args...).Start()
 }
 
+// piAgentDir returns the Pi agent config directory.
+// It respects the PI_CODING_AGENT_DIR environment variable, falling back to
+// ~/.pi/agent.
+func piAgentDir() string {
+	if dir := os.Getenv("PI_CODING_AGENT_DIR"); dir != "" {
+		return dir
+	}
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		home = os.Getenv("HOME")
+	}
+	return filepath.Join(home, ".pi", "agent")
+}
+
+// piWebDir returns the pi-web data directory inside the Pi agent dir.
+func piWebDir() string {
+	return filepath.Join(piAgentDir(), "pi-web")
+}
+
 // stateFile is held open for the lifetime of the process so the flock stays
 // in effect. Closing it releases the lock.
 var stateFile *os.File
 
-func writeStateFile(host, port string, tailscale bool, tailscaleURL string) (string, error) {
-	home := os.Getenv("HOME")
-	if home == "" {
-		return "", fmt.Errorf("HOME not set")
-	}
-	agentDir := filepath.Join(home, ".pi", "agent")
-	if err := os.MkdirAll(agentDir, 0755); err != nil {
+func writeStateFile(agentDir, host, port string, tailscale bool, tailscaleURL string) (string, error) {
+	webDir := filepath.Join(agentDir, "pi-web")
+	if err := os.MkdirAll(webDir, 0755); err != nil {
 		return "", err
 	}
-	path := filepath.Join(agentDir, "pi-web-state.json")
+	path := filepath.Join(webDir, "pi-web-state.json")
+
+	// Migrate old state file from pre-pi-web directory layout.
+	oldPath := filepath.Join(agentDir, "pi-web-state.json")
+	if _, err := os.Stat(oldPath); err == nil {
+		_ = os.Rename(oldPath, path)
+	}
+
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return "", err

--- a/main.go
+++ b/main.go
@@ -231,9 +231,15 @@ func writeStateFile(agentDir, host, port string, tailscale bool, tailscaleURL st
 	path := filepath.Join(webDir, "pi-web-state.json")
 
 	// Migrate old state file from pre-pi-web directory layout.
+	// Only migrate when the new path does not already exist; otherwise
+	// os.Rename would unlink a destination inode that another pi-web
+	// process may already hold a flock on, defeating the single-instance
+	// lock.
 	oldPath := filepath.Join(agentDir, "pi-web-state.json")
 	if _, err := os.Stat(oldPath); err == nil {
-		_ = os.Rename(oldPath, path)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			_ = os.Rename(oldPath, path)
+		}
 	}
 
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)

--- a/pi_agent_dir_test.go
+++ b/pi_agent_dir_test.go
@@ -42,6 +42,43 @@ func TestPiWebDir(t *testing.T) {
 	}
 }
 
+func TestWriteStateFile_SkipsMigrationWhenNewExists(t *testing.T) {
+	tmp := t.TempDir()
+	webDir := filepath.Join(tmp, "pi-web")
+	oldPath := filepath.Join(tmp, "pi-web-state.json")
+	newPath := filepath.Join(webDir, "pi-web-state.json")
+
+	// Simulate another instance already holding the new path
+	if err := os.MkdirAll(webDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldPath, []byte(`{"pid":123}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newPath, []byte(`{"pid":999}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := writeStateFile(tmp, "127.0.0.1", "31415", false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if stateFile != nil {
+			_ = stateFile.Close()
+			stateFile = nil
+		}
+	}()
+
+	if path != newPath {
+		t.Fatalf("expected new path %s, got %s", newPath, path)
+	}
+	// Old file should still exist (migration was skipped)
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatal("old state file should still exist when new already present")
+	}
+}
+
 func TestWriteStateFile_MigratesOldStateFile(t *testing.T) {
 	tmp := t.TempDir()
 	oldPath := filepath.Join(tmp, "pi-web-state.json")

--- a/pi_agent_dir_test.go
+++ b/pi_agent_dir_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPiAgentDir_RespectsEnvVar(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", "/custom/pi/agent")
+	got := piAgentDir()
+	if got != "/custom/pi/agent" {
+		t.Fatalf("want /custom/pi/agent, got %s", got)
+	}
+}
+
+func TestPiAgentDir_FallsBackToHome(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	got := piAgentDir()
+	if got == "" {
+		t.Fatal("expected non-empty path")
+	}
+	if got == "/custom/pi/agent" {
+		t.Fatal("should not use env var when empty")
+	}
+	// Should end with .pi/agent when falling back
+	if filepath.Base(filepath.Dir(got)) != ".pi" {
+		t.Fatalf("expected parent to be .pi, got %s", got)
+	}
+	if filepath.Base(got) != "agent" {
+		t.Fatalf("expected base to be agent, got %s", got)
+	}
+}
+
+func TestPiWebDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", tmp)
+	got := piWebDir()
+	want := filepath.Join(tmp, "pi-web")
+	if got != want {
+		t.Fatalf("want %s, got %s", want, got)
+	}
+}
+
+func TestWriteStateFile_MigratesOldStateFile(t *testing.T) {
+	tmp := t.TempDir()
+	oldPath := filepath.Join(tmp, "pi-web-state.json")
+	newPath := filepath.Join(tmp, "pi-web", "pi-web-state.json")
+
+	// Create old state file
+	if err := os.WriteFile(oldPath, []byte(`{"pid":123}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := writeStateFile(tmp, "127.0.0.1", "31415", false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if stateFile != nil {
+			_ = stateFile.Close()
+			stateFile = nil
+		}
+	}()
+
+	if path != newPath {
+		t.Fatalf("expected new path %s, got %s", newPath, path)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatal("old state file should have been moved")
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("new state file should exist: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Plumbs an `AgentDir` through the server so pi-web no longer hardcodes `~/.pi/agent` in multiple places. This also consolidates pi-web's own runtime data under a dedicated `pi-web/` subdirectory.

## Changes

### Backend (Go)
- **`AgentDir` field** added to `server.Deps` and `Server` struct; defaults to `~/.pi/agent` if empty
- **`piAgentDir()`** respects `PI_CODING_AGENT_DIR` env var, mirroring pi's own convention
- **State file** moved from `~/.pi/agent/pi-web-state.json` → `~/.pi/agent/pi-web/pi-web-state.json` (with automatic migration on first run)
- **Push manager** storage moved from `~/.pi/agent/web/` → `~/.pi/agent/pi-web/` (with migration of old `vapid.json` and `push-subs.json`)
- **`sessionStatusDir()`** now uses `agentDir` directly instead of fragile `filepath.Join(sessionsDir, "..", "session-status")`
- All tests updated to pass explicit `AgentDir`; new tests for push dir, VAPID key persistence, migration, and `piAgentDir()`

### Extension (TypeScript)
- `detectHostPort()` tries new state file path first, old path as fallback for backwards compat
- New `agentDir()` helper respects `PI_CODING_AGENT_DIR` env var

### Docs
- Updated state file paths in `AGENTS.md`, `system-overview.md`, `backend.md`, `server-startup.md`
- Fixed incorrect directory layout: `session-status/` shown as sibling of `sessions/` (not nested)
- Added `agentDir` field to `Server` struct documentation
- Updated startup sequence to mention `PI_CODING_AGENT_DIR`