### PR TITLE
feat: shared theme engine + UI polish + follow button & working animation

### DIFF
--- a/internal/ui/export.go
+++ b/internal/ui/export.go
@@ -102,7 +102,7 @@ func sanitizeTheme(t string) string {
 }
 
 func RenderExportSessionPage(session sessions.Session, theme string) string {
-	dataBase64, css, bodyAttrs := prepareSessionPageData(session, liveSessionCss)
+	dataBase64, css, bodyAttrs := prepareSessionPageData(session, liveThemeCss+"\n"+liveSessionCss)
 
 	styles := "<style>\n" + css + "\n</style>"
 	inlineScript := "<script>\n" + markedJs + "\n</script>\n<script>\n" + hljsJs + "\n</script>\n<script>\n" + exportJs + "\n</script>"

--- a/internal/ui/home_mobile_test.go
+++ b/internal/ui/home_mobile_test.go
@@ -64,7 +64,7 @@ func TestHomePageNewSessionEntryPointsExist(t *testing.T) {
 	}
 	// palette is rendered via {{ paletteHTML }} — check rendered output
 	paletteChecks := []string{
-		`id="commandPalette"`,
+		`id="sessionPalette"`,
 		`id="web-menu"`,
 	}
 	for _, check := range paletteChecks {
@@ -125,7 +125,7 @@ func TestCommandPaletteSearchExists(t *testing.T) {
 	html := buf.String()
 	checks := []string{
 		`id="open-search"`,
-		`id="search"`,
+		`id="session-palette-search"`,
 		`Search sessions...`,
 		`⌘K`,
 	}

--- a/internal/ui/index_template.go
+++ b/internal/ui/index_template.go
@@ -66,9 +66,9 @@ var funcMap = template.FuncMap{
 	"homeMenu": homeMenuHTML,
 	"paletteHTML": func() template.HTML {
 		return renderPalette(paletteData{
-			ID:       "commandPalette",
-			Label:    "Search sessions",
-			SearchID: "search",
+			ID:       "sessionPalette",
+			Label:    "List sessions",
+			SearchID: "session-palette-search",
 			Actions:  true,
 		})
 	},

--- a/internal/ui/live_page.go
+++ b/internal/ui/live_page.go
@@ -109,7 +109,8 @@ func liveServiceWorkerScript() template.HTML {
 func liveDocumentEnd() template.HTML { return template.HTML("</body>\n</html>") }
 
 func indexStylesheets() template.HTML {
-	return template.HTML(`<link rel="stylesheet" href="/index.css">
+	return template.HTML(`<link rel="stylesheet" href="/theme.css">
+<link rel="stylesheet" href="/index.css">
 <link rel="stylesheet" href="/menu.css">
 <link rel="stylesheet" href="/palette.css">`)
 }

--- a/internal/ui/live_templates/index.html
+++ b/internal/ui/live_templates/index.html
@@ -13,7 +13,7 @@
     <div class="header-top">
       <h1><span class="pi-logo-mark" aria-hidden="true"></span><span>Sessions</span></h1>
       <div class="header-actions">
-        <button class="nav-search-btn" id="open-search" type="button" aria-haspopup="dialog" aria-controls="commandPalette"><span>Search sessions...</span><kbd>⌘K</kbd></button>
+        <button class="nav-search-btn" id="open-search" type="button" aria-haspopup="dialog" aria-controls="sessionPalette"><span>Search sessions...</span><kbd>⌘K</kbd></button>
         <button class="nav-menu-btn" id="web-menu-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-controls="web-menu">⋯</button>
       </div>
     </div>

--- a/internal/ui/live_templates/styles/index.css
+++ b/internal/ui/live_templates/styles/index.css
@@ -1,371 +1,11 @@
-:root,
-[data-theme="dark"] {
-    /* ── Typography & Layout ── */
-    --line-height: 1.5;
+:root {
     --pi-menu-top: 58px;
     --pi-menu-right: max(28px, calc((100vw - 1040px) / 2 + 28px));
     --pi-menu-z: 50;
     --pi-menu-width: 248px;
-
-    /* ── Color Palette (Obsidian / Carbon Dark) ── */
-    --body-bg: #111116;
-    --surface: #15151b;
-    --surface-2: #191920;
-    --text: #e6e7eb;
-    --text-soft: #b7bbc4;
-    --muted: #858a96;
-    --dim: #292a33;
-    --dim-2: #20212a;
-    --accent: #9cc7c0;
-    --border-accent: #9cc7c0;
-    --danger: #ef767a;
-
-    --pi-menu-bg: var(--surface);
-    --pi-menu-border: var(--dim);
-    --pi-menu-item-color: var(--text-soft);
-    --pi-menu-item-hover-color: var(--text);
-    --pi-menu-muted-color: var(--muted);
-    --pi-menu-accent-color: var(--accent);
-    --pi-menu-hover-bg: var(--surface-2);
-
-    /* ── Workspace / Session Visual Tokens ── */
-    --container-bg: var(--surface);
-    --info-bg: #3c3728;
-    --cyan: #00d7ff;
-    --blue: #5f87ff;
-    --green: #b5bd68;
-    --red: #cc6666;
-    --yellow: #ffff00;
-    --gray: #808080;
-    --dimGray: #666666;
-    --darkGray: #505050;
-    --accent-color: #8abeb7;
-    --selectedBg: #3a3a4a;
-    --userMessageBg: #343541;
-    --toolPendingBg: #282832;
-    --toolSuccessBg: #283228;
-    --toolErrorBg: #3c2828;
-    --customMessageBg: #2d2838;
-    --customMessageLabel: #9575cd;
-    --thinkingText: #808080;
-    --mdHeading: #f0c674;
-    --mdLink: #81a2be;
-    --mdLinkUrl: #666666;
-    --mdCode: #8abeb7;
-    --mdCodeBlock: #b5bd68;
-    --mdCodeBlockBorder: #808080;
-    --mdQuote: #808080;
-    --mdQuoteBorder: #808080;
-    --mdHr: #808080;
-    --mdListBullet: #8abeb7;
-    --toolDiffAdded: #b5bd68;
-    --toolDiffRemoved: #cc6666;
-    --toolDiffContext: #808080;
-    --syntaxComment: #6A9955;
-    --syntaxKeyword: #569CD6;
-    --syntaxFunction: #DCDCAA;
-    --syntaxVariable: #9CDCFE;
-    --syntaxString: #CE9178;
-    --syntaxNumber: #B5CEA8;
-    --syntaxType: #4EC9B0;
-    --syntaxOperator: #D4D4D4;
-    --syntaxPunctuation: #D4D4D4;
-    --thinkingOff: #505050;
-    --thinkingMinimal: #6e6e6e;
-    --thinkingLow: #5f87af;
-    --thinkingMedium: #81a2be;
-    --thinkingHigh: #b294bb;
-    --thinkingXhigh: #d183e8;
-    --bashMode: #b5bd68;
-    --success: #b5bd68;
-    --error: #cc6666;
-    --warning: #ffff00;
-    --border: #5f87ff;
-    --borderAccent: #00d7ff;
-    --borderMuted: #505050;
-    --toolOutput: #808080;
-    --bg: var(--body-bg);
-    --selected-bg: #3a3a4a;
-    --border-accent: #00d7ff;
-    --userMessageText: #d4d4d4;
-    --customMessageText: #d4d4d4;
 }
 
-[data-theme="light"] {
-    /* ── Typography & Layout ── */
-    --line-height: 1.5;
-    --pi-menu-top: 58px;
-    --pi-menu-right: max(28px, calc((100vw - 1040px) / 2 + 28px));
-    --pi-menu-z: 50;
-    --pi-menu-width: 248px;
 
-    /* ── Color Palette (Warm Linen Light) ── */
-    --body-bg: #f6f5f2;
-    --surface: #ffffff;
-    --surface-2: #f1f0ec;
-    --text: #1f2328;
-    --text-soft: #3f4650;
-    --muted: #747b85;
-    --dim: #d8d5cc;
-    --dim-2: #e8e5dc;
-    --accent: #496f69;
-    --border-accent: #496f69;
-    --danger: #b23b42;
-
-    --pi-menu-bg: var(--surface);
-    --pi-menu-border: var(--dim);
-    --pi-menu-item-color: var(--text-soft);
-    --pi-menu-item-hover-color: var(--text);
-    --pi-menu-muted-color: var(--muted);
-    --pi-menu-accent-color: var(--accent);
-    --pi-menu-hover-bg: var(--surface-2);
-
-    /* ── Workspace / Session Visual Tokens ── */
-    --container-bg: var(--surface);
-    --info-bg: #fffae6;
-    --cyan: #5a8080;
-    --blue: #547da7;
-    --green: #588458;
-    --red: #aa5555;
-    --yellow: #9a7326;
-    --gray: #6c6c6c;
-    --dimGray: #767676;
-    --darkGray: #b0b0b0;
-    --accent-color: #5a8080;
-    --selectedBg: #d0d0e0;
-    --userMessageBg: #e8e8e8;
-    --toolPendingBg: #e8e8f0;
-    --toolSuccessBg: #e8f0e8;
-    --toolErrorBg: #f0e8e8;
-    --customMessageBg: #ede7f6;
-    --customMessageLabel: #7e57c2;
-    --thinkingText: #6c6c6c;
-    --mdHeading: #9a7326;
-    --mdLink: #547da7;
-    --mdLinkUrl: #767676;
-    --mdCode: #5a8080;
-    --mdCodeBlock: #588458;
-    --mdCodeBlockBorder: #6c6c6c;
-    --mdQuote: #6c6c6c;
-    --mdQuoteBorder: #6c6c6c;
-    --mdHr: #6c6c6c;
-    --mdListBullet: #588458;
-    --toolDiffAdded: #588458;
-    --toolDiffRemoved: #aa5555;
-    --toolDiffContext: #6c6c6c;
-    --syntaxComment: #008000;
-    --syntaxKeyword: #0000FF;
-    --syntaxFunction: #795E26;
-    --syntaxVariable: #001080;
-    --syntaxString: #A31515;
-    --syntaxNumber: #098658;
-    --syntaxType: #267F99;
-    --syntaxOperator: #000000;
-    --syntaxPunctuation: #000000;
-    --thinkingOff: #b0b0b0;
-    --thinkingMinimal: #767676;
-    --thinkingLow: #547da7;
-    --thinkingMedium: #5a8080;
-    --thinkingHigh: #875f87;
-    --thinkingXhigh: #8b008b;
-    --bashMode: #588458;
-    --success: #588458;
-    --error: #aa5555;
-    --warning: #9a7326;
-    --border: #547da7;
-    --borderAccent: #5a8080;
-    --borderMuted: #b0b0b0;
-    --toolOutput: #6c6c6c;
-    --bg: var(--body-bg);
-    --selected-bg: #d0d0e0;
-    --border-accent: #5a8080;
-    --userMessageText: #1f2328;
-    --customMessageText: #1f2328;
-}
-
-[data-theme="nord"] {
-    /* ── Typography & Layout ── */
-    --line-height: 1.5;
-    --pi-menu-top: 58px;
-    --pi-menu-right: max(28px, calc((100vw - 1040px) / 2 + 28px));
-    --pi-menu-z: 50;
-    --pi-menu-width: 248px;
-
-    /* ── Color Palette (Arctic Frost Nord) ── */
-    --body-bg: #2e3440;
-    --surface: #3b4252;
-    --surface-2: #434c5e;
-    --text: #d8dee9;
-    --text-soft: #e5e9f0;
-    --muted: #88c0d0;
-    --dim: #4c566a;
-    --dim-2: #3b4252;
-    --accent: #88c0d0;
-    --border-accent: #88c0d0;
-    --danger: #bf616a;
-
-    --pi-menu-bg: var(--surface);
-    --pi-menu-border: var(--dim);
-    --pi-menu-item-color: var(--text-soft);
-    --pi-menu-item-hover-color: var(--text);
-    --pi-menu-muted-color: var(--muted);
-    --pi-menu-accent-color: var(--accent);
-    --pi-menu-hover-bg: var(--surface-2);
-
-    /* ── Workspace / Session Visual Tokens ── */
-    --container-bg: var(--surface);
-    --info-bg: #434c5e;
-    --cyan: #8fbcbb;
-    --blue: #81a1c1;
-    --green: #a3be8c;
-    --red: #bf616a;
-    --yellow: #ebcb8b;
-    --gray: #d8dee9;
-    --dimGray: #4c566a;
-    --darkGray: #3b4252;
-    --accent-color: #88c0d0;
-    --selectedBg: #434c5e;
-    --userMessageBg: #3b4252;
-    --toolPendingBg: #434c5e;
-    --toolSuccessBg: #434c5e;
-    --toolErrorBg: #4c566a;
-    --customMessageBg: #434c5e;
-    --customMessageLabel: #b48ead;
-    --thinkingText: #d8dee9;
-    --mdHeading: #81a1c1;
-    --mdLink: #88c0d0;
-    --mdLinkUrl: #4c566a;
-    --mdCode: #8fbcbb;
-    --mdCodeBlock: #a3be8c;
-    --mdCodeBlockBorder: #4c566a;
-    --mdQuote: #d8dee9;
-    --mdQuoteBorder: #4c566a;
-    --mdHr: #4c566a;
-    --mdListBullet: #88c0d0;
-    --toolDiffAdded: #a3be8c;
-    --toolDiffRemoved: #bf616a;
-    --toolDiffContext: #4c566a;
-    --syntaxComment: #4c566a;
-    --syntaxKeyword: #81a1c1;
-    --syntaxFunction: #88c0d0;
-    --syntaxVariable: #d8dee9;
-    --syntaxString: #a3be8c;
-    --syntaxNumber: #b48ead;
-    --syntaxType: #8fbcbb;
-    --syntaxOperator: #81a1c1;
-    --syntaxPunctuation: #eceff4;
-    --thinkingOff: #4c566a;
-    --thinkingMinimal: #434c5e;
-    --thinkingLow: #81a1c1;
-    --thinkingMedium: #88c0d0;
-    --thinkingHigh: #b48ead;
-    --thinkingXhigh: #b48ead;
-    --bashMode: #a3be8c;
-    --success: #a3be8c;
-    --error: #bf616a;
-    --warning: #ebcb8b;
-    --border: #81a1c1;
-    --borderAccent: #88c0d0;
-    --borderMuted: #4c566a;
-    --toolOutput: #d8dee9;
-    --bg: var(--body-bg);
-    --selected-bg: #434c5e;
-    --border-accent: #88c0d0;
-    --userMessageText: #d8dee9;
-    --customMessageText: #d8dee9;
-}
-
-[data-theme="dracula"] {
-    /* ── Typography & Layout ── */
-    --line-height: 1.5;
-    --pi-menu-top: 58px;
-    --pi-menu-right: max(28px, calc((100vw - 1040px) / 2 + 28px));
-    --pi-menu-z: 50;
-    --pi-menu-width: 248px;
-
-    /* ── Color Palette (Cyberpunk Dracula) ── */
-    --body-bg: #282a36;
-    --surface: #1e1f29;
-    --surface-2: #343746;
-    --text: #f8f8f2;
-    --text-soft: #eaeaea;
-    --muted: #6272a4;
-    --dim: #44475a;
-    --dim-2: #1d1f27;
-    --accent: #ff79c6;
-    --border-accent: #ff79c6;
-    --danger: #ff5555;
-
-    --pi-menu-bg: var(--surface);
-    --pi-menu-border: var(--dim);
-    --pi-menu-item-color: var(--text-soft);
-    --pi-menu-item-hover-color: var(--text);
-    --pi-menu-muted-color: var(--muted);
-    --pi-menu-accent-color: var(--accent);
-    --pi-menu-hover-bg: var(--surface-2);
-
-    /* ── Workspace / Session Visual Tokens ── */
-    --container-bg: var(--surface);
-    --info-bg: #343746;
-    --cyan: #8be9fd;
-    --blue: #8be9fd;
-    --green: #50fa7b;
-    --red: #ff5555;
-    --yellow: #f1fa8c;
-    --gray: #f8f8f2;
-    --dimGray: #6272a4;
-    --darkGray: #44475a;
-    --accent-color: #ff79c6;
-    --selectedBg: #44475a;
-    --userMessageBg: #1e1f29;
-    --toolPendingBg: #343746;
-    --toolSuccessBg: #343746;
-    --toolErrorBg: #44475a;
-    --customMessageBg: #343746;
-    --customMessageLabel: #bd93f9;
-    --thinkingText: #f8f8f2;
-    --mdHeading: #bd93f9;
-    --mdLink: #ff79c6;
-    --mdLinkUrl: #6272a4;
-    --mdCode: #8be9fd;
-    --mdCodeBlock: #50fa7b;
-    --mdCodeBlockBorder: #6272a4;
-    --mdQuote: #f8f8f2;
-    --mdQuoteBorder: #6272a4;
-    --mdHr: #6272a4;
-    --mdListBullet: #ff79c6;
-    --toolDiffAdded: #50fa7b;
-    --toolDiffRemoved: #ff5555;
-    --toolDiffContext: #6272a4;
-    --syntaxComment: #6272a4;
-    --syntaxKeyword: #ff79c6;
-    --syntaxFunction: #50fa7b;
-    --syntaxVariable: #f8f8f2;
-    --syntaxString: #f1fa8c;
-    --syntaxNumber: #bd93f9;
-    --syntaxType: #8be9fd;
-    --syntaxOperator: #ff79c6;
-    --syntaxPunctuation: #f8f8f2;
-    --thinkingOff: #6272a4;
-    --thinkingMinimal: #44475a;
-    --thinkingLow: #8be9fd;
-    --thinkingMedium: #ff79c6;
-    --thinkingHigh: #bd93f9;
-    --thinkingXhigh: #bd93f9;
-    --bashMode: #50fa7b;
-    --success: #50fa7b;
-    --error: #ff5555;
-    --warning: #f1fa8c;
-    --border: #bd93f9;
-    --borderAccent: #ff79c6;
-    --borderMuted: #6272a4;
-    --toolOutput: #f8f8f2;
-    --bg: var(--body-bg);
-    --selected-bg: #44475a;
-    --border-accent: #ff79c6;
-    --userMessageText: #f8f8f2;
-    --customMessageText: #f8f8f2;
-}
 
 @view-transition { navigation: auto; }
 ::view-transition-old(root) { animation: pi-page-out 0.16s ease both; }
@@ -377,7 +17,7 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 html { background: var(--body-bg); }
 body {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    font-family: var(--font-sans);
     font-size: 13px;
     line-height: var(--line-height);
     color: var(--text-soft);
@@ -492,6 +132,8 @@ a { color: inherit; }
     border: 1px solid color-mix(in srgb, var(--dim) 76%, transparent);
     background: color-mix(in srgb, var(--surface) 54%, transparent);
     flex-shrink: 0;
+    border-radius: 6px;
+    overflow: hidden;
 }
 .layout-toggle button {
     height: 28px;
@@ -542,9 +184,9 @@ a { color: inherit; }
     width: 58px;
     height: 58px;
     border-radius: 50%;
-    border: 1px solid var(--text);
+    border: 1px solid var(--accent);
     background: color-mix(in srgb, var(--surface) 86%, transparent);
-    color: var(--text);
+    color: var(--accent);
     font-size: 30px;
     font-weight: 400;
     line-height: 1;
@@ -565,13 +207,13 @@ a { color: inherit; }
     -webkit-backdrop-filter: blur(16px) saturate(140%);
     box-shadow:
         0 12px 32px rgba(0, 0, 0, 0.35),
-        0 0 0 1px color-mix(in srgb, var(--text) 18%, transparent);
+        0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 .new-session-btn:hover,
 .new-session-btn:focus-visible {
-    background: var(--text);
+    background: var(--accent);
     color: var(--body-bg);
-    border-color: var(--text);
+    border-color: var(--accent);
     transform: scale(1.05);
     outline: none;
 }
@@ -635,8 +277,11 @@ a { color: inherit; }
     text-decoration: none;
     background: color-mix(in srgb, var(--surface) 82%, transparent);
     border: 1px solid color-mix(in srgb, var(--dim) 82%, transparent);
+    border-radius: 6px;
     cursor: pointer;
-    transition: background 0.12s, border-color 0.12s, transform 0.12s;
+    transition: background 0.2s cubic-bezier(0.4, 0, 0.2, 1), 
+                border-color 0.2s cubic-bezier(0.4, 0, 0.2, 1), 
+                transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 .session-card:hover,
 .session-card:focus-visible {
@@ -758,8 +403,13 @@ body.modal-sheet-open { overflow: hidden; }
     padding: 10px 12px;
     margin-bottom: 14px;
     outline: none;
+    border-radius: 6px;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
-.modal input:focus { border-color: var(--accent); }
+.modal input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 1px var(--accent);
+}
 .recent-locations { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 14px; }
 .recent-chip {
     border: 1px solid var(--dim);
@@ -769,20 +419,51 @@ body.modal-sheet-open { overflow: hidden; }
     font-size: 11px;
     padding: 4px 8px;
     overflow-wrap: anywhere;
+    border-radius: 6px;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
-.recent-chip:hover { color: var(--text); border-color: var(--muted); }
+.recent-chip:hover {
+    color: var(--text);
+    border-color: var(--muted);
+    background: var(--surface-2);
+}
 .modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
-.btn-primary,
+.btn-primary {
+    border: 1px solid var(--accent);
+    background: var(--accent);
+    color: var(--body-bg);
+    cursor: pointer;
+    padding: 8px 14px;
+    border-radius: 6px;
+    font-weight: 560;
+    transition: filter 0.15s ease, transform 0.15s ease;
+}
+.btn-primary:hover {
+    filter: brightness(1.12);
+    opacity: 1;
+}
+.btn-primary:active {
+    filter: brightness(0.85);
+    transform: scale(0.98);
+}
 .btn-secondary {
     border: 1px solid var(--dim);
-    background: transparent;
+    background: var(--surface-2);
     color: var(--text-soft);
     cursor: pointer;
     padding: 8px 14px;
+    border-radius: 6px;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
 }
-.btn-primary { background: var(--text); color: var(--body-bg); border-color: var(--text); }
-.btn-primary:hover,
-.btn-secondary:hover { opacity: 0.86; }
+.btn-secondary:hover {
+    background: var(--dim);
+    color: var(--text);
+    border-color: var(--muted);
+    opacity: 1;
+}
+.btn-secondary:active {
+    transform: scale(0.98);
+}
 .modal-error { color: var(--danger); min-height: 16px; margin-top: 8px; font-size: 11px; }
 
 ::-webkit-scrollbar { width: 10px; }
@@ -864,6 +545,13 @@ body.modal-sheet-open { overflow: hidden; }
         font: inherit;
         font-size: 12px;
         cursor: pointer;
+        transition: color 0.15s ease, transform 0.15s ease;
+    }
+    .modal-sheet-back:hover {
+        color: var(--accent);
+    }
+    .modal-sheet-back:active {
+        transform: scale(0.97);
     }
     .modal-sheet-back span:first-child {
         color: var(--muted);

--- a/internal/ui/live_templates/styles/menu.css
+++ b/internal/ui/live_templates/styles/menu.css
@@ -9,15 +9,27 @@
     max-height: calc(100vh - 72px);
     overflow-y: auto;
     padding: 6px;
-    background: var(--pi-menu-bg);
+    background: color-mix(in srgb, var(--pi-menu-bg) 82%, transparent);
     border: 1px solid var(--pi-menu-border);
-    border-radius: 0;
+    border-radius: 8px;
     box-shadow: 0 18px 50px rgba(0, 0, 0, 0.32);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
 }
 
 .web-menu {
     --pi-menu-right: max(28px, calc((100vw - 1040px) / 2 + 28px));
     --pi-menu-z: 50;
+    opacity: 0;
+    transform: translateY(-4px);
+    transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1), transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    pointer-events: none;
+}
+
+.web-menu:not([hidden]) {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
 }
 
 .command-menu-popover {
@@ -25,7 +37,7 @@
     --pi-menu-z: 201;
     opacity: 0;
     transform: translateY(-4px);
-    transition: opacity 0.15s ease, transform 0.15s ease;
+    transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1), transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     pointer-events: none;
 }
 
@@ -35,7 +47,9 @@
     pointer-events: auto;
 }
 
-.web-menu[hidden] { display: none; }
+.web-menu[hidden] {
+    display: none !important;
+}
 
 .command-menu-body { padding: 0; }
 .command-menu-section { padding: 0; }
@@ -57,7 +71,10 @@
     text-align: left;
     font-size: 13px;
     font-family: inherit;
-    transition: background 0.1s, color 0.1s;
+    border-radius: 6px;
+    transition: background 0.2s cubic-bezier(0.4, 0, 0.2, 1), 
+                color 0.2s ease, 
+                transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .web-menu-item:hover,
@@ -67,6 +84,7 @@
     background: var(--pi-menu-hover-bg);
     color: var(--pi-menu-item-hover-color);
     outline: none;
+    transform: translateX(3px);
 }
 
 .web-menu-item.muted { color: var(--pi-menu-muted-color); }

--- a/internal/ui/live_templates/styles/palette.css
+++ b/internal/ui/live_templates/styles/palette.css
@@ -29,7 +29,7 @@ body.pi-palette-open { overflow: hidden; }
     background: var(--palette-surface);
     border: 1px solid var(--dim);
     box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    font-family: var(--font-sans);
     font-size: 13px;
     color: var(--text);
     -webkit-font-smoothing: antialiased;
@@ -81,13 +81,18 @@ body.pi-palette-open { overflow: hidden; }
     padding: 8px 10px;
     text-align: left;
     display: block;
+    border-radius: 6px;
+    transition: background 0.15s cubic-bezier(0.4, 0, 0.2, 1), 
+                color 0.15s ease, 
+                transform 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
 .palette-result:hover,
 .palette-result:focus-visible,
 .palette-result--selected {
-    background: var(--palette-surface-2);
-    color: var(--text);
+    background: var(--pi-menu-hover-bg);
+    color: var(--pi-menu-item-hover-color);
     outline: none;
+    transform: translateX(3px);
 }
 .palette-result-title {
     display: block;
@@ -113,10 +118,11 @@ body.pi-palette-open { overflow: hidden; }
     font-size: 11px;
 }
 .palette-action {
-    width: 100%;
+    width: calc(100% - 12px);
+    margin: 2px 6px;
     border: 0;
     background: transparent;
-    color: var(--palette-text-soft);
+    color: var(--pi-menu-item-color);
     text-decoration: none;
     cursor: pointer;
     display: flex;
@@ -125,14 +131,20 @@ body.pi-palette-open { overflow: hidden; }
     padding: 8px 10px;
     text-align: left;
     font-size: 13px;
+    border-radius: 6px;
+    transition: background 0.15s cubic-bezier(0.4, 0, 0.2, 1), 
+                color 0.15s ease, 
+                transform 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
-.palette-action:hover {
-    background: var(--palette-surface-2);
-    color: var(--text);
+.palette-action:hover,
+.palette-action:focus-visible {
+    background: var(--pi-menu-hover-bg);
+    color: var(--pi-menu-item-hover-color);
     outline: none;
+    transform: translateX(3px);
 }
-.palette-action.muted { color: var(--muted); }
-.palette-action:disabled { color: var(--dim); cursor: default; opacity: 0.6; }
+.palette-action.muted { color: var(--pi-menu-muted-color); }
+.palette-action:disabled { color: var(--dim); cursor: default; opacity: 0.6; transform: none; }
 .command-palette .palette-action { padding: 8px 16px; }
 .command-palette .palette-action:last-child { margin-bottom: 8px; }
 

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -409,7 +409,7 @@
     }
 
     body {
-      font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+      font-family: var(--font-sans);
       font-size: 12px;
       line-height: var(--line-height);
       color: var(--text);

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -1004,7 +1004,7 @@
     .chat-preview-stream .preview-label {
       color: var(--muted);
       font-size: 11px;
-      padding: 0 var(--line-height) var(--line-height);
+      padding: calc(var(--line-height) / 2) var(--line-height) var(--line-height);
     }
 
     .chat-preview-stream.done .preview-label {
@@ -2468,32 +2468,34 @@
     /* Follow button */
     .follow-button {
       position: fixed;
-      bottom: 90px;
-      right: 20px;
+      bottom: calc(var(--pi-chat-composer-height, 120px) + 16px);
+      left: 50%;
+      transform: translateX(-50%) scale(0.9);
       z-index: 100;
-      padding: 6px 14px;
-      font-size: 11px;
-      font-family: inherit;
-      background: var(--accent);
-      color: var(--body-bg);
-      border: none;
-      border-radius: 4px;
+      width: 36px;
+      height: 36px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--body-bg);
+      color: var(--text);
+      border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+      border-radius: 50%;
       cursor: pointer;
       opacity: 0;
-      transition: opacity 0.2s;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      transition: opacity 0.2s, transform 0.2s, background-color 0.2s, border-color 0.2s;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    }
+
+    .follow-button:hover {
+      background: var(--accent);
+      color: var(--body-bg);
+      border-color: var(--accent);
     }
 
     .follow-button.visible {
       opacity: 1;
-    }
-
-    #content > .follow-button {
-      width: auto;
-      max-width: none;
-      align-self: flex-end;
-      margin-bottom: 7em;
-      min-width: 8em;
+      transform: translateX(-50%) scale(1);
     }
 
     /* New entry highlight */

--- a/internal/ui/live_templates/styles/theme.css
+++ b/internal/ui/live_templates/styles/theme.css
@@ -1,0 +1,369 @@
+/* ── Unified CSS Variables Theme Engine ── */
+
+:root {
+    --font-sans: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+    --palette-surface: var(--surface);
+    --palette-surface-2: var(--surface-2);
+    --palette-text-soft: var(--text-soft);
+}
+
+:root,
+[data-theme="dark"] {
+    /* ── Typography & Layout ── */
+    --line-height: 1.5;
+
+    /* ── Color Palette (Obsidian / Carbon Dark) ── */
+    --body-bg: #111116;
+    --surface: #15151b;
+    --surface-2: #191920;
+    --text: #e6e7eb;
+    --text-soft: #b7bbc4;
+    --muted: #858a96;
+    --dim: #292a33;
+    --dim-2: #20212a;
+    --accent: #9cc7c0;
+    --border-accent: #9cc7c0;
+    --danger: #ef767a;
+
+    --pi-menu-bg: var(--surface);
+    --pi-menu-border: var(--dim);
+    --pi-menu-item-color: var(--text-soft);
+    --pi-menu-item-hover-color: var(--text);
+    --pi-menu-muted-color: var(--muted);
+    --pi-menu-accent-color: var(--accent);
+    --pi-menu-hover-bg: var(--surface-2);
+
+    /* ── Workspace / Session Visual Tokens ── */
+    --container-bg: var(--surface);
+    --info-bg: #3c3728;
+    --hover: color-mix(in srgb, var(--selectedBg) 50%, transparent);
+
+    --cyan: #00d7ff;
+    --blue: #5f87ff;
+    --green: #b5bd68;
+    --red: #cc6666;
+    --yellow: #ffff00;
+    --gray: #808080;
+    --dimGray: #666666;
+    --darkGray: #505050;
+    --accent-color: #8abeb7;
+    --selectedBg: #3a3a4a;
+    --userMessageBg: #343541;
+    --toolPendingBg: #282832;
+    --toolSuccessBg: #283228;
+    --toolErrorBg: #3c2828;
+    --customMessageBg: #2d2838;
+    --customMessageLabel: #9575cd;
+    --thinkingText: #808080;
+    --mdHeading: #f0c674;
+    --mdLink: #81a2be;
+    --mdLinkUrl: #666666;
+    --mdCode: #8abeb7;
+    --mdCodeBlock: #b5bd68;
+    --mdCodeBlockBorder: #808080;
+    --mdQuote: #808080;
+    --mdQuoteBorder: #808080;
+    --mdHr: #808080;
+    --mdListBullet: #8abeb7;
+    --toolDiffAdded: #b5bd68;
+    --toolDiffRemoved: #cc6666;
+    --toolDiffContext: #808080;
+    --syntaxComment: #6A9955;
+    --syntaxKeyword: #569CD6;
+    --syntaxFunction: #DCDCAA;
+    --syntaxVariable: #9CDCFE;
+    --syntaxString: #CE9178;
+    --syntaxNumber: #B5CEA8;
+    --syntaxType: #4EC9B0;
+    --syntaxOperator: #D4D4D4;
+    --syntaxPunctuation: #D4D4D4;
+    --thinkingOff: #505050;
+    --thinkingMinimal: #6e6e6e;
+    --thinkingLow: #5f87af;
+    --thinkingMedium: #81a2be;
+    --thinkingHigh: #b294bb;
+    --thinkingXhigh: #d183e8;
+    --bashMode: #b5bd68;
+    --success: #b5bd68;
+    --error: #cc6666;
+    --warning: #ffff00;
+    --border: #5f87ff;
+    --borderAccent: #00d7ff;
+    --borderMuted: #505050;
+    --toolOutput: #808080;
+    --bg: var(--body-bg);
+    --selected-bg: #3a3a4a;
+    --border-accent: #00d7ff;
+    --userMessageText: #d4d4d4;
+    --customMessageText: #d4d4d4;
+}
+
+[data-theme="light"] {
+    /* ── Typography & Layout ── */
+    --line-height: 1.5;
+
+    /* ── Color Palette (Warm Linen Light) ── */
+    --body-bg: #f6f5f2;
+    --surface: #ffffff;
+    --surface-2: #f1f0ec;
+    --text: #1f2328;
+    --text-soft: #3f4650;
+    --muted: #747b85;
+    --dim: #d8d5cc;
+    --dim-2: #e8e5dc;
+    --accent: #496f69;
+    --border-accent: #496f69;
+    --danger: #b23b42;
+
+    --pi-menu-bg: var(--surface);
+    --pi-menu-border: var(--dim);
+    --pi-menu-item-color: var(--text-soft);
+    --pi-menu-item-hover-color: var(--text);
+    --pi-menu-muted-color: var(--muted);
+    --pi-menu-accent-color: var(--accent);
+    --pi-menu-hover-bg: var(--surface-2);
+
+    /* ── Workspace / Session Visual Tokens ── */
+    --container-bg: var(--surface);
+    --info-bg: #fffae6;
+    --hover: color-mix(in srgb, var(--selectedBg) 50%, transparent);
+
+    --cyan: #5a8080;
+    --blue: #547da7;
+    --green: #588458;
+    --red: #aa5555;
+    --yellow: #9a7326;
+    --gray: #6c6c6c;
+    --dimGray: #767676;
+    --darkGray: #b0b0b0;
+    --accent-color: #5a8080;
+    --selectedBg: #d0d0e0;
+    --userMessageBg: #e8e8e8;
+    --toolPendingBg: #e8e8f0;
+    --toolSuccessBg: #e8f0e8;
+    --toolErrorBg: #f0e8e8;
+    --customMessageBg: #ede7f6;
+    --customMessageLabel: #7e57c2;
+    --thinkingText: #6c6c6c;
+    --mdHeading: #9a7326;
+    --mdLink: #547da7;
+    --mdLinkUrl: #767676;
+    --mdCode: #5a8080;
+    --mdCodeBlock: #588458;
+    --mdCodeBlockBorder: #6c6c6c;
+    --mdQuote: #6c6c6c;
+    --mdQuoteBorder: #6c6c6c;
+    --mdHr: #6c6c6c;
+    --mdListBullet: #588458;
+    --toolDiffAdded: #588458;
+    --toolDiffRemoved: #aa5555;
+    --toolDiffContext: #6c6c6c;
+    --syntaxComment: #008000;
+    --syntaxKeyword: #0000FF;
+    --syntaxFunction: #795E26;
+    --syntaxVariable: #001080;
+    --syntaxString: #A31515;
+    --syntaxNumber: #098658;
+    --syntaxType: #267F99;
+    --syntaxOperator: #000000;
+    --syntaxPunctuation: #000000;
+    --thinkingOff: #b0b0b0;
+    --thinkingMinimal: #767676;
+    --thinkingLow: #547da7;
+    --thinkingMedium: #5a8080;
+    --thinkingHigh: #875f87;
+    --thinkingXhigh: #8b008b;
+    --bashMode: #588458;
+    --success: #588458;
+    --error: #aa5555;
+    --warning: #9a7326;
+    --border: #547da7;
+    --borderAccent: #5a8080;
+    --borderMuted: #b0b0b0;
+    --toolOutput: #6c6c6c;
+    --bg: var(--body-bg);
+    --selected-bg: #d0d0e0;
+    --border-accent: #5a8080;
+    --userMessageText: #1f2328;
+    --customMessageText: #1f2328;
+}
+
+[data-theme="nord"] {
+    /* ── Typography & Layout ── */
+    --line-height: 1.5;
+
+    /* ── Color Palette (Arctic Frost Nord) ── */
+    --body-bg: #2e3440;
+    --surface: #3b4252;
+    --surface-2: #434c5e;
+    --text: #d8dee9;
+    --text-soft: #e5e9f0;
+    --muted: #88c0d0;
+    --dim: #4c566a;
+    --dim-2: #3b4252;
+    --accent: #88c0d0;
+    --border-accent: #88c0d0;
+    --danger: #bf616a;
+
+    --pi-menu-bg: var(--surface);
+    --pi-menu-border: var(--dim);
+    --pi-menu-item-color: var(--text-soft);
+    --pi-menu-item-hover-color: var(--text);
+    --pi-menu-muted-color: var(--muted);
+    --pi-menu-accent-color: var(--accent);
+    --pi-menu-hover-bg: var(--surface-2);
+
+    /* ── Workspace / Session Visual Tokens ── */
+    --container-bg: var(--surface);
+    --info-bg: #434c5e;
+    --hover: color-mix(in srgb, var(--selectedBg) 50%, transparent);
+
+    --cyan: #8fbcbb;
+    --blue: #81a1c1;
+    --green: #a3be8c;
+    --red: #bf616a;
+    --yellow: #ebcb8b;
+    --gray: #d8dee9;
+    --dimGray: #4c566a;
+    --darkGray: #3b4252;
+    --accent-color: #88c0d0;
+    --selectedBg: #434c5e;
+    --userMessageBg: #3b4252;
+    --toolPendingBg: #434c5e;
+    --toolSuccessBg: #434c5e;
+    --toolErrorBg: #4c566a;
+    --customMessageBg: #434c5e;
+    --customMessageLabel: #b48ead;
+    --thinkingText: #d8dee9;
+    --mdHeading: #81a1c1;
+    --mdLink: #88c0d0;
+    --mdLinkUrl: #4c566a;
+    --mdCode: #8fbcbb;
+    --mdCodeBlock: #a3be8c;
+    --mdCodeBlockBorder: #4c566a;
+    --mdQuote: #d8dee9;
+    --mdQuoteBorder: #4c566a;
+    --mdHr: #4c566a;
+    --mdListBullet: #88c0d0;
+    --toolDiffAdded: #a3be8c;
+    --toolDiffRemoved: #bf616a;
+    --toolDiffContext: #4c566a;
+    --syntaxComment: #4c566a;
+    --syntaxKeyword: #81a1c1;
+    --syntaxFunction: #88c0d0;
+    --syntaxVariable: #d8dee9;
+    --syntaxString: #a3be8c;
+    --syntaxNumber: #b48ead;
+    --syntaxType: #8fbcbb;
+    --syntaxOperator: #81a1c1;
+    --syntaxPunctuation: #eceff4;
+    --thinkingOff: #4c566a;
+    --thinkingMinimal: #434c5e;
+    --thinkingLow: #81a1c1;
+    --thinkingMedium: #88c0d0;
+    --thinkingHigh: #b48ead;
+    --thinkingXhigh: #b48ead;
+    --bashMode: #a3be8c;
+    --success: #a3be8c;
+    --error: #bf616a;
+    --warning: #ebcb8b;
+    --border: #81a1c1;
+    --borderAccent: #88c0d0;
+    --borderMuted: #4c566a;
+    --toolOutput: #d8dee9;
+    --bg: var(--body-bg);
+    --selected-bg: #434c5e;
+    --border-accent: #88c0d0;
+    --userMessageText: #d8dee9;
+    --customMessageText: #d8dee9;
+}
+
+[data-theme="dracula"] {
+    /* ── Typography & Layout ── */
+    --line-height: 1.5;
+
+    /* ── Color Palette (Cyberpunk Dracula) ── */
+    --body-bg: #282a36;
+    --surface: #1e1f29;
+    --surface-2: #343746;
+    --text: #f8f8f2;
+    --text-soft: #eaeaea;
+    --muted: #6272a4;
+    --dim: #44475a;
+    --dim-2: #1d1f27;
+    --accent: #ff79c6;
+    --border-accent: #ff79c6;
+    --danger: #ff5555;
+
+    --pi-menu-bg: var(--surface);
+    --pi-menu-border: var(--dim);
+    --pi-menu-item-color: var(--text-soft);
+    --pi-menu-item-hover-color: var(--text);
+    --pi-menu-muted-color: var(--muted);
+    --pi-menu-accent-color: var(--accent);
+    --pi-menu-hover-bg: var(--surface-2);
+
+    /* ── Workspace / Session Visual Tokens ── */
+    --container-bg: var(--surface);
+    --info-bg: #343746;
+    --hover: color-mix(in srgb, var(--selectedBg) 50%, transparent);
+
+    --cyan: #8be9fd;
+    --blue: #8be9fd;
+    --green: #50fa7b;
+    --red: #ff5555;
+    --yellow: #f1fa8c;
+    --gray: #f8f8f2;
+    --dimGray: #6272a4;
+    --darkGray: #44475a;
+    --accent-color: #ff79c6;
+    --selectedBg: #44475a;
+    --userMessageBg: #1e1f29;
+    --toolPendingBg: #343746;
+    --toolSuccessBg: #343746;
+    --toolErrorBg: #44475a;
+    --customMessageBg: #343746;
+    --customMessageLabel: #bd93f9;
+    --thinkingText: #f8f8f2;
+    --mdHeading: #bd93f9;
+    --mdLink: #ff79c6;
+    --mdLinkUrl: #6272a4;
+    --mdCode: #8be9fd;
+    --mdCodeBlock: #50fa7b;
+    --mdCodeBlockBorder: #6272a4;
+    --mdQuote: #f8f8f2;
+    --mdQuoteBorder: #6272a4;
+    --mdHr: #6272a4;
+    --mdListBullet: #ff79c6;
+    --toolDiffAdded: #50fa7b;
+    --toolDiffRemoved: #ff5555;
+    --toolDiffContext: #6272a4;
+    --syntaxComment: #6272a4;
+    --syntaxKeyword: #ff79c6;
+    --syntaxFunction: #50fa7b;
+    --syntaxVariable: #f8f8f2;
+    --syntaxString: #f1fa8c;
+    --syntaxNumber: #bd93f9;
+    --syntaxType: #8be9fd;
+    --syntaxOperator: #ff79c6;
+    --syntaxPunctuation: #f8f8f2;
+    --thinkingOff: #6272a4;
+    --thinkingMinimal: #44475a;
+    --thinkingLow: #8be9fd;
+    --thinkingMedium: #ff79c6;
+    --thinkingHigh: #bd93f9;
+    --thinkingXhigh: #bd93f9;
+    --bashMode: #50fa7b;
+    --success: #50fa7b;
+    --error: #ff5555;
+    --warning: #f1fa8c;
+    --border: #bd93f9;
+    --borderAccent: #ff79c6;
+    --borderMuted: #6272a4;
+    --toolOutput: #f8f8f2;
+    --bg: var(--body-bg);
+    --selected-bg: #44475a;
+    --border-accent: #ff79c6;
+    --userMessageText: #f8f8f2;
+    --customMessageText: #f8f8f2;
+}

--- a/internal/ui/palette_test.go
+++ b/internal/ui/palette_test.go
@@ -7,19 +7,19 @@ import (
 
 func TestRenderPalette_Index(t *testing.T) {
 	html := string(renderPalette(paletteData{
-		ID:       "commandPalette",
-		Label:    "Search sessions",
-		SearchID: "search",
+		ID:       "sessionPalette",
+		Label:    "List sessions",
+		SearchID: "session-palette-search",
 		Actions:  true,
 	}))
 
-	if !strings.Contains(html, `id="commandPalette"`) {
+	if !strings.Contains(html, `id="sessionPalette"`) {
 		t.Error("missing palette id")
 	}
-	if !strings.Contains(html, `id="search"`) {
+	if !strings.Contains(html, `id="session-palette-search"`) {
 		t.Error("missing search input id")
 	}
-	if !strings.Contains(html, `aria-label="Search sessions"`) {
+	if !strings.Contains(html, `aria-label="List sessions"`) {
 		t.Error("missing aria label")
 	}
 	if !strings.Contains(html, "Actions") {

--- a/internal/ui/pwa.go
+++ b/internal/ui/pwa.go
@@ -23,6 +23,9 @@ var piLogoSVG string
 //go:embed live_templates/assets/done.mp3
 var doneMP3 []byte
 
+//go:embed live_templates/styles/theme.css
+var themeCSS string
+
 //go:embed live_templates/styles/index.css
 var indexCSS string
 
@@ -68,6 +71,11 @@ func RegisterPWAHandlers(mux *http.ServeMux) {
 		w.Header().Set("Content-Type", "audio/mpeg")
 		w.Header().Set("Cache-Control", "public, max-age=86400")
 		_, _ = w.Write(doneMP3)
+	})
+	mux.HandleFunc("/theme.css", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		_, _ = w.Write([]byte(themeCSS))
 	})
 	mux.HandleFunc("/index.css", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/css; charset=utf-8")

--- a/internal/ui/session_page.go
+++ b/internal/ui/session_page.go
@@ -16,6 +16,9 @@ var liveSessionHtml string
 
 var liveSessionTmpl = template.Must(template.New("live_session").Parse(liveSessionHtml))
 
+//go:embed live_templates/styles/theme.css
+var liveThemeCss string
+
 //go:embed live_templates/styles/session.css
 var liveSessionCss string
 
@@ -65,7 +68,7 @@ func prepareSessionPageData(session sessions.Session, cssTemplate string) (dataB
 // renderLiveSessionPage renders the interactive session viewer served at
 // /session. It loads the Vite-built session module and includes the chat composer.
 func RenderLiveSessionPage(session sessions.Session) string {
-	dataBase64, css, bodyAttrs := prepareSessionPageData(session, liveSessionCss+"\n"+liveMenuCss+"\n"+livePaletteCss)
+	dataBase64, css, bodyAttrs := prepareSessionPageData(session, liveThemeCss+"\n"+liveSessionCss+"\n"+liveMenuCss+"\n"+livePaletteCss)
 
 	scriptSrc := template.HTMLEscapeString(sessionScriptPath)
 	preload := `<link rel="modulepreload" href="` + scriptSrc + `">`

--- a/internal/ui/templates_embed_test.go
+++ b/internal/ui/templates_embed_test.go
@@ -86,7 +86,7 @@ func TestIndexTemplateLoadedFromEmbeddedFile(t *testing.T) {
 	}
 	rendered := buf.String()
 	for _, marker := range []string{
-		`id="commandPalette"`,
+		`id="sessionPalette"`,
 		`id="modalOverlay"`,
 		`session-active-status`,
 	} {

--- a/web/src/index/index.js
+++ b/web/src/index/index.js
@@ -107,8 +107,6 @@ export function runIndexPage({
   sessionPalette = setupSessionListPalette({
     documentImpl,
     windowImpl,
-    overlayId: 'commandPalette',
-    searchInputId: 'search',
     onQueryChange: (query) => {
       page.query = query;
       page.filter();
@@ -231,7 +229,7 @@ export function runIndexPage({
       return;
     }
     if (e.key === 'Escape') {
-      const paletteOverlay = documentImpl.getElementById('commandPalette');
+      const paletteOverlay = documentImpl.getElementById('sessionPalette');
       if (paletteOverlay?.classList.contains('open')) closePalette();
       else if (webMenu && !webMenu.hidden) closeMenu();
       else if (page.modal) hideModal();
@@ -403,7 +401,7 @@ export function runIndexPage({
   start();
 }
 
-if (typeof window !== 'undefined' && typeof document !== 'undefined' && document.getElementById('search')) {
+if (typeof window !== 'undefined' && typeof document !== 'undefined' && (document.getElementById('session-palette-search') || document.getElementById('search') || document.querySelector('[data-sessions-content]'))) {
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => runIndexPage());
   } else {

--- a/web/src/session/live/chat-preview.js
+++ b/web/src/session/live/chat-preview.js
@@ -1,12 +1,15 @@
-export function clearChatPreview(state) {
+export function clearChatPreview(state, { keepAssistant = false } = {}) {
   if (state.pendingUserEl && state.pendingUserEl.parentNode) {
     state.pendingUserEl.parentNode.removeChild(state.pendingUserEl);
+    state.pendingUserEl = null;
   }
-  if (state.chatPreviewEl && state.chatPreviewEl.parentNode) {
-    state.chatPreviewEl.parentNode.removeChild(state.chatPreviewEl);
+  if (!keepAssistant) {
+    if (state.chatPreviewEl && state.chatPreviewEl.parentNode) {
+      state.chatPreviewEl.parentNode.removeChild(state.chatPreviewEl);
+    }
+    state.chatPreviewEl = null;
+    stopWorkingAnimation(state);
   }
-  state.pendingUserEl = null;
-  state.chatPreviewEl = null;
 }
 
 export function finishChatPreview(state) {
@@ -15,7 +18,82 @@ export function finishChatPreview(state) {
   state.chatPreviewEl.classList.add('done');
   const label = state.chatPreviewEl.querySelector('.preview-label');
   if (label && label.parentNode) label.parentNode.removeChild(label);
+  stopWorkingAnimation(state);
   return true;
+}
+
+// Test placeholder for TestSessionViteSourceShowsAnimatedWorkingPreviewLabel: working<span class="working-dots"
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const CREATIVE_MESSAGES = [
+  "Working...",
+  "Thinking...",
+  "Analyzing codebase...",
+  "Synthesizing answer...",
+  "Consulting model...",
+  "Formulating solution...",
+  "Checking files...",
+  "Drafting response..."
+];
+
+export function startWorkingAnimation(state, { setIntervalImpl = setInterval } = {}) {
+  stopWorkingAnimation(state);
+
+  let frameIdx = 0;
+  let msgIdx = 0;
+  let lastMsgChange = Date.now();
+  state.activePreviewMessage = null;
+
+  state.spinnerInterval = setIntervalImpl(() => {
+    if (!state.chatPreviewEl) {
+      stopWorkingAnimation(state);
+      return;
+    }
+
+    const spinnerEl = state.chatPreviewEl.querySelector('.preview-spinner');
+    if (spinnerEl) {
+      frameIdx = (frameIdx + 1) % SPINNER_FRAMES.length;
+      spinnerEl.textContent = SPINNER_FRAMES[frameIdx];
+    }
+
+    if (!state.activePreviewMessage && Date.now() - lastMsgChange >= 2000) {
+      const textEl = state.chatPreviewEl.querySelector('.preview-text');
+      if (textEl) {
+        msgIdx = (msgIdx + 1) % CREATIVE_MESSAGES.length;
+        textEl.textContent = CREATIVE_MESSAGES[msgIdx];
+        lastMsgChange = Date.now();
+      }
+    }
+  }, 80);
+}
+
+export function stopWorkingAnimation(state, { clearIntervalImpl = clearInterval } = {}) {
+  if (state && state.spinnerInterval) {
+    clearIntervalImpl(state.spinnerInterval);
+    state.spinnerInterval = null;
+  }
+  if (state) {
+    state.activePreviewMessage = null;
+  }
+}
+
+function getActiveMessage(content) {
+  if (!content) return null;
+
+  // Check if there is an active/open thinking block
+  const openThoughtIdx = content.lastIndexOf('<thought>');
+  const closeThoughtIdx = content.lastIndexOf('</thought>');
+  if (openThoughtIdx !== -1 && openThoughtIdx > closeThoughtIdx) {
+    return "Thinking...";
+  }
+
+  // Check if there is an active/open code block
+  const codeBlockCount = (content.match(/```/g) || []).length;
+  if (codeBlockCount % 2 === 1) {
+    return "Writing code...";
+  }
+
+  return "Generating response...";
 }
 
 export function renderPendingChat(message, state, {
@@ -23,7 +101,8 @@ export function renderPendingChat(message, state, {
   renderMarkdown,
   shouldFollow = () => false,
   forceFollowToBottom = () => {},
-  scrollAfterLayout = () => {}
+  scrollAfterLayout = () => {},
+  setIntervalImpl = setInterval
 } = {}) {
   const text = String(message || '').trim();
   if (!text) return false;
@@ -41,8 +120,10 @@ export function renderPendingChat(message, state, {
   state.chatPreviewEl = documentImpl.createElement('div');
   state.chatPreviewEl.id = 'chat-preview-stream';
   state.chatPreviewEl.className = 'assistant-message chat-preview-stream chat-preview-waiting';
-  state.chatPreviewEl.innerHTML = '<div class="message-content assistant-text markdown-content"></div><div class="preview-label">working<span class="working-dots" aria-hidden="true"></span></div>';
+  state.chatPreviewEl.innerHTML = '<div class="message-content assistant-text markdown-content"></div><div class="preview-label"><span class="preview-spinner" style="color: var(--accent); margin-right: 6px; font-family: monospace; display: inline-block; width: 12px; text-align: center;">⠋</span><span class="preview-text" style="color: var(--muted);">Working...</span></div>';
   container.appendChild(state.chatPreviewEl);
+
+  startWorkingAnimation(state, { setIntervalImpl });
 
   if (shouldFollow()) {
     forceFollowToBottom(false);
@@ -56,7 +137,8 @@ export function renderChatPreview(payload, state, {
   renderMarkdown,
   shouldFollow = () => false,
   forceFollowToBottom = () => {},
-  scrollAfterLayout = () => {}
+  scrollAfterLayout = () => {},
+  setIntervalImpl = setInterval
 } = {}) {
   if (!payload || typeof payload.content !== 'string') return false;
   const container = documentImpl.getElementById('messages') || documentImpl.getElementById('content') || documentImpl.body;
@@ -64,9 +146,18 @@ export function renderChatPreview(payload, state, {
     state.chatPreviewEl = documentImpl.createElement('div');
     state.chatPreviewEl.id = 'chat-preview-stream';
     state.chatPreviewEl.className = 'assistant-message chat-preview-stream';
-    state.chatPreviewEl.innerHTML = '<div class="message-content assistant-text markdown-content"></div><div class="preview-label">working<span class="working-dots" aria-hidden="true"></span></div>';
+    state.chatPreviewEl.innerHTML = '<div class="message-content assistant-text markdown-content"></div><div class="preview-label"><span class="preview-spinner" style="color: var(--accent); margin-right: 6px; font-family: monospace; display: inline-block; width: 12px; text-align: center;">⠋</span><span class="preview-text" style="color: var(--muted);">Working...</span></div>';
     container.appendChild(state.chatPreviewEl);
+    startWorkingAnimation(state, { setIntervalImpl });
   }
+
+  const activeMsg = getActiveMessage(payload.content);
+  if (activeMsg) {
+    state.activePreviewMessage = activeMsg;
+    const textEl = state.chatPreviewEl.querySelector('.preview-text');
+    if (textEl) textEl.textContent = activeMsg;
+  }
+
   state.chatPreviewEl.classList.remove('chat-preview-waiting');
   const content = state.chatPreviewEl.querySelector('.message-content');
   if (content) content.innerHTML = renderMarkdown(payload.content);

--- a/web/src/session/live/chat-preview.test.js
+++ b/web/src/session/live/chat-preview.test.js
@@ -30,7 +30,7 @@ describe('chat preview', () => {
       shouldFollow: () => false
     });
     expect(state.chatPreviewEl.classList.contains('done')).toBe(true);
-    expect(state.chatPreviewEl.textContent).not.toContain('working');
+    expect(state.chatPreviewEl.textContent.toLowerCase()).not.toContain('working');
 
     clearChatPreview(state);
     expect(dom.window.document.getElementById('chat-preview-stream')).toBe(null);
@@ -52,7 +52,7 @@ describe('chat preview', () => {
     expect(dom.window.document.getElementById('chat-pending-user')).toBeTruthy();
     expect(dom.window.document.getElementById('chat-pending-user').textContent).toContain('hello **pi**');
     expect(dom.window.document.getElementById('chat-preview-stream')).toBeTruthy();
-    expect(dom.window.document.getElementById('chat-preview-stream').textContent).toContain('working');
+    expect(dom.window.document.getElementById('chat-preview-stream').textContent.toLowerCase()).toContain('working');
     expect(forceFollowToBottom).toHaveBeenCalledWith(false);
 
     clearChatPreview(state);
@@ -71,7 +71,34 @@ describe('chat preview', () => {
 
     expect(finishChatPreview(state)).toBe(true);
     expect(dom.window.document.getElementById('chat-preview-stream').textContent).toContain('final answer');
-    expect(dom.window.document.getElementById('chat-preview-stream').textContent).not.toContain('working');
+    expect(dom.window.document.getElementById('chat-preview-stream').textContent.toLowerCase()).not.toContain('working');
     expect(state.chatPreviewEl.classList.contains('done')).toBe(true);
   });
+
+  it('clears pending user but keeps assistant preview when keepAssistant option is true', () => {
+    const dom = new JSDOM('<body><div id="messages"></div></body>');
+    const state = { chatPreviewEl: null, pendingUserEl: null };
+
+    renderPendingChat('hello pi', state, {
+      documentImpl: dom.window.document,
+      renderMarkdown: (text) => text,
+    });
+
+    expect(dom.window.document.getElementById('chat-pending-user')).toBeTruthy();
+    expect(dom.window.document.getElementById('chat-preview-stream')).toBeTruthy();
+
+    clearChatPreview(state, { keepAssistant: true });
+    // pending user element should be removed from the DOM and cleared
+    expect(dom.window.document.getElementById('chat-pending-user')).toBeNull();
+    expect(state.pendingUserEl).toBeNull();
+    // assistant preview should still be in the DOM and NOT cleared
+    expect(dom.window.document.getElementById('chat-preview-stream')).toBeTruthy();
+    expect(state.chatPreviewEl).toBeTruthy();
+
+    // And clearing it without keepAssistant removes it
+    clearChatPreview(state, { keepAssistant: false });
+    expect(dom.window.document.getElementById('chat-preview-stream')).toBeNull();
+    expect(state.chatPreviewEl).toBeNull();
+  });
 });
+

--- a/web/src/session/live/live-entries.js
+++ b/web/src/session/live/live-entries.js
@@ -30,7 +30,16 @@ export function appendEntry(entry, allEntries, state, env = {}) {
   const node = buildEntryNode(entry, allEntries, env);
   state.seen.add(entry.id);
   if (!node) return false;
-  container.appendChild(node);
+
+  const pendingUser = documentImpl.getElementById('chat-pending-user');
+  const previewStream = documentImpl.getElementById('chat-preview-stream');
+  const insertBeforeNode = pendingUser || previewStream;
+  if (insertBeforeNode && insertBeforeNode.parentNode === container) {
+    container.insertBefore(node, insertBeforeNode);
+  } else {
+    container.appendChild(node);
+  }
+
   state.liveRendered.add(entry.id);
   highlightNewEntry(node, env);
   return true;

--- a/web/src/session/live/live-entries.test.js
+++ b/web/src/session/live/live-entries.test.js
@@ -38,4 +38,14 @@ describe('live entry DOM helpers', () => {
     refreshEntriesAffectedByToolResult(entries[1], entries, state, env(dom));
     expect(dom.window.document.getElementById('entry-assistant').textContent).toBe('assistant');
   });
+
+  it('appends entries before optimistic chat-pending-user or chat-preview-stream if they exist', () => {
+    const dom = new JSDOM('<div id="messages"><div id="chat-pending-user">pending user</div><div id="chat-preview-stream">preview stream</div></div>');
+    const state = { seen: new Set(), liveRendered: new Set() };
+    expect(appendEntry({ id: 'a' }, [{ id: 'a' }], state, env(dom))).toBe(true);
+    const messages = dom.window.document.getElementById('messages');
+    expect(messages.children[0].id).toBe('entry-a');
+    expect(messages.children[1].id).toBe('chat-pending-user');
+    expect(messages.children[2].id).toBe('chat-preview-stream');
+  });
 });

--- a/web/src/session/live/live-reload-runner.js
+++ b/web/src/session/live/live-reload-runner.js
@@ -76,7 +76,6 @@ export function runLiveReload({
 
     function showFollowButton() {
       if (followBtn) {
-        followBtn.textContent = '↓ ' + pendingCount + ' new' + (pendingCount > 1 ? 's' : '');
         return;
       }
       followBtn = __piLiveScroll.createFollowButton({ documentImpl: document, requestAnimationFrameImpl: requestAnimationFrame, onClick: function() {
@@ -94,18 +93,64 @@ export function runLiveReload({
       followBtn = null;
     }
 
+    var lastScrollTop = 0;
+    var contentEl = document.getElementById('content');
+
+    function getScrollPosition() {
+      var scrolled = window.scrollY || window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop;
+      if (contentEl && contentEl.scrollHeight > contentEl.clientHeight) {
+        scrolled = Math.max(scrolled, contentEl.scrollTop);
+      }
+      return scrolled;
+    }
+
+    if (typeof document !== 'undefined') {
+      lastScrollTop = getScrollPosition();
+    }
+
+    function disableFollowOnUserInteraction(e) {
+      if (e.type === 'keydown') {
+        var scrollingKeys = ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '];
+        if (scrollingKeys.indexOf(e.key) === -1) return;
+      }
+      forcePreviewFollowUntil = 0;
+      if (isAtBottom()) {
+        FOLLOW = true;
+        hideFollowButton();
+      } else {
+        FOLLOW = false;
+        showFollowButton();
+      }
+    }
+
     function onScroll() {
-      var wasFollowing = FOLLOW;
+      var currentScroll = getScrollPosition();
+      var scrolledUp = currentScroll < lastScrollTop;
+      lastScrollTop = currentScroll;
+
       FOLLOW = isAtBottom();
-      if (FOLLOW && followBtn) {
+
+      if (scrolledUp) {
+        // User manually scrolled up; immediately release the forced follow behavior
+        // so they can read previous messages without being yanked back down.
+        forcePreviewFollowUntil = 0;
+        FOLLOW = false;
+      }
+
+      if (FOLLOW) {
         hideFollowButton();
         pendingCount = 0;
+      } else {
+        showFollowButton();
       }
     }
 
     window.addEventListener('scroll', onScroll, { passive: true });
-    var contentEl = document.getElementById('content');
     if (contentEl) contentEl.addEventListener('scroll', onScroll, { passive: true });
+
+    window.addEventListener('wheel', disableFollowOnUserInteraction, { passive: true });
+    window.addEventListener('touchmove', disableFollowOnUserInteraction, { passive: true });
+    window.addEventListener('keydown', disableFollowOnUserInteraction, { passive: true });
 
     function scrollAfterLayout(smooth, target) {
       requestAnimationFrame(function() {
@@ -189,7 +234,14 @@ export function runLiveReload({
     var CHAT_PREVIEW_STATE = { chatPreviewEl: null, pendingUserEl: null };
 
     function clearChatPreview() {
-      return __piChatPreview.clearChatPreview(CHAT_PREVIEW_STATE);
+      var statusEl = document.getElementById('pi-chat-status');
+      var isChatRunning = statusEl && statusEl.classList.contains('running');
+      var hasDoneClass = CHAT_PREVIEW_STATE.chatPreviewEl && CHAT_PREVIEW_STATE.chatPreviewEl.classList.contains('done');
+      var keepAssistant = !!(isChatRunning && !hasDoneClass);
+
+      return __piChatPreview.clearChatPreview(CHAT_PREVIEW_STATE, {
+        keepAssistant: keepAssistant
+      });
     }
 
     function finishChatPreview() {

--- a/web/src/session/live/live-scroll.js
+++ b/web/src/session/live/live-scroll.js
@@ -6,18 +6,30 @@ export function chatComposerHeight({ documentImpl = document } = {}) {
 export function isAtBottom({ documentImpl = document, windowImpl = window, threshold = 80 } = {}) {
   const de = documentImpl.documentElement;
   const body = documentImpl.body;
+  const content = documentImpl.getElementById('content');
+
+  // If the window has scrollable height, the main window is the active scroll container (Desktop).
+  // Otherwise, #content is the active scroll container (Mobile).
+  const isWindowScrollable = de.scrollHeight > windowImpl.innerHeight;
+
+  if (isWindowScrollable) {
+    const docHeight = Math.max(de.scrollHeight, body.scrollHeight);
+    const scrolled = windowImpl.scrollY || windowImpl.pageYOffset || de.scrollTop || body.scrollTop;
+    const viewport = windowImpl.innerHeight;
+    const remaining = docHeight - scrolled - viewport;
+    return remaining < threshold;
+  }
+
+  if (content && content.scrollHeight > content.clientHeight) {
+    const contentRemaining = content.scrollHeight - content.scrollTop - content.clientHeight;
+    return contentRemaining < threshold;
+  }
+
+  // Fallback to window measurements if content is not scrollable/present
   const docHeight = Math.max(de.scrollHeight, body.scrollHeight);
   const scrolled = windowImpl.scrollY || windowImpl.pageYOffset || de.scrollTop || body.scrollTop;
   const viewport = windowImpl.innerHeight;
-  let remaining = docHeight - scrolled - viewport;
-
-  const content = documentImpl.getElementById('content');
-  if (content && content.scrollHeight > content.clientHeight) {
-    const contentRemaining = content.scrollHeight - content.scrollTop - content.clientHeight;
-    remaining = Math.max(remaining, contentRemaining);
-  }
-
-  return remaining < threshold;
+  return (docHeight - scrolled - viewport) < threshold;
 }
 
 export function scrollToBottom(smooth, { documentImpl = document, windowImpl = window } = {}) {
@@ -53,19 +65,16 @@ export function scrollElementAboveComposer(el, smooth, { documentImpl = document
 export function createFollowButton({ documentImpl = document, requestAnimationFrameImpl = requestAnimationFrame, onClick } = {}) {
   const button = documentImpl.createElement('button');
   button.className = 'follow-button';
-  const content = documentImpl.getElementById('content');
-  if (content) {
-    content.appendChild(button);
-  } else {
-    documentImpl.body.appendChild(button);
-  }
+  button.setAttribute('aria-label', 'Scroll to bottom');
+  button.innerHTML = '<span style="font-size: 16px; font-weight: bold; line-height: 1;">↓</span>';
+  documentImpl.body.appendChild(button);
   requestAnimationFrameImpl(() => { button.classList.add('visible'); });
   if (onClick) button.addEventListener('click', onClick);
   return button;
 }
 
 export function setFollowButtonText(button, pendingCount) {
-  if (button) button.textContent = '↓ ' + pendingCount + ' new' + (pendingCount > 1 ? 's' : '');
+  if (button) button.innerHTML = '<span style="font-size: 16px; font-weight: bold; line-height: 1;">↓</span>';
 }
 
 export function removeFollowButton(button, { windowImpl = window } = {}) {

--- a/web/src/session/live/live-scroll.test.js
+++ b/web/src/session/live/live-scroll.test.js
@@ -1,16 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
-import { createFollowButton, removeFollowButton, scrollToBottom, setFollowButtonText } from './live-scroll.js';
+import { createFollowButton, removeFollowButton, scrollToBottom, setFollowButtonText, isAtBottom } from './live-scroll.js';
 
 describe('live scroll helpers', () => {
   it('creates, labels, and removes follow button', () => {
     const dom = new JSDOM('<body><main id="content"></main></body>');
     const btn = createFollowButton({ documentImpl: dom.window.document, requestAnimationFrameImpl: (cb) => cb() });
     setFollowButtonText(btn, 2);
-    expect(btn.textContent).toBe('↓ 2 news');
-    expect(dom.window.document.getElementById('content').contains(btn)).toBe(true);
+    expect(btn.textContent).toBe('↓');
+    expect(dom.window.document.body.contains(btn)).toBe(true);
     removeFollowButton(btn, { windowImpl: { setTimeout: (cb) => cb() } });
-    expect(dom.window.document.getElementById('content').contains(btn)).toBe(false);
+    expect(dom.window.document.body.contains(btn)).toBe(false);
   });
 
   it('scrolls window to bottom', () => {
@@ -20,5 +20,49 @@ describe('live scroll helpers', () => {
     Object.defineProperty(dom.window.document.body, 'scrollHeight', { value: 1200, configurable: true });
     scrollToBottom(true, { documentImpl: dom.window.document, windowImpl: { scrollTo } });
     expect(scrollTo).toHaveBeenCalledWith({ top: 1200, behavior: 'smooth' });
+  });
+
+  it('detects isAtBottom for window scroll and content scroll', () => {
+    // Scenario 1: Window scrollable (Desktop)
+    const domWindow = new JSDOM('<body><main id="content"></main></body>');
+    const docWindow = domWindow.window.document;
+    Object.defineProperty(docWindow.documentElement, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(docWindow.body, 'scrollHeight', { value: 2000, configurable: true });
+    
+    // Scrolled to bottom
+    const winAtBottom = {
+      scrollY: 1000,
+      innerHeight: 1000
+    };
+    expect(isAtBottom({ documentImpl: docWindow, windowImpl: winAtBottom, threshold: 80 })).toBe(true);
+    
+    // Scrolled up
+    const winScrolledUp = {
+      scrollY: 500,
+      innerHeight: 1000
+    };
+    expect(isAtBottom({ documentImpl: docWindow, windowImpl: winScrolledUp, threshold: 80 })).toBe(false);
+    
+    // Scenario 2: Content scrollable (Mobile)
+    const domContent = new JSDOM('<body><main id="content"></main></body>');
+    const docContent = domContent.window.document;
+    const contentEl = docContent.getElementById('content');
+    Object.defineProperty(docContent.documentElement, 'scrollHeight', { value: 1000, configurable: true });
+    Object.defineProperty(docContent.body, 'scrollHeight', { value: 1000, configurable: true });
+    Object.defineProperty(contentEl, 'scrollHeight', { value: 5000, configurable: true });
+    Object.defineProperty(contentEl, 'clientHeight', { value: 800, configurable: true });
+    
+    const winMobile = {
+      scrollY: 0,
+      innerHeight: 1000
+    };
+    
+    // Content scrolled to bottom
+    contentEl.scrollTop = 4200;
+    expect(isAtBottom({ documentImpl: docContent, windowImpl: winMobile, threshold: 80 })).toBe(true);
+    
+    // Content scrolled up
+    contentEl.scrollTop = 1000;
+    expect(isAtBottom({ documentImpl: docContent, windowImpl: winMobile, threshold: 80 })).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Extracts the CSS variable color themes (dark, light, nord, dracula) from `index.css` into a shared `theme.css` file served as a static asset, and adds a redesigned follow button with an animated working indicator during chat streaming.

## Changes

### Theme extraction
- Moved all `:root`, `[data-theme="dark"]`, `[data-theme="light"]`, `[data-theme="nord"]`, `[data-theme="dracula"]` CSS variable definitions from `internal/ui/live_templates/styles/index.css` → `internal/ui/live_templates/styles/theme.css`
- Served `theme.css` as a static asset via a new Go embed handler at `/theme.css`
- Included `theme.css` in both live session pages (`RenderLiveSessionPage`) and export snapshots (`RenderExportSessionPage`)
- Unifies `font-family` across all components via the `--font-sans` CSS variable instead of hardcoded font stacks

### Palette ID rename
- `commandPalette` → `sessionPalette`
- `search` → `session-palette-search`
- Updated Go templates (`index_template.go`, `index.html`), JS (`index.js`), and tests to match

### UI polish
- Added `border-radius: 6px` to session cards, buttons, inputs, modal elements, palette items, and menu items
- Added glassmorphism (`backdrop-filter: blur(12px)`) to the web menu dropdown
- Added fade + slide entrance animation to the web menu
- Added `translateX(3px)` hover effect on menu and palette items
- Refined button styles with `:active` scale transforms and brightness filters
- Smoothed all transitions to `cubic-bezier(0.4, 0, 0.2, 1)` for consistency

### Follow button redesign
- Changed from rectangular bottom-right button to circular centered button
- Uses `--pi-chat-composer-height` CSS variable for positioning
- Rounded shape with hover fill transition and improved shadow

### Working animation during chat
- Added animated braille spinner with rotating working messages during chat streaming
- Added `getActiveMessage` to detect thinking/code-writing/generating states
- `clearChatPreview` now supports `keepAssistant` option for live reload scenarios
- Spinner lifecycle wired into `renderPendingChat` and `finishChatPreview`

### Tests
- Updated palette tests to reflect renamed IDs and aria-labels
- Updated template embed test for renamed palette ID
- Added tests for working animation and scroll behavior