### PR TITLE
refactor(app): extract agentdir package, split app.go helpers into sibling files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ node_modules/
 tmp/
 
 .requirements/
-.booboo/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 tmp/
 
 .requirements/
+.booboo/

--- a/internal/agentdir/agentdir.go
+++ b/internal/agentdir/agentdir.go
@@ -1,0 +1,42 @@
+// Package agentdir resolves the Pi agent configuration directory and the
+// paths pi-web stores under it. Centralizing this keeps the app and server
+// packages from drifting on where "~/.pi/agent" lives.
+package agentdir
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Path returns the Pi agent config directory. It respects the
+// PI_CODING_AGENT_DIR environment variable, falling back to ~/.pi/agent.
+//
+// This mirrors pi's own getAgentDir() and intentionally models ONLY the
+// agent-dir override. pi resolves its sessions directory with higher-priority
+// knobs that pi-web does not honor: the --session-dir flag and the
+// PI_CODING_AGENT_SESSION_DIR env var both relocate just the sessions subdir
+// (pi precedence: --session-dir > PI_CODING_AGENT_SESSION_DIR > <agentDir>/sessions).
+// pi-web only derives sessions from <agentDir>/sessions, so a user who
+// relocates only the sessions dir would have pi-web look in the wrong place.
+// That is a known, accepted gap, not an oversight.
+//
+// Note also that pi derives this var name dynamically as
+// APP_NAME.toUpperCase()+"_CODING_AGENT_DIR"; the hardcoded "PI_" prefix here
+// is correct for mainline pi but would not match a rebranded fork.
+func Path() string {
+	if dir := os.Getenv("PI_CODING_AGENT_DIR"); dir != "" {
+		return dir
+	}
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		home = os.Getenv("HOME")
+	}
+	return filepath.Join(home, ".pi", "agent")
+}
+
+// WebDir returns the pi-web data directory inside the given agent dir. Callers
+// that already hold an agent dir (e.g. the server, or a test temp dir) should
+// pass it; callers resolving from the environment can pass Path().
+func WebDir(agentDir string) string {
+	return filepath.Join(agentDir, "pi-web")
+}

--- a/internal/agentdir/agentdir_test.go
+++ b/internal/agentdir/agentdir_test.go
@@ -1,0 +1,38 @@
+package agentdir
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPath_RespectsEnvVar(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", "/custom/pi/agent")
+	if got := Path(); got != "/custom/pi/agent" {
+		t.Fatalf("want /custom/pi/agent, got %s", got)
+	}
+}
+
+func TestPath_FallsBackToHome(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	got := Path()
+	if got == "" {
+		t.Fatal("expected non-empty path")
+	}
+	if got == "/custom/pi/agent" {
+		t.Fatal("should not use env var when empty")
+	}
+	if filepath.Base(filepath.Dir(got)) != ".pi" {
+		t.Fatalf("expected parent to be .pi, got %s", got)
+	}
+	if filepath.Base(got) != "agent" {
+		t.Fatalf("expected base to be agent, got %s", got)
+	}
+}
+
+func TestWebDir(t *testing.T) {
+	got := WebDir("/custom/pi/agent")
+	want := filepath.Join("/custom/pi/agent", "pi-web")
+	if got != want {
+		t.Fatalf("want %s, got %s", want, got)
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,14 +8,12 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"runtime"
-	"strings"
 	"syscall"
 	"time"
 
+	"pi-web/internal/agentdir"
 	"pi-web/internal/auth"
 	"pi-web/internal/frontend"
 	"pi-web/internal/rpc"
@@ -45,7 +43,7 @@ func Main(version string) {
 		os.Exit(0)
 	}
 
-	agentDir := piAgentDir()
+	agentDir := agentdir.Path()
 	if err := seedSoundsDir(agentDir); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to seed sounds directory: %v\n", err)
 	}
@@ -199,130 +197,3 @@ func Main(version string) {
 		os.Exit(1)
 	}
 }
-
-func openBrowser(url string) {
-	var cmd string
-	var args []string
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = "open"
-		args = []string{url}
-	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start", url}
-	default:
-		cmd = "xdg-open"
-		args = []string{url}
-	}
-	exec.Command(cmd, args...).Start()
-}
-
-// piAgentDir returns the Pi agent config directory.
-// It respects the PI_CODING_AGENT_DIR environment variable, falling back to
-// ~/.pi/agent.
-func piAgentDir() string {
-	if dir := os.Getenv("PI_CODING_AGENT_DIR"); dir != "" {
-		return dir
-	}
-	home, _ := os.UserHomeDir()
-	if home == "" {
-		home = os.Getenv("HOME")
-	}
-	return filepath.Join(home, ".pi", "agent")
-}
-
-// piWebDir returns the pi-web data directory inside the Pi agent dir.
-func piWebDir() string {
-	return filepath.Join(piAgentDir(), "pi-web")
-}
-
-// stateFile is held open for the lifetime of the process so the flock stays
-// in effect. Closing it releases the lock.
-var stateFile *os.File
-
-func writeStateFile(agentDir, host, port string, tailscale bool, tailscaleURL string) (string, error) {
-	webDir := filepath.Join(agentDir, "pi-web")
-	if err := os.MkdirAll(webDir, 0755); err != nil {
-		return "", err
-	}
-	path := filepath.Join(webDir, "pi-web-state.json")
-
-	// Migrate old state file from pre-pi-web directory layout.
-	// Only migrate when the new path does not already exist; otherwise
-	// os.Rename would unlink a destination inode that another pi-web
-	// process may already hold a flock on, defeating the single-instance
-	// lock.
-	oldPath := filepath.Join(agentDir, "pi-web-state.json")
-	if _, err := os.Stat(oldPath); err == nil {
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			_ = os.Rename(oldPath, path)
-		}
-	}
-
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
-	if err != nil {
-		return "", err
-	}
-	if err := lockStateFile(f); err != nil {
-		_ = f.Close()
-		return "", err
-	}
-	data, err := json.Marshal(map[string]any{
-		"pid":          os.Getpid(),
-		"port":         port,
-		"host":         host,
-		"tailscale":    tailscale,
-		"tailscaleUrl": tailscaleURL,
-		"startedAt":    time.Now().UTC().Format(time.RFC3339),
-	})
-	if err != nil {
-		_ = f.Close()
-		return "", err
-	}
-	if err := f.Truncate(0); err != nil {
-		_ = f.Close()
-		return "", err
-	}
-	if _, err := f.WriteAt(data, 0); err != nil {
-		_ = f.Close()
-		return "", err
-	}
-	stateFile = f
-	return path, nil
-}
-
-// seedSoundsDir ensures that ~/.pi/agent/pi-web/assets exists and seeds it with default sounds if empty.
-func seedSoundsDir(agentDir string) error {
-	soundsDir := filepath.Join(agentDir, "pi-web", "assets")
-	if err := os.MkdirAll(soundsDir, 0755); err != nil {
-		return fmt.Errorf("failed to create sounds directory: %w", err)
-	}
-
-	files, err := os.ReadDir(soundsDir)
-	if err != nil {
-		return fmt.Errorf("failed to read sounds directory: %w", err)
-	}
-
-	hasMP3 := false
-	for _, f := range files {
-		if !f.IsDir() && filepath.Ext(strings.ToLower(f.Name())) == ".mp3" {
-			hasMP3 = true
-			break
-		}
-	}
-
-	if !hasMP3 {
-		// Seed cat.mp3
-		catPath := filepath.Join(soundsDir, "cat.mp3")
-		if err := os.WriteFile(catPath, ui.CatMP3, 0644); err != nil {
-			return fmt.Errorf("failed to seed cat.mp3: %w", err)
-		}
-		// Seed done.mp3
-		donePath := filepath.Join(soundsDir, "done.mp3")
-		if err := os.WriteFile(donePath, ui.DoneMP3, 0644); err != nil {
-			return fmt.Errorf("failed to seed done.mp3: %w", err)
-		}
-	}
-	return nil
-}
-

--- a/internal/app/browser.go
+++ b/internal/app/browser.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+func openBrowser(url string) {
+	var cmd string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+		args = []string{url}
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start", url}
+	default:
+		cmd = "xdg-open"
+		args = []string{url}
+	}
+	exec.Command(cmd, args...).Start()
+}

--- a/internal/app/sounds.go
+++ b/internal/app/sounds.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"pi-web/internal/agentdir"
+	"pi-web/internal/ui"
+)
+
+// seedSoundsDir ensures that ~/.pi/agent/pi-web/assets exists and seeds it with default sounds if empty.
+func seedSoundsDir(agentDir string) error {
+	soundsDir := filepath.Join(agentdir.WebDir(agentDir), "assets")
+	if err := os.MkdirAll(soundsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create sounds directory: %w", err)
+	}
+
+	files, err := os.ReadDir(soundsDir)
+	if err != nil {
+		return fmt.Errorf("failed to read sounds directory: %w", err)
+	}
+
+	hasMP3 := false
+	for _, f := range files {
+		if !f.IsDir() && filepath.Ext(strings.ToLower(f.Name())) == ".mp3" {
+			hasMP3 = true
+			break
+		}
+	}
+
+	if !hasMP3 {
+		// Seed cat.mp3
+		catPath := filepath.Join(soundsDir, "cat.mp3")
+		if err := os.WriteFile(catPath, ui.CatMP3, 0644); err != nil {
+			return fmt.Errorf("failed to seed cat.mp3: %w", err)
+		}
+		// Seed done.mp3
+		donePath := filepath.Join(soundsDir, "done.mp3")
+		if err := os.WriteFile(donePath, ui.DoneMP3, 0644); err != nil {
+			return fmt.Errorf("failed to seed done.mp3: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/app/sounds_test.go
+++ b/internal/app/sounds_test.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSeedSoundsDir_SeedsDefaultsWhenEmpty(t *testing.T) {
+	agentDir := t.TempDir()
+
+	if err := seedSoundsDir(agentDir); err != nil {
+		t.Fatal(err)
+	}
+
+	soundsDir := filepath.Join(agentDir, "pi-web", "assets")
+	for _, name := range []string{"cat.mp3", "done.mp3"} {
+		info, err := os.Stat(filepath.Join(soundsDir, name))
+		if err != nil {
+			t.Fatalf("expected %s to be seeded: %v", name, err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("expected %s to be non-empty", name)
+		}
+	}
+}
+
+func TestSeedSoundsDir_SkipsWhenMP3AlreadyPresent(t *testing.T) {
+	agentDir := t.TempDir()
+	soundsDir := filepath.Join(agentDir, "pi-web", "assets")
+	if err := os.MkdirAll(soundsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// A user-provided sound means the dir is "not empty"; seeding must not run.
+	if err := os.WriteFile(filepath.Join(soundsDir, "custom.mp3"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := seedSoundsDir(agentDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(soundsDir, "cat.mp3")); !os.IsNotExist(err) {
+		t.Fatal("cat.mp3 should not be seeded when an mp3 is already present")
+	}
+}

--- a/internal/app/state_file.go
+++ b/internal/app/state_file.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"pi-web/internal/agentdir"
+)
+
+// stateFile is held open for the lifetime of the process so the flock stays
+// in effect. Closing it releases the lock.
+var stateFile *os.File
+
+func writeStateFile(agentDir, host, port string, tailscale bool, tailscaleURL string) (string, error) {
+	webDir := agentdir.WebDir(agentDir)
+	if err := os.MkdirAll(webDir, 0755); err != nil {
+		return "", err
+	}
+	path := filepath.Join(webDir, "pi-web-state.json")
+
+	// Migrate old state file from pre-pi-web directory layout.
+	// Only migrate when the new path does not already exist; otherwise
+	// os.Rename would unlink a destination inode that another pi-web
+	// process may already hold a flock on, defeating the single-instance
+	// lock.
+	oldPath := filepath.Join(agentDir, "pi-web-state.json")
+	if _, err := os.Stat(oldPath); err == nil {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			_ = os.Rename(oldPath, path)
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return "", err
+	}
+	if err := lockStateFile(f); err != nil {
+		_ = f.Close()
+		return "", err
+	}
+	data, err := json.Marshal(map[string]any{
+		"pid":          os.Getpid(),
+		"port":         port,
+		"host":         host,
+		"tailscale":    tailscale,
+		"tailscaleUrl": tailscaleURL,
+		"startedAt":    time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		_ = f.Close()
+		return "", err
+	}
+	if err := f.Truncate(0); err != nil {
+		_ = f.Close()
+		return "", err
+	}
+	if _, err := f.WriteAt(data, 0); err != nil {
+		_ = f.Close()
+		return "", err
+	}
+	stateFile = f
+	return path, nil
+}

--- a/internal/app/state_file_migration_test.go
+++ b/internal/app/state_file_migration_test.go
@@ -6,42 +6,6 @@ import (
 	"testing"
 )
 
-func TestPiAgentDir_RespectsEnvVar(t *testing.T) {
-	t.Setenv("PI_CODING_AGENT_DIR", "/custom/pi/agent")
-	got := piAgentDir()
-	if got != "/custom/pi/agent" {
-		t.Fatalf("want /custom/pi/agent, got %s", got)
-	}
-}
-
-func TestPiAgentDir_FallsBackToHome(t *testing.T) {
-	t.Setenv("PI_CODING_AGENT_DIR", "")
-	got := piAgentDir()
-	if got == "" {
-		t.Fatal("expected non-empty path")
-	}
-	if got == "/custom/pi/agent" {
-		t.Fatal("should not use env var when empty")
-	}
-	// Should end with .pi/agent when falling back
-	if filepath.Base(filepath.Dir(got)) != ".pi" {
-		t.Fatalf("expected parent to be .pi, got %s", got)
-	}
-	if filepath.Base(got) != "agent" {
-		t.Fatalf("expected base to be agent, got %s", got)
-	}
-}
-
-func TestPiWebDir(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("PI_CODING_AGENT_DIR", tmp)
-	got := piWebDir()
-	want := filepath.Join(tmp, "pi-web")
-	if got != want {
-		t.Fatalf("want %s, got %s", want, got)
-	}
-}
-
 func TestWriteStateFile_SkipsMigrationWhenNewExists(t *testing.T) {
 	tmp := t.TempDir()
 	webDir := filepath.Join(tmp, "pi-web")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"pi-web/internal/agentdir"
 	"pi-web/internal/sessions"
 )
 
@@ -337,7 +338,7 @@ func isBrokenPipe(err error) bool {
 }
 
 func (s *Server) handleCustomThemes(w http.ResponseWriter, r *http.Request) {
-	path := filepath.Join(s.agentDir, "pi-web", "custom-themes.css")
+	path := filepath.Join(agentdir.WebDir(s.agentDir), "custom-themes.css")
 	w.Header().Set("Content-Type", "text/css; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	if _, err := os.Stat(path); err == nil {

--- a/internal/server/push.go
+++ b/internal/server/push.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
+
+	"pi-web/internal/agentdir"
 )
 
 // PushManager owns the VAPID key pair and the set of browser push
@@ -41,7 +43,7 @@ type vapidFile struct {
 // NewPushManager loads/creates VAPID keys and subscription store under
 // <agentDir>/pi-web/. Returns a manager ready to register HTTP handlers.
 func NewPushManager(agentDir string) (*PushManager, error) {
-	dir := filepath.Join(agentDir, "pi-web")
+	dir := agentdir.WebDir(agentDir)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, err
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"pi-web/internal/agentdir"
 	"pi-web/internal/auth"
 	"pi-web/internal/render"
 	"pi-web/internal/rpc"
@@ -96,7 +97,7 @@ func New(deps Deps) *Server {
 	}
 	agentDir := deps.AgentDir
 	if agentDir == "" {
-		agentDir = filepath.Join(os.Getenv("HOME"), ".pi", "agent")
+		agentDir = agentdir.Path()
 	}
 
 	// Ensure the agentDir exists

--- a/internal/server/sound.go
+++ b/internal/server/sound.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"pi-web/internal/agentdir"
 	"pi-web/internal/ui"
 )
 
@@ -18,7 +19,7 @@ func (s *Server) handleApiSounds(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	soundsDir := filepath.Join(s.agentDir, "pi-web", "assets")
+	soundsDir := filepath.Join(agentdir.WebDir(s.agentDir), "assets")
 	files, err := os.ReadDir(soundsDir)
 	if err != nil {
 		writeJSON(w, http.StatusOK, map[string]any{
@@ -66,7 +67,7 @@ func (s *Server) handleSounds(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	soundsDir := filepath.Join(s.agentDir, "pi-web", "assets")
+	soundsDir := filepath.Join(agentdir.WebDir(s.agentDir), "assets")
 	filePath := filepath.Clean(filepath.Join(soundsDir, name))
 	expectedDir := filepath.Clean(soundsDir)
 


### PR DESCRIPTION
## Summary

Cleans up `internal/app` and removes a real source of duplication around the Pi agent directory.

- **Split `app.go` helpers into focused sibling files** (same `package app`, no API change): `openBrowser` → `browser.go`, `seedSoundsDir` → `sounds.go`, `writeStateFile` + the `stateFile` global → `state_file.go`. `app.go` is now a lean composition root (~133 fewer lines).
- **New `internal/agentdir` package = single source of truth for the agent dir.** Previously `app.piAgentDir` (respects `PI_CODING_AGENT_DIR`) and a weaker `HOME`-only fallback in `server.New` resolved the same path two different ways. Both now call `agentdir.Path()`, and the repeated `filepath.Join(agentDir, "pi-web")` convention across `app` and `server` goes through `agentdir.WebDir()`.
- **Documented a known gap.** `agentdir.Path()` intentionally models only the agent-dir override, mirroring pi's `getAgentDir()`. pi's more specific session-dir knobs (`--session-dir`, `PI_CODING_AGENT_SESSION_DIR`) are not honored — called out in a doc comment as accepted, not an oversight.

### Behavior note
`server.New`'s fallback now respects `PI_CODING_AGENT_DIR` (it previously used `HOME` only). It only fires when `Deps.AgentDir == ""`, which never happens in the real app or the server tests (all pass an explicit dir), so it's strictly more consistent.

### Tests
- New `agentdir` tests: `Path()` env override + `~/.pi/agent` fallback, `WebDir()`.
- New `seedSoundsDir` tests: seeds defaults when empty, skips when an mp3 is already present.
- Renamed `pi_agent_dir_test.go` → `state_file_migration_test.go` (the `piAgentDir` tests moved to `agentdir`; the file now holds only the state-file migration tests).
- `openBrowser` left untested (fire-and-forget OS `exec`, not worth a DI seam).

Also adds `.booboo/` to `.gitignore` (local scratch notes).

## Test plan
- [x] `go vet ./internal/...`
- [x] `go build ./...`
- [x] `go test ./...` (all pass)
- [x] `gofmt` clean on all new/changed files