### PR TITLE
feat(chat): list loaded skills when typing /skill in the composer

### DIFF
--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -57,3 +57,7 @@ func BuildAbortCommand(id string) map[string]any {
 func BuildSetThinkingLevelCommand(id, level string) map[string]any {
 	return map[string]any{"id": id, "type": "set_thinking_level", "level": level}
 }
+
+func BuildGetCommandsCommand(id string) map[string]any {
+	return map[string]any{"id": id, "type": "get_commands"}
+}

--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -52,6 +52,13 @@ func TestBuildPromptCommandOmitsSteerWhenIdle(t *testing.T) {
 	}
 }
 
+func TestBuildGetCommandsCommand(t *testing.T) {
+	cmd := BuildGetCommandsCommand("req-7")
+	if cmd["id"] != "req-7" || cmd["type"] != "get_commands" {
+		t.Fatalf("cmd = %#v", cmd)
+	}
+}
+
 func TestWriteRPCCommandWritesJSONLine(t *testing.T) {
 	var buf bytes.Buffer
 	if err := WriteCommand(&buf, map[string]any{"type": "get_state"}); err != nil {

--- a/internal/rpc/worker.go
+++ b/internal/rpc/worker.go
@@ -34,6 +34,8 @@ type piRPCWorker struct {
 	lastStreamActivity   atomic.Int64 // unix nanos; stream/turn events keep worker visually running
 	streamSink           StreamEventSink
 	streamPreview        *streamPreviewAccumulator
+	cachedCommands       []workers.SlashCommand
+	commandsCached       bool
 }
 
 // idleReportable is implemented by workers that can report when they were last
@@ -238,6 +240,55 @@ func (w *piRPCWorker) GetState(ctx context.Context) (workers.WorkerStatus, error
 	case <-ctx.Done():
 		w.removePending(id)
 		return workers.WorkerStatus{}, ctx.Err()
+	}
+}
+
+// GetCommands queries pi for the commands available via prompt (extensions,
+// prompt templates, and skills). The set is fixed for a worker's lifetime, so
+// the result is cached after the first successful call.
+func (w *piRPCWorker) GetCommands(ctx context.Context) ([]workers.SlashCommand, error) {
+	w.mu.Lock()
+	if w.commandsCached {
+		cached := append([]workers.SlashCommand(nil), w.cachedCommands...)
+		w.mu.Unlock()
+		return cached, nil
+	}
+	w.mu.Unlock()
+
+	id := w.nextID()
+	ch := make(chan response, 1)
+	w.mu.Lock()
+	w.pending[id] = ch
+	w.mu.Unlock()
+
+	w.writeMu.Lock()
+	err := WriteCommand(w.stdin, BuildGetCommandsCommand(id))
+	w.writeMu.Unlock()
+	if err != nil {
+		w.removePending(id)
+		return nil, err
+	}
+
+	select {
+	case res := <-ch:
+		if !res.Success {
+			if res.Error != "" {
+				return nil, errors.New(res.Error)
+			}
+			return nil, fmt.Errorf("rpc get_commands rejected")
+		}
+		var payload struct {
+			Commands []workers.SlashCommand `json:"commands"`
+		}
+		_ = json.Unmarshal(res.Data, &payload)
+		w.mu.Lock()
+		w.cachedCommands = payload.Commands
+		w.commandsCached = true
+		w.mu.Unlock()
+		return payload.Commands, nil
+	case <-ctx.Done():
+		w.removePending(id)
+		return nil, ctx.Err()
 	}
 }
 

--- a/internal/rpc/worker_test.go
+++ b/internal/rpc/worker_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -128,6 +129,26 @@ func TestHandleRPCLineIgnoresMalformedJSON(t *testing.T) {
 
 	if got := w.Status(); got.State != workers.WorkerStateIdle {
 		t.Fatalf("status = %q, want idle", got.State)
+	}
+}
+
+func TestGetCommandsReturnsCacheWithoutRPC(t *testing.T) {
+	// stdin is nil: if GetCommands tried to write a command it would panic,
+	// so reaching the cached result proves it short-circuits the RPC.
+	want := []workers.SlashCommand{{Name: "skill:foo", Description: "Foo", Source: "skill"}}
+	w := &piRPCWorker{
+		status:         workers.WorkerStatus{State: workers.WorkerStateIdle},
+		pending:        make(map[string]chan response),
+		cachedCommands: want,
+		commandsCached: true,
+	}
+
+	got, err := w.GetCommands(context.Background())
+	if err != nil {
+		t.Fatalf("GetCommands error: %v", err)
+	}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("commands = %#v", got)
 	}
 }
 

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -174,12 +174,44 @@ func (s *Server) handleWorkerStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleCommands lists the slash commands (extensions, prompt templates,
-// skills) exposed by the session's pi worker. It never spawns a worker; if
-// none is running yet, it reports workerReady=false with an empty list so the
-// client can prompt the user to send a message first. Older pi builds that
+// skills) exposed by the session's pi worker.
+//
+// By default it only peeks at an existing worker; if none is running it reports
+// workerReady=false with an empty list. With ?load=1 it instead spawns (or
+// reuses) the worker first, so the client can offer an explicit "load skills"
+// action without the user having to send a chat message. Older pi builds that
 // predate the get_commands RPC are degraded gracefully to an empty list.
 func (s *Server) handleCommands(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.URL.Query().Get("id")
+	load := r.URL.Query().Get("load") == "1"
+
+	if load && s.chatSender != nil {
+		resolved, err := sessions.ResolveByID(s.sessionsDir, sessionID)
+		if err != nil {
+			switch {
+			case errors.Is(err, sessions.ErrInvalidSessionID):
+				writeJSONError(w, http.StatusBadRequest, "invalid session id")
+			case errors.Is(err, sessions.ErrSessionNotFound):
+				writeJSONError(w, http.StatusNotFound, "session not found")
+			default:
+				writeJSONError(w, http.StatusInternalServerError, err.Error())
+			}
+			return
+		}
+		if !resolved.Session.ChatAvailable {
+			writeJSONError(w, http.StatusConflict, resolved.Session.ChatDisabledReason)
+			return
+		}
+		sessionID = resolved.Session.ID
+		spawnCtx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+		err = s.chatSender.EnsureWorker(spawnCtx, sessionID, resolved.Path)
+		cancel()
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
 	commands := []workers.SlashCommand{}
 	ready := false
 	if s.chatSender != nil {

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"pi-web/internal/chat"
@@ -21,6 +22,7 @@ type ChatSender interface {
 	SetThinkingLevel(ctx context.Context, sessionID, sessionPath, level string) error
 	Abort(ctx context.Context, sessionID string) error
 	GetState(ctx context.Context, sessionID string) (workers.WorkerStatus, error)
+	GetCommands(ctx context.Context, sessionID string) ([]workers.SlashCommand, bool, error)
 	Status(sessionID string) workers.WorkerStatus
 	EnsureWorker(ctx context.Context, sessionID, sessionPath string) error
 }
@@ -169,6 +171,37 @@ func (s *Server) handleWorkerStatus(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, 0, status)
+}
+
+// handleCommands lists the slash commands (extensions, prompt templates,
+// skills) exposed by the session's pi worker. It never spawns a worker; if
+// none is running yet, it reports workerReady=false with an empty list so the
+// client can prompt the user to send a message first. Older pi builds that
+// predate the get_commands RPC are degraded gracefully to an empty list.
+func (s *Server) handleCommands(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.URL.Query().Get("id")
+	commands := []workers.SlashCommand{}
+	ready := false
+	if s.chatSender != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		defer cancel()
+		cmds, workerReady, err := s.chatSender.GetCommands(ctx, sessionID)
+		ready = workerReady
+		if err != nil && !isUnknownCommandErr(err) {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if cmds != nil {
+			commands = cmds
+		}
+	}
+	writeJSON(w, 0, map[string]any{"workerReady": ready, "commands": commands})
+}
+
+// isUnknownCommandErr reports whether err came from a pi build that does not
+// implement the get_commands RPC (pre-v0.78.0).
+func isUnknownCommandErr(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "unknown command")
 }
 
 func (s *Server) hasRecentSessionActivity(sessionID string) bool {

--- a/internal/server/chat_test.go
+++ b/internal/server/chat_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -36,6 +37,9 @@ type fakeSender struct {
 	setThinkingSessionID    string
 	setThinkingLevel        string
 	sendCh                  chan struct{}
+	commands                []workers.SlashCommand
+	commandsReady           bool
+	commandsErr             error
 }
 
 func (f *fakeSender) Send(ctx context.Context, sessionID, sessionPath string, chat chat.Request) error {
@@ -74,6 +78,10 @@ func (f *fakeSender) GetState(ctx context.Context, sessionID string) (workers.Wo
 		return f.state, nil
 	}
 	return workers.WorkerStatus{State: workers.WorkerStateIdle}, nil
+}
+
+func (f *fakeSender) GetCommands(ctx context.Context, sessionID string) ([]workers.SlashCommand, bool, error) {
+	return f.commands, f.commandsReady, f.commandsErr
 }
 
 func (f *fakeSender) Status(sessionID string) workers.WorkerStatus {
@@ -164,6 +172,91 @@ func TestHandleChatRejectsBrokenSession(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "working directory no longer exists") {
 		t.Fatalf("body = %q", w.Body.String())
+	}
+}
+
+func TestHandleCommandsReportsNotReadyWithoutWorker(t *testing.T) {
+	s := &Server{sessionsDir: t.TempDir(), chatSender: &fakeSender{}}
+	req := httptest.NewRequest(http.MethodGet, "/api/commands?id=session.jsonl", nil)
+	w := httptest.NewRecorder()
+	s.handleCommands(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var body struct {
+		WorkerReady bool                   `json:"workerReady"`
+		Commands    []workers.SlashCommand `json:"commands"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.WorkerReady {
+		t.Fatalf("workerReady = true, want false")
+	}
+	if len(body.Commands) != 0 {
+		t.Fatalf("commands = %#v, want empty", body.Commands)
+	}
+}
+
+func TestHandleCommandsReturnsCommands(t *testing.T) {
+	fake := &fakeSender{
+		commandsReady: true,
+		commands: []workers.SlashCommand{
+			{Name: "skill:foo", Description: "Foo skill", Source: "skill"},
+			{Name: "my-ext", Description: "An extension", Source: "extension"},
+		},
+	}
+	s := &Server{sessionsDir: t.TempDir(), chatSender: fake}
+	req := httptest.NewRequest(http.MethodGet, "/api/commands?id=session.jsonl", nil)
+	w := httptest.NewRecorder()
+	s.handleCommands(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var body struct {
+		WorkerReady bool                   `json:"workerReady"`
+		Commands    []workers.SlashCommand `json:"commands"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !body.WorkerReady {
+		t.Fatalf("workerReady = false, want true")
+	}
+	if len(body.Commands) != 2 || body.Commands[0].Name != "skill:foo" {
+		t.Fatalf("commands = %#v", body.Commands)
+	}
+}
+
+func TestHandleCommandsDegradesOnUnknownCommand(t *testing.T) {
+	fake := &fakeSender{commandsReady: true, commandsErr: errors.New("Unknown command: get_commands")}
+	s := &Server{sessionsDir: t.TempDir(), chatSender: fake}
+	req := httptest.NewRequest(http.MethodGet, "/api/commands?id=session.jsonl", nil)
+	w := httptest.NewRecorder()
+	s.handleCommands(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (degraded); body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		WorkerReady bool                   `json:"workerReady"`
+		Commands    []workers.SlashCommand `json:"commands"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(body.Commands) != 0 {
+		t.Fatalf("commands = %#v, want empty on unknown command", body.Commands)
+	}
+}
+
+func TestHandleCommandsReturns500OnRealError(t *testing.T) {
+	fake := &fakeSender{commandsReady: true, commandsErr: errors.New("boom")}
+	s := &Server{sessionsDir: t.TempDir(), chatSender: fake}
+	req := httptest.NewRequest(http.MethodGet, "/api/commands?id=session.jsonl", nil)
+	w := httptest.NewRecorder()
+	s.handleCommands(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
 	}
 }
 

--- a/internal/server/chat_test.go
+++ b/internal/server/chat_test.go
@@ -260,6 +260,63 @@ func TestHandleCommandsReturns500OnRealError(t *testing.T) {
 	}
 }
 
+func TestHandleCommandsLoadSpawnsWorker(t *testing.T) {
+	root := t.TempDir()
+	writeSessionFile(t, root, "--tmp--project--", "session.jsonl")
+	fake := &fakeSender{
+		commandsReady: true,
+		commands:      []workers.SlashCommand{{Name: "skill:foo", Description: "Foo", Source: "skill"}},
+	}
+	s := &Server{sessionsDir: root, chatSender: fake}
+	req := httptest.NewRequest(http.MethodGet, "/api/commands?id=session.jsonl&load=1", nil)
+	w := httptest.NewRecorder()
+	s.handleCommands(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if !fake.ensureWorkerCalled {
+		t.Fatalf("EnsureWorker was not called for load=1")
+	}
+	var body struct {
+		WorkerReady bool                   `json:"workerReady"`
+		Commands    []workers.SlashCommand `json:"commands"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !body.WorkerReady || len(body.Commands) != 1 {
+		t.Fatalf("body = %#v", body)
+	}
+}
+
+func TestHandleCommandsPeekDoesNotSpawnWorker(t *testing.T) {
+	fake := &fakeSender{}
+	s := &Server{sessionsDir: t.TempDir(), chatSender: fake}
+	req := httptest.NewRequest(http.MethodGet, "/api/commands?id=session.jsonl", nil)
+	w := httptest.NewRecorder()
+	s.handleCommands(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if fake.ensureWorkerCalled {
+		t.Fatalf("EnsureWorker should not be called without load=1")
+	}
+}
+
+func TestHandleCommandsLoadMissingSessionReturns404(t *testing.T) {
+	fake := &fakeSender{}
+	s := &Server{sessionsDir: t.TempDir(), chatSender: fake}
+	req := httptest.NewRequest(http.MethodGet, "/api/commands?id=missing.jsonl&load=1", nil)
+	w := httptest.NewRecorder()
+	s.handleCommands(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	if fake.ensureWorkerCalled {
+		t.Fatalf("EnsureWorker should not be called when session is missing")
+	}
+}
+
 func TestHandleWorkerStatusDefaultsIdle(t *testing.T) {
 	s := &Server{sessionsDir: t.TempDir(), chatSender: &fakeSender{}}
 	req := httptest.NewRequest(http.MethodGet, "/api/worker-status?id=session.jsonl", nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -199,6 +199,7 @@ func (s *Server) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/set-thinking-level", s.auth.Wrap(s.handleSetThinkingLevel))
 	mux.HandleFunc("/api/models", s.auth.Wrap(s.handleAvailableModels))
 	mux.HandleFunc("/api/worker-status", s.auth.Wrap(s.handleWorkerStatus))
+	mux.HandleFunc("/api/commands", s.auth.Wrap(s.handleCommands))
 	mux.HandleFunc("/share", s.auth.Wrap(s.handleShare))
 	mux.HandleFunc("/events", s.auth.Wrap(s.handleEvents))
 	mux.HandleFunc("/api/new-session", s.auth.Wrap(s.handleNewSession))

--- a/internal/ui/live_templates/chat_composer.html
+++ b/internal/ui/live_templates/chat_composer.html
@@ -93,6 +93,14 @@
         >
             <div id="pi-chat-thinking-list" class="pi-chat-thinking-list"></div>
         </div>
+        <div
+            id="pi-chat-skill-popup"
+            class="pi-chat-skill-popup"
+            style="display: none"
+        >
+            <div class="pi-chat-skill-header">Loaded skills</div>
+            <div id="pi-chat-skill-list" class="pi-chat-skill-list"></div>
+        </div>
         <div class="pi-chat-toolbar">
             <div class="pi-chat-toolbar-left">
                 <button

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -3196,6 +3196,19 @@
       font-size: 11px;
       text-align: center;
     }
+    .pi-chat-skill-load {
+      display: block;
+      width: calc(100% - 16px);
+      margin: 0 8px 8px;
+      padding: 6px 10px;
+      font-size: 12px;
+      color: var(--text);
+      background: var(--selected-bg, #3a3a4a);
+      border: 1px solid var(--dim);
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .pi-chat-skill-load:hover { border-color: var(--accent, #7aa2f7); }
 
     /* Share overlay */
     .share-overlay-backdrop {

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -3186,6 +3186,7 @@
       gap: 2px;
       padding: 6px 8px;
       border-radius: 3px;
+      cursor: pointer;
     }
     .pi-chat-skill-item:hover { background: var(--selected-bg, #3a3a4a); }
     .pi-chat-skill-name { color: var(--text); font-size: 12px; }

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -2245,9 +2245,34 @@
 
       #content {
         min-height: 0;
-        padding: calc(52px + env(safe-area-inset-top) + var(--line-height)) 16px var(--line-height);
+        padding: calc(52px + env(safe-area-inset-top) + var(--line-height)) 16px calc(var(--pi-chat-composer-height, 200px) + var(--line-height));
         -webkit-overflow-scrolling: touch;
         overscroll-behavior: contain;
+      }
+
+      /* iOS Safari's flex height chain fails to constrain the scroll column,
+         so the in-flow composer flows below the fold and gets clipped by the
+         body's overflow:hidden. Pin it to the layout viewport bottom instead:
+         with no keyboard it sits at the viewport floor; when the keyboard opens
+         iOS shrinks the layout viewport and it rides up above the keyboard.
+         #content gets matching padding-bottom so content isn't hidden behind it. */
+      .pi-chat-composer {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: var(--keyboard-inset, 0px);
+        z-index: 50;
+        background: var(--body-bg);
+        transition: bottom 0.15s ease-out;
+      }
+
+      /* iOS Safari zooms the page in whenever a text field with font-size < 16px
+         gains focus (it ignores maximum-scale for this). That zoom shifts the
+         visual viewport and desyncs the caret from the textarea. Force 16px on
+         the composer inputs so focusing them never triggers the zoom. */
+      #pi-chat-message,
+      .pi-chat-model-search {
+        font-size: 16px;
       }
 
       #content > * {

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -3159,6 +3159,44 @@
     .thinking-level-item.selected.thinking-xhigh,
     .thinking-level-item:hover.thinking-xhigh { color: var(--thinkingXhigh); }
 
+    /* /skill list */
+    .pi-chat-skill-popup {
+      position: absolute;
+      bottom: calc(100% + 4px);
+      left: 0;
+      right: 0;
+      background: var(--container-bg, #1e1e2e);
+      border: 1px solid var(--dim);
+      border-radius: 6px;
+      box-shadow: 0 -4px 16px rgba(0,0,0,0.3);
+      z-index: 200;
+      max-height: 320px;
+      overflow-y: auto;
+    }
+    .pi-chat-skill-header {
+      padding: 8px 10px;
+      font-size: 11px;
+      color: var(--muted);
+      border-bottom: 1px solid var(--dim);
+    }
+    .pi-chat-skill-list { padding: 4px; }
+    .pi-chat-skill-item {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      padding: 6px 8px;
+      border-radius: 3px;
+    }
+    .pi-chat-skill-item:hover { background: var(--selected-bg, #3a3a4a); }
+    .pi-chat-skill-name { color: var(--text); font-size: 12px; }
+    .pi-chat-skill-desc { color: var(--muted); font-size: 11px; }
+    .pi-chat-skill-empty {
+      padding: 10px;
+      color: var(--muted);
+      font-size: 11px;
+      text-align: center;
+    }
+
     /* Share overlay */
     .share-overlay-backdrop {
       position: fixed;

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -2186,6 +2186,7 @@
     @media (max-width: 900px) {
       html, body {
         height: 100%;
+        overscroll-behavior: none;
       }
 
       body {
@@ -2245,7 +2246,7 @@
 
       #content {
         min-height: 0;
-        padding: calc(52px + env(safe-area-inset-top) + var(--line-height)) 16px calc(var(--pi-chat-composer-height, 200px) + var(--line-height));
+        padding: calc(52px + env(safe-area-inset-top) + var(--line-height)) 16px calc(var(--keyboard-inset, 0px) + var(--pi-chat-composer-height, 200px) + var(--line-height));
         -webkit-overflow-scrolling: touch;
         overscroll-behavior: contain;
       }

--- a/internal/workers/manager.go
+++ b/internal/workers/manager.go
@@ -26,12 +26,21 @@ type WorkerStatus struct {
 	ThinkingLevel string `json:"thinkingLevel,omitempty"`
 }
 
+// SlashCommand is a command the pi agent exposes for invocation via prompt.
+// Source is one of "extension", "prompt", or "skill".
+type SlashCommand struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Source      string `json:"source"`
+}
+
 type ChatWorker interface {
 	Prompt(ctx context.Context, chat chat.Request) error
 	SetModel(ctx context.Context, provider, modelID string) error
 	SetThinkingLevel(ctx context.Context, level string) error
 	Abort(ctx context.Context) error
 	GetState(ctx context.Context) (WorkerStatus, error)
+	GetCommands(ctx context.Context) ([]SlashCommand, error)
 	Status() WorkerStatus
 	Close() error
 }
@@ -163,6 +172,21 @@ func (m *Manager) GetState(ctx context.Context, sessionID string) (WorkerStatus,
 		return WorkerStatus{State: WorkerStateIdle}, nil
 	}
 	return worker.GetState(ctx)
+}
+
+// GetCommands returns the slash commands exposed by the session's pi worker.
+// It never spawns a worker: if none is running yet, ready is false and the
+// command list is nil. Skills are fixed for a worker's lifetime, so the worker
+// caches the result after the first call.
+func (m *Manager) GetCommands(ctx context.Context, sessionID string) (commands []SlashCommand, ready bool, err error) {
+	m.mu.Lock()
+	worker := m.workers[sessionID]
+	m.mu.Unlock()
+	if worker == nil {
+		return nil, false, nil
+	}
+	commands, err = worker.GetCommands(ctx)
+	return commands, true, err
 }
 
 func (m *Manager) Abort(ctx context.Context, sessionID string) error {

--- a/internal/workers/manager_test.go
+++ b/internal/workers/manager_test.go
@@ -45,6 +45,10 @@ func (f *fakeChatWorker) GetState(ctx context.Context) (WorkerStatus, error) {
 	return f.Status(), nil
 }
 
+func (f *fakeChatWorker) GetCommands(ctx context.Context) ([]SlashCommand, error) {
+	return nil, nil
+}
+
 func (f *fakeChatWorker) Close() error { return nil }
 
 func TestManagerCreatesOneWorkerPerSession(t *testing.T) {
@@ -119,9 +123,31 @@ func (r *reapableWorker) SetModel(ctx context.Context, provider, modelID string)
 func (r *reapableWorker) SetThinkingLevel(ctx context.Context, level string) error     { return nil }
 func (r *reapableWorker) Abort(ctx context.Context) error                              { return nil }
 func (r *reapableWorker) GetState(ctx context.Context) (WorkerStatus, error)           { return r.Status(), nil }
+func (r *reapableWorker) GetCommands(ctx context.Context) ([]SlashCommand, error)      { return nil, nil }
 func (r *reapableWorker) Status() WorkerStatus                                         { return WorkerStatus{State: WorkerStateIdle} }
 func (r *reapableWorker) Close() error                                                 { r.closed = true; return nil }
 func (r *reapableWorker) IdleSince(now time.Time) time.Duration                        { return r.idleFor }
+
+func TestManagerGetCommandsDoesNotSpawnWorker(t *testing.T) {
+	created := 0
+	manager := NewManager(func(string, string) (ChatWorker, error) {
+		created++
+		return &fakeChatWorker{}, nil
+	})
+	commands, ready, err := manager.GetCommands(context.Background(), "missing.jsonl")
+	if err != nil {
+		t.Fatalf("GetCommands error: %v", err)
+	}
+	if ready {
+		t.Fatalf("ready = true, want false when no worker exists")
+	}
+	if commands != nil {
+		t.Fatalf("commands = %#v, want nil", commands)
+	}
+	if created != 0 {
+		t.Fatalf("factory called %d times, want 0", created)
+	}
+}
 
 func TestManagerReapsIdleWorkersBeyondTTL(t *testing.T) {
 	w := &reapableWorker{idleFor: time.Hour}
@@ -184,6 +210,7 @@ func (runningReapable) Abort(ctx context.Context) error                         
 func (runningReapable) GetState(ctx context.Context) (WorkerStatus, error) {
 	return WorkerStatus{State: WorkerStateRunning}, nil
 }
+func (runningReapable) GetCommands(ctx context.Context) ([]SlashCommand, error) { return nil, nil }
 func (runningReapable) Status() WorkerStatus                  { return WorkerStatus{State: WorkerStateRunning} }
 func (runningReapable) Close() error                          { return nil }
 func (runningReapable) IdleSince(now time.Time) time.Duration { return time.Hour }
@@ -197,6 +224,7 @@ func (erroredWorker) Abort(ctx context.Context) error                           
 func (erroredWorker) GetState(ctx context.Context) (WorkerStatus, error) {
 	return WorkerStatus{State: WorkerStateError}, nil
 }
+func (erroredWorker) GetCommands(ctx context.Context) ([]SlashCommand, error) { return nil, nil }
 func (erroredWorker) Status() WorkerStatus {
 	return WorkerStatus{State: WorkerStateError, Error: "dead"}
 }

--- a/web/src/session/chat/chat-api.js
+++ b/web/src/session/chat/chat-api.js
@@ -18,6 +18,10 @@ export function listModels({ fetchImpl = fetch } = {}) {
   return fetchImpl('/api/models');
 }
 
+export function getCommands(sessionId, { fetchImpl = fetch } = {}) {
+  return fetchImpl(chatUrl('/api/commands', sessionId));
+}
+
 export function setModel(sessionId, { provider, modelId }, { fetchImpl = fetch } = {}) {
   return fetchImpl(chatUrl('/api/set-model', sessionId), {
     method: 'POST',

--- a/web/src/session/chat/chat-api.js
+++ b/web/src/session/chat/chat-api.js
@@ -18,8 +18,8 @@ export function listModels({ fetchImpl = fetch } = {}) {
   return fetchImpl('/api/models');
 }
 
-export function getCommands(sessionId, { fetchImpl = fetch } = {}) {
-  return fetchImpl(chatUrl('/api/commands', sessionId));
+export function getCommands(sessionId, { fetchImpl = fetch, load = false } = {}) {
+  return fetchImpl(chatUrl('/api/commands', sessionId) + (load ? '&load=1' : ''));
 }
 
 export function setModel(sessionId, { provider, modelId }, { fetchImpl = fetch } = {}) {

--- a/web/src/session/chat/chat-api.test.js
+++ b/web/src/session/chat/chat-api.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { cancelChat, chatUrl, getWorkerStatus, listModels, sendChat, setModel, setThinkingLevel } from './chat-api.js';
+import { cancelChat, chatUrl, getCommands, getWorkerStatus, listModels, sendChat, setModel, setThinkingLevel } from './chat-api.js';
 
 describe('chat api helpers', () => {
   it('builds encoded session URLs', () => {
@@ -16,6 +16,7 @@ describe('chat api helpers', () => {
     await listModels({ fetchImpl });
     await setModel('s.jsonl', { provider: 'p', modelId: 'm' }, { fetchImpl });
     await setThinkingLevel('s.jsonl', 'medium', { fetchImpl });
+    await getCommands('s.jsonl', { fetchImpl });
 
     expect(fetchImpl).toHaveBeenNthCalledWith(1, '/api/chat?id=s.jsonl', { method: 'POST', body });
     expect(fetchImpl).toHaveBeenNthCalledWith(2, '/api/chat/cancel?id=s.jsonl', { method: 'POST' });
@@ -31,5 +32,6 @@ describe('chat api helpers', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ level: 'medium' })
     });
+    expect(fetchImpl).toHaveBeenNthCalledWith(7, '/api/commands?id=s.jsonl');
   });
 });

--- a/web/src/session/chat/chat-api.test.js
+++ b/web/src/session/chat/chat-api.test.js
@@ -17,6 +17,7 @@ describe('chat api helpers', () => {
     await setModel('s.jsonl', { provider: 'p', modelId: 'm' }, { fetchImpl });
     await setThinkingLevel('s.jsonl', 'medium', { fetchImpl });
     await getCommands('s.jsonl', { fetchImpl });
+    await getCommands('s.jsonl', { fetchImpl, load: true });
 
     expect(fetchImpl).toHaveBeenNthCalledWith(1, '/api/chat?id=s.jsonl', { method: 'POST', body });
     expect(fetchImpl).toHaveBeenNthCalledWith(2, '/api/chat/cancel?id=s.jsonl', { method: 'POST' });
@@ -33,5 +34,6 @@ describe('chat api helpers', () => {
       body: JSON.stringify({ level: 'medium' })
     });
     expect(fetchImpl).toHaveBeenNthCalledWith(7, '/api/commands?id=s.jsonl');
+    expect(fetchImpl).toHaveBeenNthCalledWith(8, '/api/commands?id=s.jsonl&load=1');
   });
 });

--- a/web/src/session/chat/chat-composer-runner.js
+++ b/web/src/session/chat/chat-composer-runner.js
@@ -12,6 +12,7 @@ export function runChatComposer({
   chatSelectors,
   modelSelector,
   thinkingSelector,
+  skillList,
   FormDataImpl = FormData,
   URLSearchParamsImpl = URLSearchParams,
   CustomEventImpl = CustomEvent,
@@ -25,6 +26,7 @@ export function runChatComposer({
   const __piChatSelectors = chatSelectors;
   const __piModelSelector = modelSelector;
   const __piThinkingSelector = thinkingSelector;
+  const __piSkillList = skillList;
   const FormData = FormDataImpl;
   const URLSearchParams = URLSearchParamsImpl;
   const CustomEvent = CustomEventImpl;
@@ -405,6 +407,7 @@ export function runChatComposer({
       textarea.addEventListener('input', () => {
         autoResizeTextarea();
         updateSendEnabled();
+        if (_skillListApi && _skillListApi.maybeShow) _skillListApi.maybeShow(textarea.value);
       });
       // Initial sizing in case the textarea was pre-filled (e.g. browser autofill).
       autoResizeTextarea();
@@ -868,6 +871,7 @@ export function runChatComposer({
 
   let _modelSelectorApi = null;
   let _thinkingSelectorApi = null;
+  let _skillListApi = null;
 
   function initPiChatControls() {
     setupCwdCopy();
@@ -893,6 +897,7 @@ export function runChatComposer({
 
     _modelSelectorApi = loadModelSelector();
     _thinkingSelectorApi = setupThinkingLevelSelector();
+    _skillListApi = loadSkillList();
   }
 
   if (document.readyState === 'loading') {
@@ -916,6 +921,18 @@ export function runChatComposer({
       getKnownModelLabel: () => knownModelLabel,
       setCurrentModelForThinking: (model) => { currentModelForThinking = model; },
       setWorkerModelUpdate: (handler) => { onWorkerModelUpdate = handler; }
+    });
+  }
+
+  // ── Skill list (/skill) ──────────────────────────────────────────────
+  function loadSkillList() {
+    if (!__piSkillList || typeof __piSkillList.setupSkillList !== 'function') return null;
+    const sessionId = new URLSearchParams(window.location.search).get('id') || (document.getElementById('pi-chat-composer') || {}).dataset?.sessionId || '';
+    return __piSkillList.setupSkillList({
+      documentImpl: document,
+      sessionId,
+      chatApi: __piChatApi,
+      escapeHtml
     });
   }
 

--- a/web/src/session/chat/chat-composer-runner.js
+++ b/web/src/session/chat/chat-composer-runner.js
@@ -920,7 +920,8 @@ export function runChatComposer({
       setKnownModelLabel: (label) => { knownModelLabel = label; },
       getKnownModelLabel: () => knownModelLabel,
       setCurrentModelForThinking: (model) => { currentModelForThinking = model; },
-      setWorkerModelUpdate: (handler) => { onWorkerModelUpdate = handler; }
+      setWorkerModelUpdate: (handler) => { onWorkerModelUpdate = handler; },
+      onOpen: () => { if (_skillListApi && _skillListApi.close) _skillListApi.close(); }
     });
   }
 

--- a/web/src/session/chat/model-selector.js
+++ b/web/src/session/chat/model-selector.js
@@ -30,7 +30,8 @@ export function setupModelSelector({
   setKnownModelLabel = () => {},
   getKnownModelLabel = () => '',
   setCurrentModelForThinking = () => {},
-  setWorkerModelUpdate = () => {}
+  setWorkerModelUpdate = () => {},
+  onOpen = () => {}
 } = {}) {
   let allModels = [];
   let selectedModel = null;
@@ -57,6 +58,9 @@ export function setupModelSelector({
 
   function openPopup() {
     if (!popup) return;
+    // Dismiss any sibling popup (e.g. the /skill list) since the model button's
+    // click stops propagation, so their outside-click handlers never fire.
+    onOpen();
     popup.style.display = 'flex';
     if (popupSearch) {
       popupSearch.value = '';

--- a/web/src/session/chat/skill-list.js
+++ b/web/src/session/chat/skill-list.js
@@ -41,7 +41,7 @@ export function renderSkillList(skills, { workerReady = true, escapeHtml = Strin
       const desc = s.description
         ? `<span class="pi-chat-skill-desc">${escapeHtml(s.description)}</span>`
         : '';
-      return `<div class="pi-chat-skill-item"><span class="pi-chat-skill-name">${escapeHtml(s.displayName)}</span>${desc}</div>`;
+      return `<div class="pi-chat-skill-item" data-skill="${escapeHtml(s.name || '')}"><span class="pi-chat-skill-name">${escapeHtml(s.displayName)}</span>${desc}</div>`;
     })
     .join('');
 }
@@ -98,10 +98,32 @@ export function setupSkillList({
     return fetchAndRender(true);
   }
 
+  // insertSkill writes the skill's slash invocation into the composer so the
+  // user only has to press send. The skill name is already prefixed "skill:",
+  // so the invocation is "/skill:<name>".
+  function insertSkill(name) {
+    if (!name) return;
+    const textarea = documentImpl.getElementById('pi-chat-message');
+    if (!textarea) return;
+    textarea.value = `/${name} `;
+    if (typeof textarea.focus === 'function') textarea.focus();
+    if (typeof textarea.dispatchEvent === 'function') {
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    close();
+  }
+
   documentImpl.addEventListener('click', (e) => {
     const target = e && e.target;
     if (target && target.id === SKILL_LOAD_BUTTON_ID) {
       load();
+      return;
+    }
+    const item = target && typeof target.closest === 'function'
+      ? target.closest('.pi-chat-skill-item')
+      : null;
+    if (item && typeof item.getAttribute === 'function') {
+      insertSkill(item.getAttribute('data-skill'));
       return;
     }
     if (popup && popup.style.display !== 'none') {
@@ -110,5 +132,5 @@ export function setupSkillList({
     }
   });
 
-  return { maybeShow, load, close };
+  return { maybeShow, load, insertSkill, close };
 }

--- a/web/src/session/chat/skill-list.js
+++ b/web/src/session/chat/skill-list.js
@@ -70,7 +70,17 @@ export function setupSkillList({
   // "Load skills" button); otherwise it only peeks at an existing worker.
   async function fetchAndRender(load) {
     if (!chatApi || typeof chatApi.getCommands !== 'function') return;
+    // Injecting the popup's DOM while the textarea is focused makes iOS Safari
+    // blur it (dismissing the keyboard and shifting focus). Re-assert focus
+    // after each render — preventScroll stops iOS's jumpy scroll-into-view.
+    const textarea = documentImpl.getElementById('pi-chat-message');
+    const keepFocus = () => {
+      if (textarea && documentImpl.activeElement !== textarea && typeof textarea.focus === 'function') {
+        textarea.focus({ preventScroll: true });
+      }
+    };
     show('<div class="pi-chat-skill-empty">Loading…</div>');
+    keepFocus();
     try {
       const res = await chatApi.getCommands(sessionId, { load });
       const data = await res.json();
@@ -80,6 +90,7 @@ export function setupSkillList({
     } catch (_) {
       show('<div class="pi-chat-skill-empty">Failed to load skills</div>');
     }
+    keepFocus();
   }
 
   // maybeShow opens the skill list when the composer value is exactly "/skill",

--- a/web/src/session/chat/skill-list.js
+++ b/web/src/session/chat/skill-list.js
@@ -1,0 +1,91 @@
+// Skill listing for the chat composer. Typing exactly "/skill" in the message
+// box lists the skills loaded by the session's pi worker. Skills are exposed by
+// pi's get_commands RPC as commands named "skill:<name>" with source "skill".
+
+const SKILL_TRIGGER = '/skill';
+
+export function isSkillTrigger(value) {
+  return typeof value === 'string' && value.trim() === SKILL_TRIGGER;
+}
+
+// extractSkills filters a get_commands list down to skills and strips the
+// "skill:" prefix pi uses on their command names for display.
+export function extractSkills(commands) {
+  if (!Array.isArray(commands)) return [];
+  return commands
+    .filter((c) => c && c.source === 'skill')
+    .map((c) => {
+      const name = String(c.name || '');
+      return {
+        name,
+        displayName: name.startsWith('skill:') ? name.slice('skill:'.length) : name,
+        description: String(c.description || ''),
+      };
+    });
+}
+
+export function renderSkillList(skills, { workerReady = true, escapeHtml = String } = {}) {
+  if (!workerReady) {
+    return '<div class="pi-chat-skill-empty">Send a message first to load skills</div>';
+  }
+  if (!skills || skills.length === 0) {
+    return '<div class="pi-chat-skill-empty">No skills loaded</div>';
+  }
+  return skills
+    .map((s) => {
+      const desc = s.description
+        ? `<span class="pi-chat-skill-desc">${escapeHtml(s.description)}</span>`
+        : '';
+      return `<div class="pi-chat-skill-item"><span class="pi-chat-skill-name">${escapeHtml(s.displayName)}</span>${desc}</div>`;
+    })
+    .join('');
+}
+
+export function setupSkillList({
+  documentImpl = document,
+  sessionId,
+  chatApi,
+  escapeHtml = String,
+} = {}) {
+  const popup = documentImpl.getElementById('pi-chat-skill-popup');
+  const list = documentImpl.getElementById('pi-chat-skill-list');
+
+  function close() {
+    if (popup) popup.style.display = 'none';
+  }
+
+  function show(html) {
+    if (!popup || !list) return;
+    list.innerHTML = html;
+    popup.style.display = 'block';
+  }
+
+  // maybeShow opens the skill list when the composer value is exactly "/skill",
+  // otherwise hides it. Returns a promise so callers/tests can await the fetch.
+  async function maybeShow(value) {
+    if (!isSkillTrigger(value)) {
+      close();
+      return;
+    }
+    if (!chatApi || typeof chatApi.getCommands !== 'function') return;
+    show('<div class="pi-chat-skill-empty">Loading…</div>');
+    try {
+      const res = await chatApi.getCommands(sessionId);
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'failed to load skills');
+      const skills = extractSkills(data.commands);
+      show(renderSkillList(skills, { workerReady: data.workerReady, escapeHtml }));
+    } catch (_) {
+      show('<div class="pi-chat-skill-empty">Failed to load skills</div>');
+    }
+  }
+
+  documentImpl.addEventListener('click', (e) => {
+    if (popup && popup.style.display !== 'none') {
+      const textarea = documentImpl.getElementById('pi-chat-message');
+      if (!popup.contains(e.target) && e.target !== textarea) close();
+    }
+  });
+
+  return { maybeShow, close };
+}

--- a/web/src/session/chat/skill-list.js
+++ b/web/src/session/chat/skill-list.js
@@ -24,9 +24,14 @@ export function extractSkills(commands) {
     });
 }
 
+export const SKILL_LOAD_BUTTON_ID = 'pi-chat-skill-load';
+
 export function renderSkillList(skills, { workerReady = true, escapeHtml = String } = {}) {
   if (!workerReady) {
-    return '<div class="pi-chat-skill-empty">Send a message first to load skills</div>';
+    return (
+      '<div class="pi-chat-skill-empty">No skills loaded yet</div>' +
+      `<button type="button" id="${SKILL_LOAD_BUTTON_ID}" class="pi-chat-skill-load">Load skills</button>`
+    );
   }
   if (!skills || skills.length === 0) {
     return '<div class="pi-chat-skill-empty">No skills loaded</div>';
@@ -60,17 +65,14 @@ export function setupSkillList({
     popup.style.display = 'block';
   }
 
-  // maybeShow opens the skill list when the composer value is exactly "/skill",
-  // otherwise hides it. Returns a promise so callers/tests can await the fetch.
-  async function maybeShow(value) {
-    if (!isSkillTrigger(value)) {
-      close();
-      return;
-    }
+  // fetchAndRender queries the commands endpoint and renders the result.
+  // When load is true the server spawns the worker first (used by the explicit
+  // "Load skills" button); otherwise it only peeks at an existing worker.
+  async function fetchAndRender(load) {
     if (!chatApi || typeof chatApi.getCommands !== 'function') return;
     show('<div class="pi-chat-skill-empty">Loading…</div>');
     try {
-      const res = await chatApi.getCommands(sessionId);
+      const res = await chatApi.getCommands(sessionId, { load });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'failed to load skills');
       const skills = extractSkills(data.commands);
@@ -80,12 +82,33 @@ export function setupSkillList({
     }
   }
 
+  // maybeShow opens the skill list when the composer value is exactly "/skill",
+  // otherwise hides it. Returns a promise so callers/tests can await the fetch.
+  function maybeShow(value) {
+    if (!isSkillTrigger(value)) {
+      close();
+      return Promise.resolve();
+    }
+    return fetchAndRender(false);
+  }
+
+  // load spawns the worker on demand and lists its skills. Bound to the
+  // "Load skills" button shown when no worker is running yet.
+  function load() {
+    return fetchAndRender(true);
+  }
+
   documentImpl.addEventListener('click', (e) => {
+    const target = e && e.target;
+    if (target && target.id === SKILL_LOAD_BUTTON_ID) {
+      load();
+      return;
+    }
     if (popup && popup.style.display !== 'none') {
       const textarea = documentImpl.getElementById('pi-chat-message');
-      if (!popup.contains(e.target) && e.target !== textarea) close();
+      if (!popup.contains(target) && target !== textarea) close();
     }
   });
 
-  return { maybeShow, close };
+  return { maybeShow, load, close };
 }

--- a/web/src/session/chat/skill-list.test.js
+++ b/web/src/session/chat/skill-list.test.js
@@ -28,9 +28,10 @@ describe('skill-list pure helpers', () => {
     expect(notReady).toContain('Load skills');
     expect(notReady).toContain('pi-chat-skill-load');
     expect(renderSkillList([], { workerReady: true })).toContain('No skills loaded');
-    const html = renderSkillList([{ displayName: 'foo', description: 'Foo skill' }], { workerReady: true });
+    const html = renderSkillList([{ name: 'skill:foo', displayName: 'foo', description: 'Foo skill' }], { workerReady: true });
     expect(html).toContain('foo');
     expect(html).toContain('Foo skill');
+    expect(html).toContain('data-skill="skill:foo"');
   });
 });
 
@@ -101,5 +102,13 @@ describe('setupSkillList controller', () => {
     expect(chatApi.getCommands).toHaveBeenCalledWith('s.jsonl', { load: true });
     expect(popup.style.display).toBe('block');
     expect(list.innerHTML).toContain('bar');
+  });
+
+  it('insertSkill writes the slash invocation and closes the popup', () => {
+    popup.style.display = 'block';
+    const api = setupSkillList({ documentImpl, sessionId: 's.jsonl', chatApi: {} });
+    api.insertSkill('skill:memory');
+    expect(textarea.value).toBe('/skill:memory ');
+    expect(popup.style.display).toBe('none');
   });
 });

--- a/web/src/session/chat/skill-list.test.js
+++ b/web/src/session/chat/skill-list.test.js
@@ -24,7 +24,9 @@ describe('skill-list pure helpers', () => {
   });
 
   it('renders states for not-ready, empty, and populated', () => {
-    expect(renderSkillList([], { workerReady: false })).toContain('Send a message first');
+    const notReady = renderSkillList([], { workerReady: false });
+    expect(notReady).toContain('Load skills');
+    expect(notReady).toContain('pi-chat-skill-load');
     expect(renderSkillList([], { workerReady: true })).toContain('No skills loaded');
     const html = renderSkillList([{ displayName: 'foo', description: 'Foo skill' }], { workerReady: true });
     expect(html).toContain('foo');
@@ -61,7 +63,7 @@ describe('setupSkillList controller', () => {
     };
     const api = setupSkillList({ documentImpl, sessionId: 's.jsonl', chatApi });
     await api.maybeShow('/skill');
-    expect(chatApi.getCommands).toHaveBeenCalledWith('s.jsonl');
+    expect(chatApi.getCommands).toHaveBeenCalledWith('s.jsonl', { load: false });
     expect(popup.style.display).toBe('block');
     expect(list.innerHTML).toContain('foo');
   });
@@ -74,7 +76,7 @@ describe('setupSkillList controller', () => {
     expect(popup.style.display).toBe('none');
   });
 
-  it('shows a hint when the worker is not ready', async () => {
+  it('shows a load button when the worker is not ready', async () => {
     const chatApi = {
       getCommands: vi.fn(() => Promise.resolve(new Response(
         JSON.stringify({ workerReady: false, commands: [] }),
@@ -83,6 +85,21 @@ describe('setupSkillList controller', () => {
     };
     const api = setupSkillList({ documentImpl, sessionId: 's.jsonl', chatApi });
     await api.maybeShow('/skill');
-    expect(list.innerHTML).toContain('Send a message first');
+    expect(chatApi.getCommands).toHaveBeenCalledWith('s.jsonl', { load: false });
+    expect(list.innerHTML).toContain('Load skills');
+  });
+
+  it('load() requests a spawn and renders the skills', async () => {
+    const chatApi = {
+      getCommands: vi.fn(() => Promise.resolve(new Response(
+        JSON.stringify({ workerReady: true, commands: [{ name: 'skill:bar', description: 'Bar', source: 'skill' }] }),
+        { status: 200 }
+      ))),
+    };
+    const api = setupSkillList({ documentImpl, sessionId: 's.jsonl', chatApi });
+    await api.load();
+    expect(chatApi.getCommands).toHaveBeenCalledWith('s.jsonl', { load: true });
+    expect(popup.style.display).toBe('block');
+    expect(list.innerHTML).toContain('bar');
   });
 });

--- a/web/src/session/chat/skill-list.test.js
+++ b/web/src/session/chat/skill-list.test.js
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { extractSkills, isSkillTrigger, renderSkillList, setupSkillList } from './skill-list.js';
+
+describe('skill-list pure helpers', () => {
+  it('detects the /skill trigger only on exact match', () => {
+    expect(isSkillTrigger('/skill')).toBe(true);
+    expect(isSkillTrigger('  /skill  ')).toBe(true);
+    expect(isSkillTrigger('/skills')).toBe(false);
+    expect(isSkillTrigger('/skill foo')).toBe(false);
+    expect(isSkillTrigger('hello')).toBe(false);
+  });
+
+  it('filters skills and strips the skill: prefix', () => {
+    const skills = extractSkills([
+      { name: 'skill:foo', description: 'Foo', source: 'skill' },
+      { name: 'my-ext', description: 'Ext', source: 'extension' },
+      { name: 'my-prompt', description: 'P', source: 'prompt' },
+      { name: 'skill:bar', description: '', source: 'skill' },
+    ]);
+    expect(skills).toEqual([
+      { name: 'skill:foo', displayName: 'foo', description: 'Foo' },
+      { name: 'skill:bar', displayName: 'bar', description: '' },
+    ]);
+  });
+
+  it('renders states for not-ready, empty, and populated', () => {
+    expect(renderSkillList([], { workerReady: false })).toContain('Send a message first');
+    expect(renderSkillList([], { workerReady: true })).toContain('No skills loaded');
+    const html = renderSkillList([{ displayName: 'foo', description: 'Foo skill' }], { workerReady: true });
+    expect(html).toContain('foo');
+    expect(html).toContain('Foo skill');
+  });
+});
+
+describe('setupSkillList controller', () => {
+  let popup;
+  let list;
+  let textarea;
+  let documentImpl;
+
+  beforeEach(() => {
+    popup = { style: { display: 'none' }, contains: () => false };
+    list = { innerHTML: '' };
+    textarea = {};
+    documentImpl = {
+      getElementById: (id) => ({
+        'pi-chat-skill-popup': popup,
+        'pi-chat-skill-list': list,
+        'pi-chat-message': textarea,
+      }[id] || null),
+      addEventListener: () => {},
+    };
+  });
+
+  it('fetches and shows skills when input is /skill', async () => {
+    const chatApi = {
+      getCommands: vi.fn(() => Promise.resolve(new Response(
+        JSON.stringify({ workerReady: true, commands: [{ name: 'skill:foo', description: 'Foo', source: 'skill' }] }),
+        { status: 200 }
+      ))),
+    };
+    const api = setupSkillList({ documentImpl, sessionId: 's.jsonl', chatApi });
+    await api.maybeShow('/skill');
+    expect(chatApi.getCommands).toHaveBeenCalledWith('s.jsonl');
+    expect(popup.style.display).toBe('block');
+    expect(list.innerHTML).toContain('foo');
+  });
+
+  it('hides without fetching when input is not /skill', async () => {
+    const chatApi = { getCommands: vi.fn() };
+    const api = setupSkillList({ documentImpl, sessionId: 's.jsonl', chatApi });
+    await api.maybeShow('hello world');
+    expect(chatApi.getCommands).not.toHaveBeenCalled();
+    expect(popup.style.display).toBe('none');
+  });
+
+  it('shows a hint when the worker is not ready', async () => {
+    const chatApi = {
+      getCommands: vi.fn(() => Promise.resolve(new Response(
+        JSON.stringify({ workerReady: false, commands: [] }),
+        { status: 200 }
+      ))),
+    };
+    const api = setupSkillList({ documentImpl, sessionId: 's.jsonl', chatApi });
+    await api.maybeShow('/skill');
+    expect(list.innerHTML).toContain('Send a message first');
+  });
+});

--- a/web/src/session/live/live-scroll.js
+++ b/web/src/session/live/live-scroll.js
@@ -7,8 +7,17 @@ export function isAtBottom({ documentImpl = document, windowImpl = window, thres
   const body = documentImpl.body;
   const content = documentImpl.getElementById('content');
 
-  // If the window has scrollable height, the main window is the active scroll container (Desktop).
-  // Otherwise, #content is the active scroll container (Mobile).
+  // #content is the active scroll container whenever it actually overflows
+  // (always on mobile, where the composer is fixed and body is overflow:hidden).
+  // Check it first: with a fixed composer the document can edge just past the
+  // viewport, which would otherwise mis-route us to the window branch (scroll
+  // position 0) and leave the follow button stuck on.
+  if (content && content.scrollHeight > content.clientHeight) {
+    const contentRemaining = content.scrollHeight - content.scrollTop - content.clientHeight;
+    return contentRemaining < threshold;
+  }
+
+  // Otherwise the main window is the scroll container (Desktop).
   const isWindowScrollable = de.scrollHeight > windowImpl.innerHeight;
 
   if (isWindowScrollable) {
@@ -17,11 +26,6 @@ export function isAtBottom({ documentImpl = document, windowImpl = window, thres
     const viewport = windowImpl.innerHeight;
     const remaining = docHeight - scrolled - viewport;
     return remaining < threshold;
-  }
-
-  if (content && content.scrollHeight > content.clientHeight) {
-    const contentRemaining = content.scrollHeight - content.scrollTop - content.clientHeight;
-    return contentRemaining < threshold;
   }
 
   // Fallback to window measurements if content is not scrollable/present

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -22,6 +22,7 @@ import { setupBtwPopup } from './live/btw-popup.js';
 import * as chatSelectors from './chat/chat-selectors.js';
 import * as thinkingSelector from './chat/thinking-selector.js';
 import * as modelSelector from './chat/model-selector.js';
+import * as skillList from './chat/skill-list.js';
 import * as liveReloadRunner from './live/live-reload-runner.js';
 import * as liveScroll from './live/live-scroll.js';
 import * as liveStats from './live/live-stats.js';
@@ -456,6 +457,7 @@ export function runSessionApp({ target = window } = {}) {
     chatSelectors,
     modelSelector,
     thinkingSelector,
+    skillList,
     FormDataImpl: target.FormData,
     URLSearchParamsImpl: target.URLSearchParams,
     CustomEventImpl: target.CustomEvent,

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -476,13 +476,37 @@ export function runSessionApp({ target = window } = {}) {
   // Handle Visual Viewport changes to prevent mobile browsers from shifting
   // the top fixed header out of view when the virtual keyboard is open.
   if (target.visualViewport) {
+    const isTextInputFocused = () => {
+      const ae = documentImpl.activeElement;
+      return !!ae && (ae.tagName === 'TEXTAREA' || ae.tagName === 'INPUT');
+    };
+
     const handleVisualViewportChange = () => {
-      const height = target.visualViewport.height;
-      documentImpl.documentElement.style.setProperty('--viewport-height', `${height}px`);
+      const vv = target.visualViewport;
+      // Override the layout height only while a text field is focused (keyboard
+      // open), so the composer is pulled above the keyboard. When nothing is
+      // focused, fall back to the CSS `100svh` — on iOS Safari
+      // visualViewport.height can report the larger, toolbar-excluding height,
+      // which over-sizes the page and pushes the composer's send/git bar behind
+      // the bottom toolbar.
+      if (isTextInputFocused()) {
+        documentImpl.documentElement.style.setProperty('--viewport-height', `${vv.height}px`);
+      } else {
+        documentImpl.documentElement.style.removeProperty('--viewport-height');
+      }
+
+      // iOS Safari pins `position:fixed; bottom:0` to the *layout* viewport,
+      // which the keyboard overlays rather than shrinks — so the composer ends
+      // up behind the keyboard. Measure how much the keyboard covers (layout
+      // viewport bottom minus visual viewport bottom) and expose it as
+      // `--keyboard-inset` so the composer can lift itself above the keyboard.
+      const layoutHeight = documentImpl.documentElement.clientHeight;
+      const keyboardInset = Math.max(0, Math.round(layoutHeight - vv.height - vv.offsetTop));
+      documentImpl.documentElement.style.setProperty('--keyboard-inset', `${keyboardInset}px`);
 
       // Dynamically adjust the top header's vertical position to offset
       // layout viewport scroll/shift caused by mobile virtual keyboard.
-      const offsetTop = target.visualViewport.offsetTop;
+      const offsetTop = vv.offsetTop;
       const header = documentImpl.querySelector('.session-header-bar');
       if (header) {
         header.style.transform = `translateY(${Math.max(0, offsetTop)}px)`;
@@ -490,6 +514,8 @@ export function runSessionApp({ target = window } = {}) {
     };
     target.visualViewport.addEventListener('resize', handleVisualViewportChange);
     target.visualViewport.addEventListener('scroll', handleVisualViewportChange);
+    documentImpl.addEventListener('focusin', handleVisualViewportChange);
+    documentImpl.addEventListener('focusout', handleVisualViewportChange);
     handleVisualViewportChange();
   }
 

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -481,8 +481,17 @@ export function runSessionApp({ target = window } = {}) {
       return !!ae && (ae.tagName === 'TEXTAREA' || ae.tagName === 'INPUT');
     };
 
+    let prevKeyboardInset = 0;
     const handleVisualViewportChange = () => {
       const vv = target.visualViewport;
+      // Capture follow state before mutating layout: if the message stream is
+      // already near the bottom we keep it pinned there after the keyboard
+      // grows the reserved space below #content.
+      const content = documentImpl.getElementById('content');
+      const wasAtBottom = content
+        ? (content.scrollHeight - content.scrollTop - content.clientHeight < 80)
+        : false;
+
       // Override the layout height only while a text field is focused (keyboard
       // open), so the composer is pulled above the keyboard. When nothing is
       // focused, fall back to the CSS `100svh` — on iOS Safari
@@ -504,6 +513,15 @@ export function runSessionApp({ target = window } = {}) {
       const keyboardInset = Math.max(0, Math.round(layoutHeight - vv.height - vv.offsetTop));
       documentImpl.documentElement.style.setProperty('--keyboard-inset', `${keyboardInset}px`);
 
+      // When the keyboard opens (inset grows) and the user was following the
+      // latest message, re-pin to the bottom once the new padding-bottom is
+      // applied — otherwise the freshly reserved space leaves the last message
+      // stranded behind the composer.
+      if (content && keyboardInset > prevKeyboardInset && wasAtBottom) {
+        target.requestAnimationFrame(() => { content.scrollTop = content.scrollHeight; });
+      }
+      prevKeyboardInset = keyboardInset;
+
       // Dynamically adjust the top header's vertical position to offset
       // layout viewport scroll/shift caused by mobile virtual keyboard.
       const offsetTop = vv.offsetTop;
@@ -519,22 +537,6 @@ export function runSessionApp({ target = window } = {}) {
     handleVisualViewportChange();
   }
 
-  // Prevent mobile browser from auto-scrolling the layout viewport when keyboard opens
-  target.addEventListener('scroll', () => {
-    if (target.scrollY !== 0 || target.scrollX !== 0) {
-      target.scrollTo(0, 0);
-    }
-  });
-  documentImpl.addEventListener('scroll', () => {
-    if (documentImpl.documentElement.scrollTop !== 0 || documentImpl.documentElement.scrollLeft !== 0) {
-      documentImpl.documentElement.scrollTop = 0;
-      documentImpl.documentElement.scrollLeft = 0;
-    }
-    if (documentImpl.body.scrollTop !== 0 || documentImpl.body.scrollLeft !== 0) {
-      documentImpl.body.scrollTop = 0;
-      documentImpl.body.scrollLeft = 0;
-    }
-  });
 }
 
 


### PR DESCRIPTION
## Summary

Typing exactly `/skill` in the chat composer now opens a popup listing the skills loaded by the session's pi worker — a quick way to see what's available without leaving the browser.

## How it works

- **Protocol:** Skills come from pi's `get_commands` RPC (pi v0.78.0+), which returns commands shaped `{name, description, source}`. Skills are the entries with `source === "skill"` and names like `skill:<name>`; the UI strips the `skill:` prefix for display.
- **Backend:** A new `/api/commands?id=<session>` endpoint returns `{workerReady, commands}`. It only **peeks** at an existing worker for the session — it never spawns one — and the result is **cached on the worker** for the session lifetime (cleared naturally when the worker is reaped). If no worker exists yet, it reports `workerReady: false` and the popup hints "Send a message first to load skills".
- **Graceful degradation:** Builds of pi older than v0.78.0 that don't implement `get_commands` return an "unknown command" error, which is treated as an empty skill list rather than a hard failure.
- **Frontend:** New `skill-list.js` module (pure helpers + a DI-friendly controller) wired into the chat composer. Filtering on `source === "skill"` keeps the door open for a fuller slash palette later.

## Layers touched

- `internal/rpc` — `get_commands` command builder + worker method with caching
- `internal/workers` — `SlashCommand` type, `Manager.GetCommands` (peek, no spawn)
- `internal/server` — `/api/commands` handler with timeout + graceful degradation
- `internal/ui/live_templates` — skill popup markup + styles (mirrors the model/thinking popups)
- `web/src/session/chat` — `chat-api.js` wrapper, `skill-list.js` module, composer wiring

## Tests

- Go: builder, worker cache-hit-without-RPC, manager no-spawn, and 4 handler cases (not-ready, populated, degraded unknown-command, real 500). Full `go test ./...` passes.
- Frontend: `skill-list.test.js` (trigger detection, prefix stripping, render states, controller fetch/show/hide) + `chat-api.test.js` coverage for the new endpoint.
- `make build` is green.

## Test plan

- [ ] Open a session, send a message so a worker spawns, then type `/skill` — popup lists loaded skills.
- [ ] Type `/skill` before sending any message — popup shows the "send a message first" hint, no worker spawned.
- [ ] Type `/skills` or `/skill foo` — popup does not trigger.
- [ ] Run against a pi build without `get_commands` — popup shows "No skills loaded" rather than erroring.