### PR TITLE
fix: add pi manifest to extension package.json for discovery

### DIFF
--- a/.pi/extensions/package.json
+++ b/.pi/extensions/package.json
@@ -1,6 +1,9 @@
 {
   "name": "pi-web-extension",
   "private": true,
+  "pi": {
+    "extensions": ["./pi-web.ts"]
+  },
   "dependencies": {
     "qrcode": "^1.5.4",
     "typebox": "^1.1.38"


### PR DESCRIPTION
## Problem

`pi install @ygncode/pi-web` succeeds but `pi-web` extension is not discovered at runtime. The extension directory `.pi/extensions/` contains `pi-web.ts` and `package.json`, but pi fails to load it.

## Root Cause

pi's `resolveExtensionEntries()` checks for a `pi` field in `package.json` first. If absent, it falls back to `index.ts`/`index.js`. The pi-web extension's `package.json` had neither:
- No `"pi": { "extensions": [...] }` manifest
- No `index.ts` or `index.js` re-export file (only `pi-web.ts` exists)

So the extension was never discovered.

## Fix

Add the `"pi"` manifest to `.pi/extensions/package.json`:

```json
"pi": {
  "extensions": ["./pi-web.ts"]
}
```

This follows pi's documented extension discovery protocol and is the proper upstream fix (rather than creating an `index.ts` re-export file).

## Testing

- Verified `pi-web` extension loads correctly after the fix
- Confirmed the fix works on both Windows (MINGW) and Linux (Ubuntu)
