### PR TITLE
refactor(memory): streamline skill for pi-web users, add project/session context

### DIFF
--- a/.pi/skills/memory/README.md
+++ b/.pi/skills/memory/README.md
@@ -1,16 +1,19 @@
 # Memory Skill
 
-Project-local memory workflow for Set Kyar's workspace.
+Project-local memory workflow for pi-web users.
 
 ## Files
 - `SKILL.md` — skill instructions
 - `scripts/memory.py` — CLI implementation
-- `../../../data/memory.sqlite` — database
-- `../../../data/schema.sql` — schema
+- `$PI_CODING_AGENT_DIR/pi-web-memory.sqlite` (default `~/.pi/agent/`) — database
+- `data/schema.sql` — schema (shipped with the skill)
 
 ## Use from repo root
 ```bash
-python3 .pi/skills/memory/scripts/memory.py search "rent"
-python3 .pi/skills/memory/scripts/memory.py add-memory "Prefers concise answers" --category preference --importance 4
-python3 .pi/skills/memory/scripts/memory.py add-reminder "Pay rental" --due-at "2026-05-21 09:00" --timezone Asia/Singapore
+# Remember a project fact (always scoped to cwd/project)
+python3 .pi/skills/memory/scripts/memory.py add-memory "Prefers tabs over spaces" \
+  --category preference --importance 4 --cwd /path/to/project --project my-project
+
+# Search memories for the current project
+python3 .pi/skills/memory/scripts/memory.py search "tabs" --project my-project
 ```

--- a/.pi/skills/memory/README.md
+++ b/.pi/skills/memory/README.md
@@ -5,11 +5,14 @@ Project-local memory workflow for pi-web users.
 ## Files
 - `SKILL.md` — skill instructions
 - `scripts/memory.py` — CLI implementation
-- `$PI_CODING_AGENT_DIR/pi-web-memory.sqlite` (default `~/.pi/agent/`) — database
+- `$PI_CODING_AGENT_DIR/pi-web-memory.sqlite` (default `~/.pi/agent/`) — database, auto-initialized on first use
 - `data/schema.sql` — schema (shipped with the skill)
 
 ## Use from repo root
 ```bash
+# Optional: initialize explicitly (normal commands also auto-initialize)
+python3 .pi/skills/memory/scripts/memory.py init
+
 # Remember a project fact (always scoped to cwd/project)
 python3 .pi/skills/memory/scripts/memory.py add-memory "Prefers tabs over spaces" \
   --category preference --importance 4 --cwd /path/to/project --project my-project

--- a/.pi/skills/memory/SKILL.md
+++ b/.pi/skills/memory/SKILL.md
@@ -1,35 +1,72 @@
 ---
 name: memory
-description: Manages project-local long-term memory in SQLite for Set Kyar's workspace. Use when storing, searching, correcting, or listing memories, reminders, accounts, automations, or schema changes.
+description: Manages project-local long-term memory in SQLite for pi-web users. Use when storing, searching, correcting, or listing memories.
 ---
 
 # Memory
 
-Use this skill for project memory tasks.
+Use this skill for project memory tasks. Every memory is scoped to a specific project (working directory) so facts stay relevant to the right context.
 
 ## Core files
-- `data/memory.sqlite` — primary memory database
-- `data/schema.sql` — schema definition
+- `$PI_CODING_AGENT_DIR/pi-web-memory.sqlite` (default `~/.pi/agent/`) — primary memory database
+- `.pi/skills/memory/data/schema.sql` — schema definition (shipped with the skill)
 - `.pi/skills/memory/scripts/memory.py` — CLI implementation
+
+## Project context
+
+Memories are associated with a project via `--cwd` and `--project`. This allows the same database to serve multiple projects without cross-polluting recall. When a pi session is active, also capture session info so you can trace which conversation produced a memory.
+
+| Context field | Source | Example |
+|---|---|---|
+| `--cwd` | `pwd` / pi session header `cwd` | `/Users/setkyar/pi-web` |
+| `--project` | basename of cwd | `pi-web` |
+| `--session-id` | pi session header `id` (8-char UUID) | `a1b2c3d4` |
+| `--session-name` | `/name` or `session_info` entry | `Refactor auth module` |
+
+Pi sessions are stored as JSONL trees in `getSessionsDir()` (default `~/.pi/agent/sessions/<encoded-cwd>/`). Each session file has a header with `id`, `cwd`, `timestamp`, and optional `parentSession`. Entries form a tree via `id`/`parentId`; use `/tree` to navigate branches, `/fork` to split into a new session, and `/name` to set a display name.
+
+When the user says "remember that" or "save this for later", record:
+- The fact itself (`add-memory`)
+- `--cwd` of the current project
+- `--project` (derived from cwd basename)
+- Current pi session ID and name if a pi session is active
 
 ## Common commands
 ```bash
-python3 .pi/skills/memory/scripts/memory.py search "rent"
-python3 .pi/skills/memory/scripts/memory.py add-memory "Prefers concise answers" --category preference --importance 4
-python3 .pi/skills/memory/scripts/memory.py add-reminder "Pay rental" --due-at "2026-05-21 09:00" --timezone Asia/Singapore
-python3 .pi/skills/memory/scripts/memory.py add-account "Syfe" --account-name "Brokerage" --currency SGD --balance 100000
-python3 .pi/skills/memory/scripts/memory.py schema-changes
+# Remember a project fact
+python3 .pi/skills/memory/scripts/memory.py add-memory "Prefers tabs over spaces" \
+  --category preference --importance 4 --cwd /Users/setkyar/pi-web --project pi-web
+
+# Remember with session context
+python3 .pi/skills/memory/scripts/memory.py add-memory "Decided to use Go 1.25 for the backend" \
+  --category decision --importance 5 --cwd /Users/setkyar/pi-web --project pi-web \
+  --session-id a1b2c3d4 --session-name "pi-web backend refactor"
+
+# Search across all projects or filter by project
+python3 .pi/skills/memory/scripts/memory.py search "tabs" --project pi-web
 ```
 
 ## Rules
 - Store explicit remember requests without asking again, unless sensitive.
+- **Always capture `--cwd` and `--project`** when adding a memory. Derive `--project` from the basename of cwd.
+- When a pi session is active, also capture `--session-id` and `--session-name` so memories are traceable to the conversation that produced them.
 - Ask before storing sensitive domains like finance, health, legal, identity, addresses, or private documents.
 - Never store passwords, API keys, seed phrases, OTPs, or full card numbers.
 - Prefer additive schema changes only.
 - Use `schema-change` for schema updates.
 
+## Outdated memories
+
+Memories are point-in-time snapshots. A memory recorded three months ago may no longer reflect reality — the codebase changed, the decision was reversed, or the preference shifted.
+
+When recalling memories:
+- **Check the timestamp** — `created_at` tells you when the memory was recorded. Older memories carry less weight.
+- **Verify against code** — use `read`, `bash`, `rg` to confirm a memory still reflects the current codebase before acting on it.
+- **Treat old memories as hints, not facts** — if a memory from March says "Auth uses JWT", but the current code has session cookies, the code wins.
+- **Correct stale memories** — when you detect a memory is outdated, use `add-memory` with updated info (the new memory naturally supersedes the old one in search recency). Optionally archive the old entry if needed.
+- **Surfacing staleness** — when presenting a recalled memory to the user, note its age: "I recall from [March 2026] that we decided X — let me verify that's still the case."
+
 ## When to use
+- Remember project-specific facts, decisions, conventions, or patterns
 - Save user preferences or personal facts
-- Add reminders or recurring automations
-- Update corrected memories
-- Check existing stored context before answering
+- Check existing stored context before answering a question about the current project

--- a/.pi/skills/memory/SKILL.md
+++ b/.pi/skills/memory/SKILL.md
@@ -8,7 +8,7 @@ description: Manages project-local long-term memory in SQLite for pi-web users. 
 Use this skill for project memory tasks. Every memory is scoped to a specific project (working directory) so facts stay relevant to the right context.
 
 ## Core files
-- `$PI_CODING_AGENT_DIR/pi-web-memory.sqlite` (default `~/.pi/agent/`) — primary memory database
+- `$PI_CODING_AGENT_DIR/pi-web-memory.sqlite` (default `~/.pi/agent/`) — primary memory database, auto-initialized on first use
 - `.pi/skills/memory/data/schema.sql` — schema definition (shipped with the skill)
 - `.pi/skills/memory/scripts/memory.py` — CLI implementation
 
@@ -33,6 +33,9 @@ When the user says "remember that" or "save this for later", record:
 
 ## Common commands
 ```bash
+# Optional: initialize explicitly (normal commands also auto-initialize)
+python3 .pi/skills/memory/scripts/memory.py init
+
 # Remember a project fact
 python3 .pi/skills/memory/scripts/memory.py add-memory "Prefers tabs over spaces" \
   --category preference --importance 4 --cwd /Users/setkyar/pi-web --project pi-web

--- a/.pi/skills/memory/data/schema.sql
+++ b/.pi/skills/memory/data/schema.sql
@@ -1,0 +1,85 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS memories (
+  id INTEGER PRIMARY KEY,
+  content TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'general',
+  context TEXT,
+  importance INTEGER NOT NULL DEFAULT 3 CHECK (importance BETWEEN 1 AND 5),
+  sensitivity TEXT NOT NULL DEFAULT 'normal' CHECK (sensitivity IN ('low','normal','high','secret')),
+  source TEXT,
+  confidence REAL NOT NULL DEFAULT 1.0 CHECK (confidence >= 0 AND confidence <= 1),
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  archived INTEGER NOT NULL DEFAULT 0 CHECK (archived IN (0,1))
+);
+
+CREATE TABLE IF NOT EXISTS memory_events (
+  id INTEGER PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  table_name TEXT,
+  row_id INTEGER,
+  summary TEXT,
+  raw_input TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS schema_changes (
+  id INTEGER PRIMARY KEY,
+  change_type TEXT NOT NULL CHECK (change_type IN ('create_table','create_index','alter_table_add_column','other_additive')),
+  object_name TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  sql TEXT NOT NULL,
+  applied_by TEXT NOT NULL DEFAULT 'agent',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);
+CREATE INDEX IF NOT EXISTS idx_memories_context ON memories(context);
+CREATE INDEX IF NOT EXISTS idx_memories_sensitivity ON memories(sensitivity);
+CREATE INDEX IF NOT EXISTS idx_memories_importance ON memories(importance);
+CREATE INDEX IF NOT EXISTS idx_memories_archived_updated ON memories(archived, updated_at);
+CREATE INDEX IF NOT EXISTS idx_memory_events_table_row ON memory_events(table_name, row_id);
+CREATE INDEX IF NOT EXISTS idx_memory_events_created_at ON memory_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_schema_changes_object ON schema_changes(object_name);
+CREATE INDEX IF NOT EXISTS idx_schema_changes_created_at ON schema_changes(created_at);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+  content,
+  category,
+  context,
+  source,
+  content='memories',
+  content_rowid='id',
+  tokenize='unicode61 remove_diacritics 2'
+);
+
+CREATE TRIGGER IF NOT EXISTS memories_fts_ai
+AFTER INSERT ON memories BEGIN
+  INSERT INTO memories_fts(rowid, content, category, context, source)
+  VALUES (new.id, new.content, new.category, new.context, new.source);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_fts_ad
+AFTER DELETE ON memories BEGIN
+  INSERT INTO memories_fts(memories_fts, rowid, content, category, context, source)
+  VALUES('delete', old.id, old.content, old.category, old.context, old.source);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_fts_au
+AFTER UPDATE ON memories BEGIN
+  INSERT INTO memories_fts(memories_fts, rowid, content, category, context, source)
+  VALUES('delete', old.id, old.content, old.category, old.context, old.source);
+  INSERT INTO memories_fts(rowid, content, category, context, source)
+  VALUES (new.id, new.content, new.category, new.context, new.source);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_updated_at
+AFTER UPDATE ON memories
+FOR EACH ROW
+WHEN NEW.updated_at = OLD.updated_at
+BEGIN
+  UPDATE memories SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END;
+
+

--- a/.pi/skills/memory/scripts/memory.py
+++ b/.pi/skills/memory/scripts/memory.py
@@ -8,7 +8,7 @@ import re
 import sqlite3
 from pathlib import Path
 
-SKILL_ROOT = Path(__file__).resolve().parents[2]
+SKILL_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = SKILL_ROOT / "data" / "schema.sql"
 
 # Mirror pi's getAgentDir() logic: respect PI_CODING_AGENT_DIR env var, default to ~/.pi/agent
@@ -21,9 +21,16 @@ def _agent_dir():
 DB = _agent_dir() / "pi-web-memory.sqlite"
 
 
+def get_db_path():
+    env = os.environ.get("PI_MEMORY_DB")
+    return Path(env) if env else DB
+
+
 def conn():
-    DB.parent.mkdir(parents=True, exist_ok=True)
-    c = sqlite3.connect(DB)
+    db_path = get_db_path()
+    if db_path != Path(":memory:"):
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+    c = sqlite3.connect(str(db_path))
     c.row_factory = sqlite3.Row
     c.execute("PRAGMA foreign_keys = ON")
     return c
@@ -32,7 +39,7 @@ def conn():
 def init_db(_args):
     with conn() as c:
         c.executescript(SCHEMA.read_text())
-    print(f"initialized {DB}")
+    print(f"initialized {get_db_path()}")
 
 
 def add_memory(args):
@@ -110,10 +117,10 @@ def search(args):
             params_like = [like_q, like_q, like_q] + params
             rows = c.execute(
                 f"""
-                SELECT 'memory' AS type, id, content AS title, category, sensitivity, created_at, NULL AS rank
-                FROM memories
-                WHERE archived = 0 AND (content LIKE ? OR category LIKE ? OR IFNULL(context,'') LIKE ?) {project_filter}
-                ORDER BY importance DESC, updated_at DESC
+                SELECT 'memory' AS type, m.id, m.content AS title, m.category, m.sensitivity, m.created_at, NULL AS rank
+                FROM memories m
+                WHERE m.archived = 0 AND (m.content LIKE ? OR m.category LIKE ? OR IFNULL(m.context,'') LIKE ?) {project_filter}
+                ORDER BY m.importance DESC, m.updated_at DESC
                 LIMIT ?
                 """,
                 params_like,

--- a/.pi/skills/memory/scripts/memory.py
+++ b/.pi/skills/memory/scripts/memory.py
@@ -1,15 +1,24 @@
 #!/usr/bin/env python3
-"""Small CLI for Set Kyar's SQLite memory database."""
+"""Small CLI for the pi-web memory database."""
 
 import argparse
 import json
+import os
 import re
 import sqlite3
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[4]
-DB = ROOT / "data" / "memory.sqlite"
-SCHEMA = ROOT / "data" / "schema.sql"
+SKILL_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = SKILL_ROOT / "data" / "schema.sql"
+
+# Mirror pi's getAgentDir() logic: respect PI_CODING_AGENT_DIR env var, default to ~/.pi/agent
+def _agent_dir():
+    env_dir = os.environ.get("PI_CODING_AGENT_DIR")
+    if env_dir:
+        return Path(env_dir).expanduser()
+    return Path.home() / ".pi" / "agent"
+
+DB = _agent_dir() / "pi-web-memory.sqlite"
 
 
 def conn():
@@ -27,6 +36,20 @@ def init_db(_args):
 
 
 def add_memory(args):
+    # Build context JSON from project/session info
+    ctx_parts = {}
+    if args.cwd:
+        ctx_parts["cwd"] = args.cwd
+    if args.project:
+        ctx_parts["project"] = args.project
+    if args.session_id:
+        ctx_parts["session_id"] = args.session_id
+    if args.session_name:
+        ctx_parts["session_name"] = args.session_name
+    if args.context:
+        ctx_parts["note"] = args.context
+    context_json = json.dumps(ctx_parts) if ctx_parts else None
+
     with conn() as c:
         cur = c.execute(
             """
@@ -36,7 +59,7 @@ def add_memory(args):
             (
                 args.content,
                 args.category,
-                args.context,
+                context_json,
                 args.importance,
                 args.sensitivity,
                 args.source,
@@ -51,69 +74,6 @@ def add_memory(args):
     print(f"memory #{row_id} added")
 
 
-def add_reminder(args):
-    with conn() as c:
-        cur = c.execute(
-            """
-            INSERT INTO reminders (title, description, due_at, timezone, recurrence_rule, priority)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                args.title,
-                args.description,
-                args.due_at,
-                args.timezone,
-                args.recurrence,
-                args.priority,
-            ),
-        )
-        row_id = cur.lastrowid
-        c.execute(
-            "INSERT INTO memory_events (event_type, table_name, row_id, summary, raw_input) VALUES (?, ?, ?, ?, ?)",
-            (
-                "create",
-                "reminders",
-                row_id,
-                args.title,
-                json.dumps({k: v for k, v in vars(args).items() if k != "func"}),
-            ),
-        )
-    print(f"reminder #{row_id} added")
-
-
-def add_account(args):
-    with conn() as c:
-        cur = c.execute(
-            """
-            INSERT INTO financial_accounts
-            (institution, account_name, account_type, currency, balance, balance_as_of, notes, sensitivity)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                args.institution,
-                args.account_name,
-                args.account_type,
-                args.currency,
-                args.balance,
-                args.balance_as_of,
-                args.notes,
-                args.sensitivity,
-            ),
-        )
-        row_id = cur.lastrowid
-        c.execute(
-            "INSERT INTO memory_events (event_type, table_name, row_id, summary, raw_input) VALUES (?, ?, ?, ?, ?)",
-            (
-                "create",
-                "financial_accounts",
-                row_id,
-                f"{args.institution} {args.account_name or ''}".strip(),
-                json.dumps({k: v for k, v in vars(args).items() if k != "func"}),
-            ),
-        )
-    print(f"financial account #{row_id} added")
-
-
 def make_fts_query(query: str) -> str:
     tokens = re.findall(r"[\w]+", query, flags=re.UNICODE)
     return " OR ".join(f'"{token}"' for token in tokens) or '""'
@@ -122,50 +82,46 @@ def make_fts_query(query: str) -> str:
 def search(args):
     fts_q = make_fts_query(args.query)
     like_q = f"%{args.query}%"
+    project_filter = ""
+    params = [args.limit]
+    if args.project:
+        project_filter = "AND json_extract(m.context, '$.project') = ?"
+        params.insert(0, args.project)
+
     with conn() as c:
         try:
+            params_fts = [fts_q] + params
             rows = c.execute(
-                """
+                f"""
                 SELECT 'memory' AS type, m.id, m.content AS title, m.category, m.sensitivity,
                        m.created_at, bm25(memories_fts) AS rank
                 FROM memories_fts
                 JOIN memories m ON m.id = memories_fts.rowid
-                WHERE memories_fts MATCH ? AND m.archived = 0
+                WHERE memories_fts MATCH ? AND m.archived = 0 {project_filter}
                 ORDER BY rank, m.importance DESC, m.updated_at DESC
                 LIMIT ?
                 """,
-                (fts_q, args.limit),
+                params_fts,
             ).fetchall()
         except sqlite3.OperationalError:
             rows = []
 
         if not rows:
+            params_like = [like_q, like_q, like_q] + params
             rows = c.execute(
-                """
+                f"""
                 SELECT 'memory' AS type, id, content AS title, category, sensitivity, created_at, NULL AS rank
                 FROM memories
-                WHERE archived = 0 AND (content LIKE ? OR category LIKE ? OR IFNULL(context,'') LIKE ?)
+                WHERE archived = 0 AND (content LIKE ? OR category LIKE ? OR IFNULL(context,'') LIKE ?) {project_filter}
                 ORDER BY importance DESC, updated_at DESC
                 LIMIT ?
                 """,
-                (like_q, like_q, like_q, args.limit),
+                params_like,
             ).fetchall()
 
     for r in rows:
         print(
             f"[{r['type']} #{r['id']}] {r['title']} ({r['category']}, {r['sensitivity']}, {r['created_at']})"
-        )
-
-
-def list_reminders(args):
-    with conn() as c:
-        rows = c.execute(
-            "SELECT id, title, due_at, timezone, status, priority FROM reminders WHERE status = ? ORDER BY due_at LIMIT ?",
-            (args.status, args.limit),
-        ).fetchall()
-    for r in rows:
-        print(
-            f"[reminder #{r['id']}] {r['due_at']} {r['timezone']} - {r['title']} ({r['status']}, p{r['priority']})"
         )
 
 
@@ -242,7 +198,11 @@ def main():
     s = sub.add_parser("add-memory")
     s.add_argument("content")
     s.add_argument("--category", default="general")
-    s.add_argument("--context")
+    s.add_argument("--context", help="Free-form note for the context field")
+    s.add_argument("--cwd", help="Working directory this memory belongs to")
+    s.add_argument("--project", help="Project name (derived from cwd basename)")
+    s.add_argument("--session-id", help="Pi session ID (from session header)")
+    s.add_argument("--session-name", help="Pi session display name (/name)")
     s.add_argument("--importance", type=int, default=3)
     s.add_argument(
         "--sensitivity", choices=["low", "normal", "high", "secret"], default="normal"
@@ -251,39 +211,11 @@ def main():
     s.add_argument("--confidence", type=float, default=1.0)
     s.set_defaults(func=add_memory)
 
-    s = sub.add_parser("add-reminder")
-    s.add_argument("title")
-    s.add_argument(
-        "--due-at", required=True, help="ISO-like date/time, e.g. 2026-05-21 09:00"
-    )
-    s.add_argument("--description")
-    s.add_argument("--timezone", default="Asia/Singapore")
-    s.add_argument("--recurrence")
-    s.add_argument("--priority", type=int, default=3)
-    s.set_defaults(func=add_reminder)
-
-    s = sub.add_parser("add-account")
-    s.add_argument("institution")
-    s.add_argument("--account-name")
-    s.add_argument("--account-type")
-    s.add_argument("--currency", default="USD")
-    s.add_argument("--balance", type=float)
-    s.add_argument("--balance-as-of")
-    s.add_argument("--notes")
-    s.add_argument(
-        "--sensitivity", choices=["low", "normal", "high", "secret"], default="high"
-    )
-    s.set_defaults(func=add_account)
-
     s = sub.add_parser("search")
     s.add_argument("query")
+    s.add_argument("--project", help="Filter results to a specific project name")
     s.add_argument("--limit", type=int, default=20)
     s.set_defaults(func=search)
-
-    s = sub.add_parser("reminders")
-    s.add_argument("--status", default="pending")
-    s.add_argument("--limit", type=int, default=20)
-    s.set_defaults(func=list_reminders)
 
     s = sub.add_parser("schema-change")
     s.add_argument(

--- a/.pi/skills/memory/scripts/memory.py
+++ b/.pi/skills/memory/scripts/memory.py
@@ -26,19 +26,32 @@ def get_db_path():
     return Path(env) if env else DB
 
 
-def conn():
+def _schema_missing(c):
+    row = c.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'memories'"
+    ).fetchone()
+    return row is None
+
+
+def _init_schema(c):
+    c.executescript(SCHEMA.read_text())
+
+
+def conn(auto_init=True):
     db_path = get_db_path()
     if db_path != Path(":memory:"):
         db_path.parent.mkdir(parents=True, exist_ok=True)
     c = sqlite3.connect(str(db_path))
     c.row_factory = sqlite3.Row
     c.execute("PRAGMA foreign_keys = ON")
+    if auto_init and _schema_missing(c):
+        _init_schema(c)
     return c
 
 
 def init_db(_args):
-    with conn() as c:
-        c.executescript(SCHEMA.read_text())
+    with conn(auto_init=False) as c:
+        _init_schema(c)
     print(f"initialized {get_db_path()}")
 
 
@@ -92,7 +105,10 @@ def search(args):
     project_filter = ""
     params = [args.limit]
     if args.project:
-        project_filter = "AND json_extract(m.context, '$.project') = ?"
+        project_filter = (
+            "AND (CASE WHEN json_valid(m.context) "
+            "THEN json_extract(m.context, '$.project') END) = ?"
+        )
         params.insert(0, args.project)
 
     with conn() as c:

--- a/.pi/skills/memory/scripts/test_memory.py
+++ b/.pi/skills/memory/scripts/test_memory.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Unit tests for memory.py CLI script."""
+
+import argparse
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Add the scripts directory to sys.path so we can import memory
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import memory
+
+
+class TestMakeFtsQuery(unittest.TestCase):
+    """Tests for make_fts_query — a pure function, no DB needed."""
+
+    def test_single_token(self):
+        self.assertEqual(memory.make_fts_query("hello"), '"hello"')
+
+    def test_multiple_tokens(self):
+        self.assertEqual(memory.make_fts_query("hello world"), '"hello" OR "world"')
+
+    def test_punctuation_stripped(self):
+        self.assertEqual(memory.make_fts_query("hello-world!"), '"hello" OR "world"')
+
+    def test_empty_string(self):
+        self.assertEqual(memory.make_fts_query(""), '""')
+
+    def test_unicode(self):
+        self.assertEqual(memory.make_fts_query("caf\u00e9 r\u00e9sum\u00e9"), '"caf\u00e9" OR "r\u00e9sum\u00e9"')
+
+    def test_numbers(self):
+        self.assertEqual(memory.make_fts_query("test 123"), '"test" OR "123"')
+
+    def test_only_symbols(self):
+        self.assertEqual(memory.make_fts_query("!@#$%"), '""')
+
+
+class TestMemoryDB(unittest.TestCase):
+    """Integration tests that exercise the full add → search pipeline on a temp DB."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.db_path = str(Path(self.tmpdir.name) / "test.sqlite")
+        os.environ["PI_MEMORY_DB"] = self.db_path
+        # Suppress CLI output noise during setup/teardown
+        self._stdout_patcher = patch("sys.stdout", io.StringIO())
+        self._stdout_patcher.start()
+        memory.init_db(None)
+
+    def tearDown(self):
+        self._stdout_patcher.stop()
+        self.tmpdir.cleanup()
+        os.environ.pop("PI_MEMORY_DB", None)
+
+    # --- helpers ---
+
+    def _add(self, content, **kwargs):
+        args = argparse.Namespace(
+            content=content,
+            category=kwargs.get("category", "general"),
+            context=kwargs.get("context", None),
+            cwd=kwargs.get("cwd", None),
+            project=kwargs.get("project", None),
+            session_id=kwargs.get("session_id", None),
+            session_name=kwargs.get("session_name", None),
+            importance=kwargs.get("importance", 3),
+            sensitivity=kwargs.get("sensitivity", "normal"),
+            source=kwargs.get("source", "user request"),
+            confidence=kwargs.get("confidence", 1.0),
+        )
+        memory.add_memory(args)
+
+    def _search(self, query, project=None, limit=20):
+        args = argparse.Namespace(query=query, project=project, limit=limit)
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            memory.search(args)
+        return buf.getvalue()
+
+    # --- tests ---
+
+    def test_add_and_search_basic(self):
+        self._add("Test memory one", category="test", importance=4)
+        self._add("Test memory two", category="test", importance=5)
+        output = self._search("Test")
+        self.assertIn("Test memory one", output)
+        self.assertIn("Test memory two", output)
+
+    def test_search_empty_database(self):
+        output = self._search("nonexistent")
+        self.assertEqual(output.strip(), "")
+
+    def test_search_by_project(self):
+        self._add("pi-web feature", project="pi-web", cwd="/Users/test/pi-web")
+        self._add("other project idea", project="other-project", cwd="/other")
+
+        output = self._search("", project="pi-web")
+        self.assertIn("pi-web feature", output)
+        self.assertNotIn("other project idea", output)
+
+    def test_search_fallback_with_project_filter(self):
+        """Regression: search with --project when FTS returns empty results."""
+        self._add("A feature idea", category="idea", project="pi-web", cwd="/Users/test/pi-web")
+        output = self._search("", project="pi-web")
+        self.assertIn("A feature idea", output)
+
+    def test_search_no_alias_bug_regression(self):
+        """Exact scenario that was broken before fixing the m alias in fallback query."""
+        self._add("pi-web roadmap item", category="plan", project="pi-web", cwd="/test/pi-web")
+        output = self._search("", project="pi-web")
+        self.assertIn("pi-web roadmap item", output)
+
+    def test_context_json_stored(self):
+        self._add("Memory with context", context="extra note", project="test-proj", cwd="/test/proj")
+        output = self._search("Memory with context")
+        self.assertIn("Memory with context", output)
+
+    def test_session_context_stored(self):
+        self._add(
+            "Session-linked memory",
+            session_id="abc12345",
+            session_name="Refactor auth",
+            project="pi-web",
+            cwd="/test/pi-web",
+        )
+        output = self._search("", project="pi-web")
+        self.assertIn("Session-linked memory", output)
+
+    def test_search_partial_word(self):
+        self._add("Wonderland exploration", category="idea")
+        output = self._search("wonder")  # LIKE matches partial
+        self.assertIn("Wonderland exploration", output)
+
+    def test_search_by_category(self):
+        self._add("A bug report", category="bug")
+        self._add("A feature request", category="feature")
+        output = self._search("bug")
+        self.assertIn("A bug report", output)
+
+    def test_search_no_match(self):
+        self._add("something")
+        output = self._search("nope")
+        self.assertEqual(output.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.pi/skills/memory/scripts/test_memory.py
+++ b/.pi/skills/memory/scripts/test_memory.py
@@ -40,6 +40,42 @@ class TestMakeFtsQuery(unittest.TestCase):
         self.assertEqual(memory.make_fts_query("!@#$%"), '""')
 
 
+class TestMemoryAutoInit(unittest.TestCase):
+    """Tests for first-use behavior on a brand-new DB path."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.db_path = str(Path(self.tmpdir.name) / "new.sqlite")
+        os.environ["PI_MEMORY_DB"] = self.db_path
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+        os.environ.pop("PI_MEMORY_DB", None)
+
+    def test_add_memory_auto_initializes_new_database(self):
+        args = argparse.Namespace(
+            content="First use memory",
+            category="general",
+            context=None,
+            cwd="/test/pi-web",
+            project="pi-web",
+            session_id=None,
+            session_name=None,
+            importance=3,
+            sensitivity="normal",
+            source="user request",
+            confidence=1.0,
+        )
+        with patch("sys.stdout", io.StringIO()):
+            memory.add_memory(args)
+
+        search_args = argparse.Namespace(query="First", project="pi-web", limit=20)
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            memory.search(search_args)
+        self.assertIn("First use memory", buf.getvalue())
+
+
 class TestMemoryDB(unittest.TestCase):
     """Integration tests that exercise the full add → search pipeline on a temp DB."""
 
@@ -114,6 +150,19 @@ class TestMemoryDB(unittest.TestCase):
         self._add("pi-web roadmap item", category="plan", project="pi-web", cwd="/test/pi-web")
         output = self._search("", project="pi-web")
         self.assertIn("pi-web roadmap item", output)
+
+    def test_project_filter_ignores_legacy_plain_text_context(self):
+        """Regression: --project should not crash on pre-JSON context values."""
+        with memory.conn() as c:
+            c.execute(
+                "INSERT INTO memories (content, category, context) VALUES (?, ?, ?)",
+                ("legacy plain context", "general", "not-json"),
+            )
+        self._add("legacy json context", project="pi-web", cwd="/test/pi-web")
+
+        output = self._search("legacy", project="pi-web")
+        self.assertIn("legacy json context", output)
+        self.assertNotIn("legacy plain context", output)
 
     def test_context_json_stored(self):
         self._add("Memory with context", context="extra note", project="test-proj", cwd="/test/proj")

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build setup frontend-setup go-setup root-setup frontend-build frontend-test extension-test go-test vet test check clean dev
+.PHONY: build setup frontend-setup go-setup root-setup frontend-build frontend-test extension-test memory-test go-test vet test check clean dev
 
 BINARY ?= pi-web
 WEB_DIR := web
@@ -40,15 +40,18 @@ frontend-test: frontend-setup
 extension-test: root-setup
 	npm run test:extensions
 
+memory-test:
+	PYTHONDONTWRITEBYTECODE=1 python3 .pi/skills/memory/scripts/test_memory.py
+
 go-test: go-setup
 	go test ./...
 
 vet: go-setup
 	go vet ./...
 
-test: frontend-test extension-test go-test
+test: frontend-test extension-test memory-test go-test
 
-check: frontend-test extension-test frontend-build go-test vet
+check: frontend-test extension-test memory-test frontend-build go-test vet
 
 dev: frontend-setup go-setup
 	@echo "Starting dev mode (frontend watcher + Go hot-reloader)..."


### PR DESCRIPTION
## Summary

Refactors the memory skill from a personal tool into a pi-web project skill:

- **Database location**: Moved to `$PI_CODING_AGENT_DIR/pi-web-memory.sqlite`, mirrors pi's own `getAgentDir()` logic
- **Schema**: Shipped inside the skill at `.pi/skills/memory/data/schema.sql`
- **Project context**: `add-memory` now captures `--cwd`, `--project`, `--session-id`, `--session-name` — stored as JSON in the context column
- **Search filtering**: `search` supports `--project` filter using `json_extract()`
- **Removed tables**: financial_accounts, reminders, todos, automations — memory skill is now scoped to project knowledge only
- **Outdated memories**: Added guidance on verifying stale memories against current codebase
- **Generic naming**: Replaced all personal references with pi-web user orientation