### PR TITLE
fix: tailscale timeout and DMG path fallback

### DIFF
--- a/.pi/extensions/pi-web.ts
+++ b/.pi/extensions/pi-web.ts
@@ -13,7 +13,7 @@ import {
   type KeybindingsManager,
   type TUI,
 } from "@earendil-works/pi-tui";
-import { basename } from "node:path";
+import { basename, delimiter, join } from "node:path";
 import { constants as fsConstants, readFileSync, accessSync } from "node:fs";
 import { homedir } from "node:os";
 
@@ -108,25 +108,42 @@ export function isTailscaleHost(host: string): boolean {
   return ip.toLowerCase().startsWith("fd7a:115c:a1e0");
 }
 
-function tailscaleBin(): string {
-  // DMG install path (not in default PATH)
-  const dmg = "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
+function isExecutable(path: string): boolean {
   try {
-    accessSync(dmg, fsConstants.X_OK);
-    return dmg;
+    accessSync(path, fsConstants.X_OK);
+    return true;
   } catch {
-    // fall through
+    return false;
   }
-  // Homebrew / system paths
-  for (const p of ["/opt/homebrew/bin/tailscale", "/usr/local/bin/tailscale", "/usr/bin/tailscale"]) {
-    try {
-      accessSync(p, fsConstants.X_OK);
-      return p;
-    } catch {
-      // continue
-    }
+}
+
+function pathTailscaleBin(): string | null {
+  const pathEnv = process.env["PATH"] || "";
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, "tailscale");
+    if (isExecutable(candidate)) return candidate;
   }
-  return "tailscale"; // fall back to PATH lookup
+  return null;
+}
+
+function tailscaleBin(): string {
+  // Prefer PATH first so user-selected CLI installs override fallback locations.
+  const pathBin = pathTailscaleBin();
+  if (pathBin) return pathBin;
+
+  for (const p of [
+    // DMG install paths (not in default PATH)
+    "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+    "/Applications/Tailscale.app/Contents/MacOS/tailscale",
+    // Homebrew / system paths
+    "/opt/homebrew/bin/tailscale",
+    "/usr/local/bin/tailscale",
+    "/usr/bin/tailscale",
+  ]) {
+    if (isExecutable(p)) return p;
+  }
+  return "tailscale"; // final fallback to PATH lookup
 }
 
 async function detectTailscaleHttpsUrl(
@@ -134,7 +151,9 @@ async function detectTailscaleHttpsUrl(
   port: string,
 ): Promise<string | null> {
   try {
-    const result = await pi.exec(tailscaleBin(), ["status", "--json"]);
+    const result = await pi.exec(tailscaleBin(), ["status", "--json"], {
+      timeout: 10_000,
+    });
     const status = JSON.parse(result.stdout);
     if (status.BackendState && status.BackendState !== "Running") return null;
     const dnsName = String(status.Self?.DNSName || "").replace(/\.$/, "");

--- a/.pi/extensions/pi-web.ts
+++ b/.pi/extensions/pi-web.ts
@@ -108,12 +108,33 @@ export function isTailscaleHost(host: string): boolean {
   return ip.toLowerCase().startsWith("fd7a:115c:a1e0");
 }
 
+function tailscaleBin(): string {
+  // DMG install path (not in default PATH)
+  const dmg = "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
+  try {
+    accessSync(dmg, fsConstants.X_OK);
+    return dmg;
+  } catch {
+    // fall through
+  }
+  // Homebrew / system paths
+  for (const p of ["/opt/homebrew/bin/tailscale", "/usr/local/bin/tailscale", "/usr/bin/tailscale"]) {
+    try {
+      accessSync(p, fsConstants.X_OK);
+      return p;
+    } catch {
+      // continue
+    }
+  }
+  return "tailscale"; // fall back to PATH lookup
+}
+
 async function detectTailscaleHttpsUrl(
   pi: ExtensionAPI,
   port: string,
 ): Promise<string | null> {
   try {
-    const result = await pi.exec("tailscale", ["status", "--json"]);
+    const result = await pi.exec(tailscaleBin(), ["status", "--json"]);
     const status = JSON.parse(result.stdout);
     if (status.BackendState && status.BackendState !== "Running") return null;
     const dnsName = String(status.Self?.DNSName || "").replace(/\.$/, "");

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -109,24 +109,18 @@ func Main(version string) {
 	var tailscaleURL string
 	var tailscaleServe bool
 	if *hostOverride == "" {
-		tsDone := make(chan struct{})
-		var tsURL string
-		var tsOk bool
-		var tsErr error
-		go func() {
-			tsURL, tsOk, tsErr = configureTailscaleServe(*port)
-			close(tsDone)
-		}()
-		select {
-		case <-tsDone:
-			if tsErr == nil && tsOk {
-				tailscaleURL = tsURL
-				tailscaleServe = true
-			} else if tsErr != nil {
+		tsCtx, tsCancel := context.WithTimeout(context.Background(), tailscaleConfigureTimeout)
+		tsURL, tsOk, tsErr := configureTailscaleServe(tsCtx, *port)
+		tsCancel()
+		if tsErr == nil && tsOk {
+			tailscaleURL = tsURL
+			tailscaleServe = true
+		} else if tsErr != nil {
+			if tsCtx.Err() == context.DeadlineExceeded {
+				fmt.Fprintf(os.Stderr, "Tailscale Serve timed out after %s; continuing without it\n", tailscaleConfigureTimeout)
+			} else {
 				fmt.Fprintf(os.Stderr, "Tailscale Serve unavailable: %v\n", tsErr)
 			}
-		case <-time.After(12 * time.Second):
-			fmt.Fprintf(os.Stderr, "Tailscale Serve timed out after 12s; continuing without it\n")
 		}
 	}
 	fmt.Printf("Pi Sessions Viewer -> %s\n", url)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -109,11 +109,24 @@ func Main(version string) {
 	var tailscaleURL string
 	var tailscaleServe bool
 	if *hostOverride == "" {
-		if tsURL, ok, err := configureTailscaleServe(*port); err == nil && ok {
-			tailscaleURL = tsURL
-			tailscaleServe = true
-		} else if err != nil {
-			fmt.Fprintf(os.Stderr, "Tailscale Serve unavailable: %v\n", err)
+		tsDone := make(chan struct{})
+		var tsURL string
+		var tsOk bool
+		var tsErr error
+		go func() {
+			tsURL, tsOk, tsErr = configureTailscaleServe(*port)
+			close(tsDone)
+		}()
+		select {
+		case <-tsDone:
+			if tsErr == nil && tsOk {
+				tailscaleURL = tsURL
+				tailscaleServe = true
+			} else if tsErr != nil {
+				fmt.Fprintf(os.Stderr, "Tailscale Serve unavailable: %v\n", tsErr)
+			}
+		case <-time.After(12 * time.Second):
+			fmt.Fprintf(os.Stderr, "Tailscale Serve timed out after 12s; continuing without it\n")
 		}
 	}
 	fmt.Printf("Pi Sessions Viewer -> %s\n", url)

--- a/internal/app/tailscale.go
+++ b/internal/app/tailscale.go
@@ -10,7 +10,10 @@ import (
 	"time"
 )
 
-const tailscaleTimeout = 10 * time.Second
+var (
+	tailscaleCommandTimeout   = 10 * time.Second
+	tailscaleConfigureTimeout = 12 * time.Second
+)
 
 func tailscaleCLI() (string, error) {
 	if bin, err := exec.LookPath("tailscale"); err == nil {
@@ -35,14 +38,14 @@ func tailscaleCLI() (string, error) {
 // tailscaleSelfDNS returns the Tailscale MagicDNS name for this node
 // (e.g. "personal-laptop.tail9f98d.ts.net"). Returns an error if the
 // tailscale CLI is unavailable, the node is not connected, or MagicDNS is off.
-func tailscaleSelfDNS() (string, error) {
+func tailscaleSelfDNS(ctx context.Context) (string, error) {
 	bin, err := tailscaleCLI()
 	if err != nil {
 		return "", err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), tailscaleTimeout)
+	cmdCtx, cancel := context.WithTimeout(ctx, tailscaleCommandTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, bin, "status", "--json").Output()
+	out, err := exec.CommandContext(cmdCtx, bin, "status", "--json").Output()
 	if err != nil {
 		return "", fmt.Errorf("tailscale status failed: %w", err)
 	}
@@ -80,8 +83,8 @@ const (
 
 // configureTailscaleServe publishes the local HTTP server through Tailscale Serve.
 // Tailscale owns HTTPS/certs; pi-web keeps listening only on localhost.
-func configureTailscaleServe(port string) (string, bool, error) {
-	hostname, err := tailscaleSelfDNS()
+func configureTailscaleServe(ctx context.Context, port string) (string, bool, error) {
+	hostname, err := tailscaleSelfDNS(ctx)
 	if err != nil {
 		return "", false, err
 	}
@@ -92,7 +95,7 @@ func configureTailscaleServe(port string) (string, bool, error) {
 	target := "http://127.0.0.1:" + port
 	url := "https://" + hostname + ":" + port
 
-	state, err := tailscaleServeRuleState(bin, port, target)
+	state, err := tailscaleServeRuleState(ctx, bin, port, target)
 	if err != nil {
 		return "", false, err
 	}
@@ -103,9 +106,9 @@ func configureTailscaleServe(port string) (string, bool, error) {
 		return "", false, fmt.Errorf("tailscale HTTPS port %s is already configured for another service; not overwriting it. To replace it, run: tailscale serve --bg --https=%s %s", port, port, target)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), tailscaleTimeout)
+	cmdCtx, cancel := context.WithTimeout(ctx, tailscaleCommandTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, bin, "serve", "--bg", "--https="+port, target)
+	cmd := exec.CommandContext(cmdCtx, bin, "serve", "--bg", "--https="+port, target)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -114,10 +117,10 @@ func configureTailscaleServe(port string) (string, bool, error) {
 	return url, true, nil
 }
 
-func tailscaleServeRuleState(bin, port, target string) (serveRuleState, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), tailscaleTimeout)
+func tailscaleServeRuleState(ctx context.Context, bin, port, target string) (serveRuleState, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, tailscaleCommandTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, bin, "serve", "status", "--json").Output()
+	out, err := exec.CommandContext(cmdCtx, bin, "serve", "status", "--json").Output()
 	if err != nil {
 		return serveRuleMissing, fmt.Errorf("tailscale serve status failed: %w", err)
 	}

--- a/internal/app/tailscale.go
+++ b/internal/app/tailscale.go
@@ -1,12 +1,16 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+const tailscaleTimeout = 10 * time.Second
 
 func tailscaleCLI() (string, error) {
 	if bin, err := exec.LookPath("tailscale"); err == nil {
@@ -36,7 +40,9 @@ func tailscaleSelfDNS() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	out, err := exec.Command(bin, "status", "--json").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), tailscaleTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin, "status", "--json").Output()
 	if err != nil {
 		return "", fmt.Errorf("tailscale status failed: %w", err)
 	}
@@ -47,7 +53,12 @@ func tailscaleSelfDNS() (string, error) {
 		} `json:"Self"`
 	}
 	if err := json.Unmarshal(out, &status); err != nil {
-		return "", fmt.Errorf("parse tailscale status: %w", err)
+		// Include raw output in error so we can see what tailscale actually returned
+		preview := string(out)
+		if len(preview) > 200 {
+			preview = preview[:200] + "..."
+		}
+		return "", fmt.Errorf("parse tailscale status: %w (raw: %q)", err, preview)
 	}
 	if status.BackendState != "Running" {
 		return "", fmt.Errorf("tailscale not running (BackendState=%s)", status.BackendState)
@@ -92,7 +103,9 @@ func configureTailscaleServe(port string) (string, bool, error) {
 		return "", false, fmt.Errorf("tailscale HTTPS port %s is already configured for another service; not overwriting it. To replace it, run: tailscale serve --bg --https=%s %s", port, port, target)
 	}
 
-	cmd := exec.Command(bin, "serve", "--bg", "--https="+port, target)
+	ctx, cancel := context.WithTimeout(context.Background(), tailscaleTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, "serve", "--bg", "--https="+port, target)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -102,7 +115,9 @@ func configureTailscaleServe(port string) (string, bool, error) {
 }
 
 func tailscaleServeRuleState(bin, port, target string) (serveRuleState, error) {
-	out, err := exec.Command(bin, "serve", "status", "--json").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), tailscaleTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin, "serve", "status", "--json").Output()
 	if err != nil {
 		return serveRuleMissing, fmt.Errorf("tailscale serve status failed: %w", err)
 	}

--- a/internal/app/tailscale_test.go
+++ b/internal/app/tailscale_test.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func writeFakeTailscale(t *testing.T, dir, script string) string {
@@ -38,7 +40,7 @@ echo "unexpected tailscale args: $*" >&2
 exit 2
 `)
 
-	url, ok, err := configureTailscaleServe("31415")
+	url, ok, err := configureTailscaleServe(context.Background(), "31415")
 	if err != nil {
 		t.Fatalf("configureTailscaleServe returned error: %v", err)
 	}
@@ -79,7 +81,7 @@ fi
 exit 2
 `)
 
-	url, ok, err := configureTailscaleServe("31415")
+	url, ok, err := configureTailscaleServe(context.Background(), "31415")
 	if err != nil {
 		t.Fatalf("configureTailscaleServe returned error: %v", err)
 	}
@@ -113,7 +115,7 @@ fi
 exit 2
 `)
 
-	_, ok, err := configureTailscaleServe("31415")
+	_, ok, err := configureTailscaleServe(context.Background(), "31415")
 	if err == nil || !strings.Contains(err.Error(), "already configured") {
 		t.Fatalf("configureTailscaleServe error = %v, want conflict", err)
 	}
@@ -135,8 +137,47 @@ fi
 exit 2
 `)
 
-	_, err := tailscaleSelfDNS()
+	_, err := tailscaleSelfDNS(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "BackendState=Stopped") {
 		t.Fatalf("tailscaleSelfDNS error = %v, want BackendState error", err)
+	}
+}
+
+func TestConfigureTailscaleServeOverallDeadlinePreventsLateServe(t *testing.T) {
+	oldCommandTimeout := tailscaleCommandTimeout
+	tailscaleCommandTimeout = time.Second
+	t.Cleanup(func() { tailscaleCommandTimeout = oldCommandTimeout })
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "tailscale-args.log")
+	writeFakeTailscale(t, dir, `#!/bin/sh
+if [ "$1" = "status" ] && [ "$2" = "--json" ]; then
+  printf '%s\n' '{"BackendState":"Running","Self":{"DNSName":"macbook.tailnet.ts.net."}}'
+  exit 0
+fi
+if [ "$1" = "serve" ] && [ "$2" = "status" ] && [ "$3" = "--json" ]; then
+  exec sleep 1
+fi
+if [ "$1" = "serve" ]; then
+  printf '%s\n' "$*" > "`+logPath+`"
+  exit 0
+fi
+exit 2
+`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, ok, err := configureTailscaleServe(ctx, "31415")
+	if err == nil {
+		t.Fatalf("configureTailscaleServe error = nil, want deadline error")
+	}
+	if ok {
+		t.Fatalf("ok = true, want false")
+	}
+
+	// If configure work escaped the deadline, it could still invoke serve --bg later.
+	time.Sleep(100 * time.Millisecond)
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("tailscale serve was run after overall deadline")
 	}
 }


### PR DESCRIPTION
- Add 10s timeout to all tailscale exec calls (prevents startup hang when tailscale daemon is unresponsive)
- Wrap configureTailscaleServe in goroutine with 12s deadline so pi-web always starts even if tailscale blocks
- Add raw output to JSON parse errors for easier debugging
- Add tailscaleBin() with DMG/brew fallback paths in extension so detectTailscaleHttpsUrl works regardless of install method