### PR TITLE
feat(btw): per-session scratch-chat with session UI fixes

### DIFF
--- a/internal/server/bench_test.go
+++ b/internal/server/bench_test.go
@@ -52,7 +52,7 @@ func newBenchServer(b *testing.B, numSessions, messagesPerSession int) (*Server,
 		Auth:        auth.New(""),
 		Cache:       sessions.NewCache(),
 		RenderIndex: func(w io.Writer, _ []sessions.SessionSummary) error { return nil },
-		RenderLiveSession: func(s sessions.Session) string {
+		RenderLiveSession: func(s sessions.Session, _ string) string {
 			return fmt.Sprintf("<html><body>%d entries</body></html>", len(s.Entries))
 		},
 		RenderExportSession: func(s sessions.Session, theme string) string { return "" },

--- a/internal/server/btw.go
+++ b/internal/server/btw.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -9,74 +10,231 @@ import (
 	"pi-web/internal/sessions"
 )
 
-// settingBtwSessionID is the app_settings key holding the id of the single,
-// global "btw" scratch-chat session surfaced in the floating btw window.
+// settingBtwSessionID is the legacy app_settings key that held the id of the
+// single, global "btw" scratch-chat. It is migrated into btw_sessions on
+// startup and no longer written.
 const settingBtwSessionID = "btw_session_id"
 
-func (s *Server) getBtwSessionID() string {
+// settingShowBtwInIndex toggles whether btw scratch-chats appear in the session
+// list. Off by default; surfaced on the /settings page.
+const settingShowBtwInIndex = "pi-web:v1:show-btw-in-index"
+
+// btwGlobalParent is the sentinel parent_id used when a btw chat is opened with
+// no parent session (a future index-level btw). The legacy single global btw
+// migrates under this key so existing users do not lose their chat.
+const btwGlobalParent = "__global__"
+
+// btwSessionsSchema records every btw scratch-chat. Each parent session page has
+// at most one active (active=1) btw; pressing "new" orphans the prior one
+// (active=0) but keeps it on disk. Rows persist after orphaning so btw sessions
+// stay identifiable — and hideable from the index — for their whole lifetime.
+const btwSessionsSchema = `CREATE TABLE IF NOT EXISTS btw_sessions (
+	btw_id    TEXT PRIMARY KEY,
+	parent_id TEXT NOT NULL,
+	active    INTEGER NOT NULL DEFAULT 1
+)`
+
+// migrateLegacyBtwSession moves the old single-row app_settings btw pointer into
+// the per-parent registry under the global sentinel. Idempotent and a no-op once
+// the legacy key is gone.
+func migrateLegacyBtwSession(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	var id string
+	if err := db.QueryRow("SELECT value FROM app_settings WHERE key = ?", settingBtwSessionID).Scan(&id); err != nil || id == "" {
+		return
+	}
+	_, _ = db.Exec(`INSERT INTO btw_sessions (btw_id, parent_id, active) VALUES (?, ?, 1)
+		ON CONFLICT(btw_id) DO NOTHING`, id, btwGlobalParent)
+	_, _ = db.Exec("DELETE FROM app_settings WHERE key = ?", settingBtwSessionID)
+}
+
+func normalizeBtwParent(parent string) string {
+	if parent == "" {
+		return btwGlobalParent
+	}
+	return parent
+}
+
+// getBtwSessionID returns the active btw session id for a parent, or "".
+func (s *Server) getBtwSessionID(parentID string) string {
 	if s.db == nil {
 		return ""
 	}
 	var v string
-	if err := s.db.QueryRow("SELECT value FROM app_settings WHERE key = ?", settingBtwSessionID).Scan(&v); err != nil {
+	if err := s.db.QueryRow(
+		"SELECT btw_id FROM btw_sessions WHERE parent_id = ? AND active = 1",
+		normalizeBtwParent(parentID)).Scan(&v); err != nil {
 		return ""
 	}
 	return v
 }
 
-func (s *Server) setBtwSessionID(id string) {
-	if s.db == nil {
+// setBtwSessionID records id as the active btw for parentID, orphaning any prior
+// active btw for that parent (kept on disk, active=0). Broadcasts the change on
+// the parent's SSE topic so other devices viewing that page re-sync in realtime.
+func (s *Server) setBtwSessionID(parentID, id string) {
+	if s.db == nil || id == "" {
 		return
 	}
-	prev := s.getBtwSessionID()
-	_, _ = s.db.Exec(`INSERT INTO app_settings (key, value) VALUES (?, ?)
-		ON CONFLICT(key) DO UPDATE SET value=excluded.value`, settingBtwSessionID, id)
-	// Notify every connected client (on any device) so an open btw window can
-	// switch to the new session in realtime. Only when it actually changed.
-	if id != prev {
-		s.broadcastBtwChanged(id)
+	parentID = normalizeBtwParent(parentID)
+	if id == s.getBtwSessionID(parentID) {
+		return
 	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return
+	}
+	if _, err := tx.Exec("UPDATE btw_sessions SET active = 0 WHERE parent_id = ?", parentID); err != nil {
+		_ = tx.Rollback()
+		return
+	}
+	if _, err := tx.Exec(`INSERT INTO btw_sessions (btw_id, parent_id, active) VALUES (?, ?, 1)
+		ON CONFLICT(btw_id) DO UPDATE SET parent_id=excluded.parent_id, active=1`, id, parentID); err != nil {
+		_ = tx.Rollback()
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		return
+	}
+	s.broadcastBtwChanged(parentID, id)
 }
 
-// broadcastBtwChanged tells all clients which session is now the global btw
-// session. Sent on the global topic so any open btw window re-syncs even if it
-// is currently subscribed to a different (or no) session.
-func (s *Server) broadcastBtwChanged(id string) {
+// deleteBtwRow removes a btw registry row (used when its session file is gone).
+func (s *Server) deleteBtwRow(id string) {
+	if s.db == nil || id == "" {
+		return
+	}
+	_, _ = s.db.Exec("DELETE FROM btw_sessions WHERE btw_id = ?", id)
+}
+
+// broadcastBtwChanged tells clients viewing parentID which session is now its
+// btw. Scoped to the parent's topic so only windows opened from that page
+// re-sync. Empty id means "no btw" (e.g. the pointer was cleared).
+func (s *Server) broadcastBtwChanged(parentID, id string) {
 	msg, err := formatSSEJSONEvent("btw-changed", map[string]string{"sessionId": id})
 	if err != nil {
 		return
 	}
-	s.broadcast(globalSessID, msg)
+	s.broadcast(normalizeBtwParent(parentID), msg)
 }
 
-// handleGetBtw returns the current global btw session id, clearing the stored
-// pointer if the session file has since been deleted so the client can fall
-// back to its empty state.
+// btwSessionIDs returns every session id that is a btw scratch-chat (active or
+// orphaned), used to hide them from the index.
+func (s *Server) btwSessionIDs() map[string]bool {
+	if s.db == nil {
+		return nil
+	}
+	rows, err := s.db.Query("SELECT btw_id FROM btw_sessions")
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	set := make(map[string]bool)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			continue
+		}
+		set[id] = true
+	}
+	return set
+}
+
+// showBtwInIndex reports whether btw scratch-chats should appear in the session
+// list. Off by default; toggled on the /settings page.
+func (s *Server) showBtwInIndex() bool {
+	return s.getSetting(settingShowBtwInIndex, "false") == "true"
+}
+
+// filterBtwSummaries drops btw scratch-chats from the list unless the user has
+// opted to show them. A no-op when none exist or showing is enabled.
+func (s *Server) filterBtwSummaries(summaries []sessions.SessionSummary) []sessions.SessionSummary {
+	if s.showBtwInIndex() {
+		return summaries
+	}
+	hidden := s.btwSessionIDs()
+	if len(hidden) == 0 {
+		return summaries
+	}
+	out := make([]sessions.SessionSummary, 0, len(summaries))
+	for _, sum := range summaries {
+		if !hidden[sum.ID] {
+			out = append(out, sum)
+		}
+	}
+	return out
+}
+
+// reapOrphanedBtw deletes btw sessions whose parent session no longer exists,
+// removing both the registry row and the session file so a btw never outlives
+// its parent. The __global__ sentinel parent is never reaped. `all` must be the
+// full, unfiltered session list.
+func (s *Server) reapOrphanedBtw(all []sessions.SessionSummary) {
+	if s.db == nil {
+		return
+	}
+	existing := make(map[string]bool, len(all))
+	for _, sum := range all {
+		existing[sum.ID] = true
+	}
+	rows, err := s.db.Query("SELECT btw_id, parent_id FROM btw_sessions")
+	if err != nil {
+		return
+	}
+	type orphan struct{ btwID string }
+	var orphans []orphan
+	for rows.Next() {
+		var btwID, parentID string
+		if err := rows.Scan(&btwID, &parentID); err != nil {
+			continue
+		}
+		if parentID == btwGlobalParent || existing[parentID] {
+			continue
+		}
+		orphans = append(orphans, orphan{btwID})
+	}
+	rows.Close()
+	for _, o := range orphans {
+		if resolved, err := sessions.ResolveByID(s.sessionsDir, o.btwID); err == nil {
+			_ = os.Remove(resolved.Path)
+		}
+		s.deleteBtwRow(o.btwID)
+	}
+}
+
+// handleGetBtw returns the active btw session id for the given parent, clearing
+// the row if the session file has since been deleted so the client falls back to
+// its empty state.
 func (s *Server) handleGetBtw(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	id := s.getBtwSessionID()
+	parent := normalizeBtwParent(r.URL.Query().Get("parent"))
+	id := s.getBtwSessionID(parent)
 	if id != "" {
 		if _, err := sessions.ResolveByID(s.sessionsDir, id); err != nil {
+			s.deleteBtwRow(id)
+			s.broadcastBtwChanged(parent, "")
 			id = ""
-			s.setBtwSessionID("")
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"sessionId": id})
 }
 
-// handleNewBtw creates a fresh session, records it as the global btw session,
-// and returns its id. The path defaults to the user's home directory when the
-// caller does not supply one (e.g. the originating page had no cwd).
+// handleNewBtw creates a fresh session and records it as the active btw for the
+// caller's parent (orphaning the previous one). The path defaults to the home
+// directory when the caller does not supply one.
 func (s *Server) handleNewBtw(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 	var body struct {
-		Path string `json:"path"`
+		Path   string `json:"path"`
+		Parent string `json:"parent"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid json body")
@@ -92,7 +250,7 @@ func (s *Server) handleNewBtw(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	s.setBtwSessionID(id)
+	s.setBtwSessionID(body.Parent, id)
 
 	// Pre-warm a worker so the first chat message lands quickly, mirroring
 	// handleNewSession.

--- a/internal/server/btw_test.go
+++ b/internal/server/btw_test.go
@@ -6,49 +6,93 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+
+	"pi-web/internal/sessions"
 
 	_ "modernc.org/sqlite"
 )
 
-func newAppSettingsDB(t *testing.T) *sql.DB {
+// newBtwDB creates an in-memory db with every table the btw code touches:
+// app_settings (legacy migration), settings (show-in-index toggle), and the
+// btw_sessions registry.
+func newBtwDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("failed to open test db: %v", err)
 	}
-	if _, err := db.Exec(appSettingsSchema); err != nil {
-		t.Fatalf("failed to create app_settings table: %v", err)
+	for _, schema := range []string{
+		appSettingsSchema,
+		`CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT, updated_at DATETIME)`,
+		btwSessionsSchema,
+	} {
+		if _, err := db.Exec(schema); err != nil {
+			t.Fatalf("failed to create table: %v", err)
+		}
 	}
 	t.Cleanup(func() { db.Close() })
 	return db
 }
 
 func TestBtwSessionIDRoundTrip(t *testing.T) {
-	db := newAppSettingsDB(t)
+	db := newBtwDB(t)
 	s := &Server{db: db}
 
-	if got := s.getBtwSessionID(); got != "" {
+	if got := s.getBtwSessionID("p1"); got != "" {
 		t.Fatalf("expected empty id initially, got %q", got)
 	}
-	s.setBtwSessionID("abc.jsonl")
-	if got := s.getBtwSessionID(); got != "abc.jsonl" {
+	s.setBtwSessionID("p1", "abc.jsonl")
+	if got := s.getBtwSessionID("p1"); got != "abc.jsonl" {
 		t.Fatalf("expected 'abc.jsonl', got %q", got)
 	}
-	// Upsert overwrites.
-	s.setBtwSessionID("def.jsonl")
-	if got := s.getBtwSessionID(); got != "def.jsonl" {
-		t.Fatalf("expected 'def.jsonl', got %q", got)
+	// A second parent is independent.
+	if got := s.getBtwSessionID("p2"); got != "" {
+		t.Fatalf("expected p2 empty, got %q", got)
+	}
+	s.setBtwSessionID("p2", "xyz.jsonl")
+	if got := s.getBtwSessionID("p2"); got != "xyz.jsonl" {
+		t.Fatalf("expected 'xyz.jsonl' for p2, got %q", got)
+	}
+	if got := s.getBtwSessionID("p1"); got != "abc.jsonl" {
+		t.Fatalf("p1 should be unaffected, got %q", got)
+	}
+}
+
+func TestSetBtwKeepsPriorAsOrphan(t *testing.T) {
+	db := newBtwDB(t)
+	s := &Server{db: db}
+
+	s.setBtwSessionID("p1", "old.jsonl")
+	s.setBtwSessionID("p1", "new.jsonl")
+
+	if got := s.getBtwSessionID("p1"); got != "new.jsonl" {
+		t.Fatalf("expected active 'new.jsonl', got %q", got)
+	}
+	// The prior btw stays on record (orphaned), so it remains identifiable as a
+	// btw and hideable from the index.
+	ids := s.btwSessionIDs()
+	if !ids["old.jsonl"] || !ids["new.jsonl"] {
+		t.Fatalf("expected both old and new tracked, got %v", ids)
+	}
+	// Exactly one active row for the parent.
+	var activeCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM btw_sessions WHERE parent_id='p1' AND active=1").Scan(&activeCount); err != nil {
+		t.Fatal(err)
+	}
+	if activeCount != 1 {
+		t.Fatalf("expected exactly 1 active row, got %d", activeCount)
 	}
 }
 
 func TestHandleNewBtwThenGet(t *testing.T) {
-	db := newAppSettingsDB(t)
+	db := newBtwDB(t)
 	dir := t.TempDir()
 	s := &Server{db: db, sessionsDir: dir}
 
-	// Create a new btw session rooted at a real directory.
-	body := bytes.NewBufferString(`{"path":"` + dir + `"}`)
+	// Create a new btw session for parent "parent-1".
+	body := bytes.NewBufferString(`{"path":"` + dir + `","parent":"parent-1"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/btw/new", body)
 	w := httptest.NewRecorder()
 	s.handleNewBtw(w, req)
@@ -64,12 +108,12 @@ func TestHandleNewBtwThenGet(t *testing.T) {
 	if id == "" {
 		t.Fatalf("expected a new session id, got %v", created)
 	}
-	if stored := s.getBtwSessionID(); stored != id {
+	if stored := s.getBtwSessionID("parent-1"); stored != id {
 		t.Fatalf("expected stored btw id %q, got %q", id, stored)
 	}
 
-	// GET returns the same id, since the session file now exists.
-	greq := httptest.NewRequest(http.MethodGet, "/api/btw", nil)
+	// GET scoped to the same parent returns the same id.
+	greq := httptest.NewRequest(http.MethodGet, "/api/btw?parent=parent-1", nil)
 	gw := httptest.NewRecorder()
 	s.handleGetBtw(gw, greq)
 	if gw.Code != http.StatusOK {
@@ -82,16 +126,28 @@ func TestHandleNewBtwThenGet(t *testing.T) {
 	if got["sessionId"] != id {
 		t.Fatalf("expected sessionId %q, got %v", id, got["sessionId"])
 	}
+
+	// A different parent has no btw.
+	oreq := httptest.NewRequest(http.MethodGet, "/api/btw?parent=other", nil)
+	ow := httptest.NewRecorder()
+	s.handleGetBtw(ow, oreq)
+	var other map[string]any
+	if err := json.Unmarshal(ow.Body.Bytes(), &other); err != nil {
+		t.Fatal(err)
+	}
+	if other["sessionId"] != "" {
+		t.Fatalf("expected empty btw for other parent, got %v", other["sessionId"])
+	}
 }
 
 func TestHandleGetBtwClearsStalePointer(t *testing.T) {
-	db := newAppSettingsDB(t)
+	db := newBtwDB(t)
 	s := &Server{db: db, sessionsDir: t.TempDir()}
 
 	// Point at a session that does not exist on disk.
-	s.setBtwSessionID("2026-01-01T00-00-00.000Z_deadbeef.jsonl")
+	s.setBtwSessionID("parent-1", "2026-01-01T00-00-00.000Z_deadbeef.jsonl")
 
-	req := httptest.NewRequest(http.MethodGet, "/api/btw", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/btw?parent=parent-1", nil)
 	w := httptest.NewRecorder()
 	s.handleGetBtw(w, req)
 	if w.Code != http.StatusOK {
@@ -104,13 +160,17 @@ func TestHandleGetBtwClearsStalePointer(t *testing.T) {
 	if got["sessionId"] != "" {
 		t.Fatalf("expected empty sessionId for stale pointer, got %v", got["sessionId"])
 	}
-	if stored := s.getBtwSessionID(); stored != "" {
+	if stored := s.getBtwSessionID("parent-1"); stored != "" {
 		t.Fatalf("expected stale pointer cleared, still have %q", stored)
+	}
+	// The row is dropped entirely (file is gone — not a real orphan).
+	if ids := s.btwSessionIDs(); len(ids) != 0 {
+		t.Fatalf("expected stale row removed, got %v", ids)
 	}
 }
 
 func TestHandleBtwMethodGuards(t *testing.T) {
-	s := &Server{db: newAppSettingsDB(t), sessionsDir: t.TempDir()}
+	s := &Server{db: newBtwDB(t), sessionsDir: t.TempDir()}
 
 	// GET handler rejects POST.
 	w := httptest.NewRecorder()
@@ -125,4 +185,97 @@ func TestHandleBtwMethodGuards(t *testing.T) {
 	if w2.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("expected 405 for GET on new handler, got %d", w2.Code)
 	}
+}
+
+func TestFilterBtwSummaries(t *testing.T) {
+	db := newBtwDB(t)
+	s := &Server{db: db}
+	s.setBtwSessionID("parent-1", "btw.jsonl")
+
+	all := []sessions.SessionSummary{
+		{ID: "regular.jsonl"},
+		{ID: "btw.jsonl"},
+	}
+
+	// Hidden by default.
+	out := s.filterBtwSummaries(all)
+	if len(out) != 1 || out[0].ID != "regular.jsonl" {
+		t.Fatalf("expected btw hidden by default, got %v", out)
+	}
+
+	// Shown when the toggle is on.
+	if _, err := db.Exec(`INSERT INTO settings (key, value) VALUES (?, 'true')`, settingShowBtwInIndex); err != nil {
+		t.Fatal(err)
+	}
+	out = s.filterBtwSummaries(all)
+	if len(out) != 2 {
+		t.Fatalf("expected btw shown when enabled, got %v", out)
+	}
+}
+
+func TestReapOrphanedBtw(t *testing.T) {
+	db := newBtwDB(t)
+	dir := t.TempDir()
+	s := &Server{db: db, sessionsDir: dir}
+
+	// Create a btw for an existing parent and one for a parent that is gone.
+	keepID, err := sessions.CreateSessionFileWithSettings(dir, dir, sessions.InitialSettings{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.setBtwSessionID("alive-parent", keepID)
+
+	goneID, err := sessions.CreateSessionFileWithSettings(dir, dir, sessions.InitialSettings{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.setBtwSessionID("dead-parent", goneID)
+
+	// Also a global-sentinel btw, which must never be reaped.
+	s.setBtwSessionID(btwGlobalParent, "global.jsonl")
+
+	// Only the alive parent appears in the current session list.
+	all := []sessions.SessionSummary{
+		{ID: "alive-parent"},
+		{ID: keepID},
+		{ID: goneID},
+	}
+	s.reapOrphanedBtw(all)
+
+	ids := s.btwSessionIDs()
+	if !ids[keepID] {
+		t.Fatalf("expected alive-parent's btw kept, got %v", ids)
+	}
+	if ids[goneID] {
+		t.Fatalf("expected dead-parent's btw reaped, got %v", ids)
+	}
+	if !ids["global.jsonl"] {
+		t.Fatalf("expected global sentinel btw kept, got %v", ids)
+	}
+	// The reaped btw file is removed from disk.
+	if resolved, err := sessions.ResolveByID(dir, goneID); err == nil {
+		if _, statErr := os.Stat(resolved.Path); statErr == nil {
+			t.Fatalf("expected reaped btw file deleted: %s", resolved.Path)
+		}
+	}
+}
+
+func TestMigrateLegacyBtwSession(t *testing.T) {
+	db := newBtwDB(t)
+	if _, err := db.Exec(`INSERT INTO app_settings (key, value) VALUES (?, 'legacy.jsonl')`, settingBtwSessionID); err != nil {
+		t.Fatal(err)
+	}
+
+	migrateLegacyBtwSession(db)
+
+	s := &Server{db: db}
+	if got := s.getBtwSessionID(btwGlobalParent); got != "legacy.jsonl" {
+		t.Fatalf("expected legacy btw migrated to global sentinel, got %q", got)
+	}
+	// Legacy key is removed; running again is a harmless no-op.
+	var v string
+	if err := db.QueryRow("SELECT value FROM app_settings WHERE key = ?", settingBtwSessionID).Scan(&v); err != sql.ErrNoRows {
+		t.Fatalf("expected legacy key deleted, got value=%q err=%v", v, err)
+	}
+	migrateLegacyBtwSession(db)
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -30,7 +30,9 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), 500)
 		return
 	}
+	s.reapOrphanedBtw(summaries)
 	summaries = s.filterEnabledSummaries(summaries)
+	summaries = s.filterBtwSummaries(summaries)
 	sessions.SortSummariesByActivity(summaries)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.renderIndex(w, summaries); err != nil {
@@ -174,6 +176,7 @@ func (s *Server) handleApiSessions(w http.ResponseWriter, r *http.Request) {
 	} else {
 		summaries = s.filterEnabledSummaries(summaries)
 	}
+	summaries = s.filterBtwSummaries(summaries)
 	sessions.SortSummariesByActivity(summaries)
 
 	writeJSON(w, 0, map[string]any{"sessions": summaries})

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -55,8 +55,16 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	scratchpad := ""
+	if resolved.Session.Header != nil {
+		if cwd, ok := resolved.Session.Header["cwd"].(string); ok && cwd != "" {
+			if content, err := s.lookupScratchpad(cwd); err == nil {
+				scratchpad = content
+			}
+		}
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	io.WriteString(w, s.renderLiveSession(resolved.Session))
+	io.WriteString(w, s.renderLiveSession(resolved.Session, scratchpad))
 }
 
 func (s *Server) handleApiForkSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/scratchpad.go
+++ b/internal/server/scratchpad.go
@@ -7,6 +7,21 @@ import (
 	"time"
 )
 
+// lookupScratchpad returns the saved scratchpad content for a project path.
+// An unknown project (or no database) yields an empty string, not an error, so
+// callers on the page-render path can pre-fill the textarea best-effort.
+func (s *Server) lookupScratchpad(project string) (string, error) {
+	if project == "" || s.db == nil {
+		return "", nil
+	}
+	var content string
+	err := s.db.QueryRow("SELECT content FROM scratchpads WHERE project_path = ?", project).Scan(&content)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return content, err
+}
+
 func (s *Server) handleGetScratchpad(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -24,14 +39,8 @@ func (s *Server) handleGetScratchpad(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var content string
-	err := s.db.QueryRow("SELECT content FROM scratchpads WHERE project_path = ?", project).Scan(&content)
+	content, err := s.lookupScratchpad(project)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			// Not found, return empty
-			writeJSON(w, http.StatusOK, map[string]any{"content": ""})
-			return
-		}
 		writeJSONError(w, http.StatusInternalServerError, "failed to query scratchpad: "+err.Error())
 		return
 	}

--- a/internal/server/scratchpad_test.go
+++ b/internal/server/scratchpad_test.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
+
+	"pi-web/internal/sessions"
 
 	_ "modernc.org/sqlite"
 )
@@ -166,5 +169,50 @@ func TestHandleSaveScratchpad(t *testing.T) {
 	sNoDB.handleSaveScratchpad(w5, req5)
 	if w5.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500 for nil db, got %d", w5.Code)
+	}
+}
+
+// TestHandleSessionRendersScratchpad verifies the session page is pre-filled
+// with the saved scratchpad for the session's cwd, so the textarea is present
+// on first paint instead of blanking until the async fetch resolves.
+func TestHandleSessionRendersScratchpad(t *testing.T) {
+	db := newTestDB(t)
+	if _, err := db.Exec(`INSERT INTO scratchpads (project_path, content, updated_at) VALUES (?, ?, datetime('now'))`, "/home/user/project-a", "my saved notes"); err != nil {
+		t.Fatalf("failed to insert scratchpad: %v", err)
+	}
+
+	sessionsDir := t.TempDir()
+	writeSessionWithCWD(t, filepath.Join(sessionsDir, "sub"), "with-pad.jsonl", "/home/user/project-a")
+	writeSessionWithCWD(t, filepath.Join(sessionsDir, "sub"), "no-pad.jsonl", "/home/user/project-b")
+
+	s := &Server{
+		db:          db,
+		sessionsDir: sessionsDir,
+		cache:       sessions.NewCache(),
+		renderLiveSession: func(_ sessions.Session, scratchpad string) string {
+			return "[scratchpad:" + scratchpad + "]"
+		},
+	}
+
+	// Session whose cwd has a saved scratchpad gets it rendered into the page.
+	req := httptest.NewRequest(http.MethodGet, "/session?id=with-pad.jsonl", nil)
+	w := httptest.NewRecorder()
+	s.handleSession(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if got := w.Body.String(); got != "[scratchpad:my saved notes]" {
+		t.Fatalf("expected scratchpad rendered into page, got %q", got)
+	}
+
+	// Session whose cwd has no scratchpad renders an empty string, not an error.
+	req2 := httptest.NewRequest(http.MethodGet, "/session?id=no-pad.jsonl", nil)
+	w2 := httptest.NewRecorder()
+	s.handleSession(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("status = %d", w2.Code)
+	}
+	if got := w2.Body.String(); got != "[scratchpad:]" {
+		t.Fatalf("expected empty scratchpad, got %q", got)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -134,6 +134,10 @@ func New(deps Deps) *Server {
 		if _, err := db.Exec(appSettingsSchema); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to create app_settings table: %v\n", err)
 		}
+		if _, err := db.Exec(btwSessionsSchema); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create btw_sessions table: %v\n", err)
+		}
+		migrateLegacyBtwSession(db)
 	}
 
 	s := &Server{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,7 +42,7 @@ type Deps struct {
 	ChatSender          ChatSender
 	Cache               *sessions.Cache
 	RenderIndex         func(w io.Writer, summaries []sessions.SessionSummary) error
-	RenderLiveSession   func(s sessions.Session) string
+	RenderLiveSession   func(s sessions.Session, scratchpad string) string
 	RenderExportSession func(s sessions.Session, theme string) string
 	RenderSettings      func(w io.Writer) error
 	Models              func(ctx context.Context) (json.RawMessage, error)
@@ -73,7 +73,7 @@ type Server struct {
 	shareRunner         shareCmdRunner
 	now                 func() time.Time
 	renderIndex         func(w io.Writer, summaries []sessions.SessionSummary) error
-	renderLiveSession   func(s sessions.Session) string
+	renderLiveSession   func(s sessions.Session, scratchpad string) string
 	renderExportSession func(s sessions.Session, theme string) string
 	renderSettings      func(w io.Writer) error
 	models              func(ctx context.Context) (json.RawMessage, error)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -20,7 +20,7 @@ func newTestServer(t *testing.T) *Server {
 		Auth:          auth.New(""),
 		Cache:         sessions.NewCache(),
 		RenderIndex:   func(w io.Writer, _ []sessions.SessionSummary) error { return nil },
-		RenderLiveSession:   func(s sessions.Session) string { return "" },
+		RenderLiveSession:   func(s sessions.Session, _ string) string { return "" },
 		RenderExportSession: func(s sessions.Session, theme string) string { return "" },
 		Models:        func(ctx context.Context) (json.RawMessage, error) { return nil, nil },
 	})

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -40,6 +40,7 @@ var settingDefaults = map[string]string{
 	"pi-share:v1:notify-on-done":  "false",
 	"pi-share:v1:done-sound":      "cat.mp3",
 	"pi-sessions:view-layout":     "timeline",
+	"pi-web:v1:show-btw-in-index": "false",
 	"pi-web:v1:cat:enabled":       "true",
 	"pi-web:v1:cat:focus-min":     "25",
 	"pi-web:v1:cat:break-min":     "5",

--- a/internal/ui/live_menu.go
+++ b/internal/ui/live_menu.go
@@ -58,10 +58,6 @@ func homeMenuHTML() template.HTML {
 				{Label: "Manage Projects", Attrs: `id="manage-projects-btn" data-manage-projects-btn role="menuitem"`},
 			}},
 			{Items: []liveMenuItem{
-				{Label: "Documentation", Href: "https://github.com/ygncode/pi-web/tree/main/docs", Attrs: `target="_blank" rel="noreferrer" role="menuitem"`},
-				{Label: "GitHub", Href: "https://github.com/ygncode/pi-web", Attrs: `target="_blank" rel="noreferrer" role="menuitem"`},
-			}},
-			{Items: []liveMenuItem{
 				{Label: "<span>Settings</span>", Suffix: "<kbd>⌘,</kbd>", Href: "/settings", Attrs: `role="menuitem"`},
 				{
 					Label:  "<span>Version</span>",
@@ -92,9 +88,6 @@ func sessionMenuHTML(id, class, bodyClass, itemClass, versionStatusID, container
 				{Label: "Fork", Attrs: `data-action="fork"`},
 				{Label: "Clone", Attrs: `data-action="clone"`},
 			}},
-			{Title: "Preferences", Items: []liveMenuItem{
-				{Label: "<span>Cat Gatekeeper</span>", Suffix: "<span>›</span>", Attrs: `data-action="cat-gatekeeper"`},
-			}},
 			{Title: "Development", Items: []liveMenuItem{
 				{Label: "Resume via Terminal", Attrs: `data-action="terminal"`},
 				{Label: "Tree", Suffix: template.HTML("<kbd>⌘B</kbd>"), Attrs: `data-action="tree"`},
@@ -102,10 +95,6 @@ func sessionMenuHTML(id, class, bodyClass, itemClass, versionStatusID, container
 			}},
 			{Title: "Insights", Items: []liveMenuItem{
 				{Label: "Model Usage", Attrs: `data-action="model-usage"`},
-			}},
-			{Title: "Resources", Items: []liveMenuItem{
-				{Label: "Documentation", Href: "https://github.com/ygncode/pi-web/tree/main/docs", Attrs: `target="_blank" rel="noreferrer" role="menuitem"`},
-				{Label: "GitHub", Href: "https://github.com/ygncode/pi-web", Attrs: `target="_blank" rel="noreferrer" role="menuitem"`},
 			}},
 			{Items: []liveMenuItem{
 				{Label: "<span>Settings</span>", Suffix: "<kbd>⌘,</kbd>", Href: "/settings", Attrs: `role="menuitem"`},

--- a/internal/ui/live_page.go
+++ b/internal/ui/live_page.go
@@ -93,7 +93,7 @@ func renderLiveDocumentStart(data liveDocumentData) string {
 	var b strings.Builder
 	b.WriteString("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n")
 	b.WriteString("<meta charset=\"UTF-8\">\n")
-	b.WriteString("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, maximum-scale=1\">\n")
+	b.WriteString("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=resizes-content\">\n")
 	b.WriteString("<title>")
 	b.WriteString(template.HTMLEscapeString(data.Title))
 	b.WriteString("</title>\n")

--- a/internal/ui/live_templates/session.html
+++ b/internal/ui/live_templates/session.html
@@ -1,4 +1,4 @@
-{{.LiveDocumentStart}}  <script>try{const c=localStorage.getItem('pi-share:v1:sidebar-collapsed');if(c==='true')document.body.classList.add('sidebar-collapsed');}catch(e){}try{const rc=localStorage.getItem('pi-web:v1:right-sidebar-collapsed');if(rc==='true')document.body.classList.add('right-sidebar-collapsed');}catch(e){}</script>
+{{.LiveDocumentStart}}  <script>try{const c=localStorage.getItem('pi-share:v1:sidebar-collapsed');if(c==='true')document.body.classList.add('sidebar-collapsed');}catch(e){}try{const rc=localStorage.getItem('pi-web:v1:right-sidebar-collapsed');const mobile=window.matchMedia&&window.matchMedia('(max-width: 900px)').matches;if(rc==='true'||mobile)document.body.classList.add('right-sidebar-collapsed');}catch(e){}</script>
   {{.ThemeBoot}}
   {{.ServiceWorker}}
 

--- a/internal/ui/live_templates/session.html
+++ b/internal/ui/live_templates/session.html
@@ -1,4 +1,4 @@
-{{.LiveDocumentStart}}  <script>try{const c=localStorage.getItem('pi-share:v1:sidebar-collapsed');if(c==='true')document.body.classList.add('sidebar-collapsed');}catch(e){}try{const rc=localStorage.getItem('pi-web:v1:right-sidebar-collapsed');const mobile=window.matchMedia&&window.matchMedia('(max-width: 900px)').matches;if(rc==='true'||mobile)document.body.classList.add('right-sidebar-collapsed');}catch(e){}</script>
+{{.LiveDocumentStart}}  <script>try{const c=localStorage.getItem('pi-share:v1:sidebar-collapsed');if(c==='true')document.body.classList.add('sidebar-collapsed');}catch(e){}try{const lw=Number(localStorage.getItem('pi-share:v1:sidebar-width'));if(isFinite(lw)&&lw>0)document.documentElement.style.setProperty('--sidebar-width',Math.round(lw)+'px');}catch(e){}try{const rc=localStorage.getItem('pi-web:v1:right-sidebar-collapsed');const mobile=window.matchMedia&&window.matchMedia('(max-width: 900px)').matches;if(rc==='true'||mobile)document.body.classList.add('right-sidebar-collapsed');}catch(e){}try{const w=Number(localStorage.getItem('pi-web:v1:right-sidebar-width'));if(isFinite(w)&&w>0)document.documentElement.style.setProperty('--right-sidebar-width',Math.round(w)+'px');}catch(e){}</script>
   {{.ThemeBoot}}
   {{.ServiceWorker}}
 
@@ -111,7 +111,7 @@
         </div>
       </div>
       <div class="right-sidebar-content">
-        <textarea id="scratchpad-textarea" class="scratchpad-textarea" placeholder="Write project-level notes, scratchpad, tasks..."></textarea>
+        <textarea id="scratchpad-textarea" class="scratchpad-textarea" placeholder="Write project-level notes, scratchpad, tasks...">{{.Scratchpad}}</textarea>
       </div>
       <div class="right-sidebar-footer">
         <span id="scratchpad-status" class="scratchpad-status">Saved</span>

--- a/internal/ui/live_templates/settings.html
+++ b/internal/ui/live_templates/settings.html
@@ -199,6 +199,37 @@
     </div>
   </section>
 
+  <section class="settings-section">
+    <div class="settings-section-title">About</div>
+    <div class="settings-row">
+      <div class="settings-row-label">
+        <span class="name">Documentation</span>
+        <span class="hint">Guides and architecture docs for pi-web.</span>
+      </div>
+      <div class="settings-control">
+        <a class="settings-link" href="https://github.com/ygncode/pi-web/tree/main/docs" target="_blank" rel="noreferrer">Open docs</a>
+      </div>
+    </div>
+    <div class="settings-row">
+      <div class="settings-row-label">
+        <span class="name">GitHub</span>
+        <span class="hint">If pi-web is useful to you, please give the repo a ⭐.</span>
+      </div>
+      <div class="settings-control">
+        <a class="settings-link" href="https://github.com/ygncode/pi-web" target="_blank" rel="noreferrer">Star on GitHub</a>
+      </div>
+    </div>
+    <div class="settings-row">
+      <div class="settings-row-label">
+        <span class="name">Sponsor</span>
+        <span class="hint">Support continued development of pi-web by sponsoring the creator.</span>
+      </div>
+      <div class="settings-control">
+        <a class="settings-link" href="https://github.com/sponsors/setkyar" target="_blank" rel="noreferrer">Become a sponsor</a>
+      </div>
+    </div>
+  </section>
+
   <div class="settings-saved-hint" data-settings-saved>Saved</div>
 </div>
 

--- a/internal/ui/live_templates/settings.html
+++ b/internal/ui/live_templates/settings.html
@@ -111,6 +111,18 @@
         </select>
       </div>
     </div>
+    <div class="settings-row">
+      <div class="settings-row-label">
+        <span class="name">Show btw chats in list</span>
+        <span class="hint">Include the throwaway btw scratch-chats in the sessions list. Hidden by default.</span>
+      </div>
+      <div class="settings-control">
+        <label class="settings-toggle">
+          <input type="checkbox" data-setting="pi-web:v1:show-btw-in-index" data-setting-bool>
+          <span class="slider"></span>
+        </label>
+      </div>
+    </div>
   </section>
 
   <section class="settings-section">

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -2188,11 +2188,27 @@
         height: 100%;
       }
 
+      /* Pin the whole shell to the top of the layout viewport. iOS Safari
+         otherwise scrolls the layout viewport when the keyboard opens, sliding
+         the bottom-docked composer underneath it. With position:fixed the shell
+         can't be shifted, and its height tracks the visible viewport
+         (--viewport-height, kept in sync from visualViewport in session.js), so
+         the composer always sits just above the keyboard. */
       body {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
         display: flex;
         flex-direction: column;
         height: 100vh;
         height: var(--viewport-height, 100svh);
+        /* The base body rule sets min-height:100vh. On iOS 100vh is the LARGE
+           viewport (full screen, behind the keyboard), and min-height beats
+           height — so without this override the body stays full-height and the
+           bottom-docked composer is buried under the keyboard. Track the
+           visible viewport here too. */
+        min-height: var(--viewport-height, 100svh);
         overflow: hidden;
       }
 
@@ -2265,8 +2281,17 @@
         padding: env(safe-area-inset-top) 12px 0;
       }
 
+      /* On phones the title sat absolutely centered and overlapped the
+         left (back + tree toggle) and right action clusters. Drop it into the
+         flex flow so it occupies only the gap between them and truncates. */
       .session-header-title {
-        max-width: 50vw;
+        position: static;
+        transform: none;
+        flex: 1 1 auto;
+        min-width: 0;
+        max-width: none;
+        margin: 0 8px;
+        text-align: center;
       }
 
       body.sidebar-open .session-header-bar {
@@ -2313,6 +2338,29 @@
 
       .right-sidebar-resizer {
         display: none !important;
+      }
+
+      /* The btw scratch-chat is a draggable floating window on desktop. On a
+         phone a fixed box gets buried behind the on-screen keyboard, so dock it
+         as a full-height sheet sized to the visible viewport (--viewport-height
+         tracks the keyboard). Its input row, pinned at the bottom of that
+         height, then stays above the keyboard. */
+      .pi-btw-window {
+        top: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+        bottom: auto !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        max-width: 100% !important;
+        height: var(--viewport-height, 100svh) !important;
+        max-height: none !important;
+        border-radius: 0 !important;
+        resize: none !important;
+      }
+
+      .pi-btw-header {
+        cursor: default;
       }
     }
 

--- a/internal/ui/live_templates/styles/settings.css
+++ b/internal/ui/live_templates/styles/settings.css
@@ -159,6 +159,24 @@
   background: #fff;
 }
 
+.settings-link {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-soft);
+  text-decoration: none;
+  font-size: 1em;
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--dim);
+  background: var(--input-bg, var(--surface-2));
+  white-space: nowrap;
+}
+
+.settings-link:hover {
+  color: var(--text);
+  background: var(--hover);
+}
+
 .settings-saved-hint {
   text-align: center;
   color: var(--muted);

--- a/internal/ui/session_page.go
+++ b/internal/ui/session_page.go
@@ -68,7 +68,7 @@ func prepareSessionPageData(session sessions.Session, cssTemplate string) (dataB
 
 // renderLiveSessionPage renders the interactive session viewer served at
 // /session. It loads the Vite-built session module and includes the chat composer.
-func RenderLiveSessionPage(session sessions.Session) string {
+func RenderLiveSessionPage(session sessions.Session, scratchpad string) string {
 	dataBase64, css, bodyAttrs := prepareSessionPageData(session, liveThemeCss+"\n"+liveSessionCss+"\n"+liveMenuCss+"\n"+livePaletteCss)
 
 	scriptSrc := template.HTMLEscapeString(sessionScriptPath)
@@ -88,6 +88,7 @@ func RenderLiveSessionPage(session sessions.Session) string {
 		SessionScript      template.HTML
 		FirstMessageStub   template.HTML
 		ChatComposer       template.HTML
+		Scratchpad         string
 		LiveDocumentEnd    template.HTML
 	}{
 		IsLive:             true,
@@ -112,6 +113,7 @@ func RenderLiveSessionPage(session sessions.Session) string {
 		SessionScript:    template.HTML(`<script type="module" src="` + scriptSrc + `"></script>`),
 		FirstMessageStub: template.HTML(firstMessageStub(session)),
 		ChatComposer:     template.HTML(chatComposerHtmlForSession(session)),
+		Scratchpad:       scratchpad,
 		LiveDocumentEnd:  liveDocumentEnd(),
 	}
 
@@ -122,7 +124,9 @@ func RenderLiveSessionPage(session sessions.Session) string {
 	return buf.String()
 }
 
-func renderLiveSessionPage(session sessions.Session) string { return RenderLiveSessionPage(session) }
+func renderLiveSessionPage(session sessions.Session) string {
+	return RenderLiveSessionPage(session, "")
+}
 
 // firstMessageStub returns a minimal HTML stub for the first user message so
 // the browser has an LCP candidate before the JS bundle finishes loading.

--- a/web/src/session/chat/chat-composer-runner.js
+++ b/web/src/session/chat/chat-composer-runner.js
@@ -289,7 +289,7 @@ export function runChatComposer({
     if (!notice) {
       notice = document.createElement('div');
       notice.id = 'pi-chat-cwd-toast';
-      notice.style.cssText = 'position:fixed;top:8px;right:8px;z-index:200;padding:2px 8px;font-size:10px;font-family:inherit;background:var(--accent);color:var(--body-bg);border-radius:3px;opacity:0;transition:opacity 0.3s;pointer-events:none;';
+      notice.style.cssText = 'position:fixed;top:60px;right:8px;z-index:200;padding:2px 8px;font-size:10px;font-family:inherit;background:var(--accent);color:var(--body-bg);border-radius:3px;opacity:0;transition:opacity 0.3s;pointer-events:none;';
       document.body.appendChild(notice);
     }
     notice.textContent = message;

--- a/web/src/session/live/btw-popup.js
+++ b/web/src/session/live/btw-popup.js
@@ -1,19 +1,19 @@
 // The "btw" floating window: a draggable, resizable scratch-chat opened from
-// the git bar. It talks to a single global pi session ("the btw session")
-// persisted server-side in the sqlite app_settings table, so the conversation
-// survives reloads AND stays in sync across every device in realtime. The
-// window itself is built entirely in JS, so the export snapshot (no
-// composer/git bar) never includes it.
+// the git bar. Each session page has its own btw session, persisted server-side
+// in the sqlite btw_sessions table keyed by the parent session id, so the
+// conversation survives reloads AND stays in sync across every device viewing
+// the same page in realtime. The window itself is built entirely in JS, so the
+// export snapshot (no composer/git bar) never includes it.
 //
-// Backend contract:
-//   GET  /api/btw            -> { sessionId }            current btw session (or "")
-//   POST /api/btw/new {path} -> { id }                   create + adopt a new btw session
+// Backend contract (parent = the session page this window was opened from):
+//   GET  /api/btw?parent=<pid> -> { sessionId }          active btw for parent (or "")
+//   POST /api/btw/new {path,parent} -> { id }            create + adopt a new btw session
 //   POST /api/chat?id=<id>   (FormData message)          send a message
 //   POST /api/chat/cancel?id=<id>                        cancel the running turn
 //   GET  /api/worker-status?id=<id> -> { state }         idle|running|error
 //   GET  /api/session?id=<id>-> { entries, ... }         transcript
 //   /events?id=<id>          SSE: "reload" + "chat-preview" {content,done}
-//   /events?id=__all__       SSE: "btw-changed" {sessionId}  cross-device pointer sync
+//   /events?id=<pid>         SSE: "btw-changed" {sessionId}  per-parent pointer sync
 
 import { marked } from 'marked';
 import { safeMarkedParse } from '../render/markdown.js';
@@ -21,7 +21,10 @@ import { formatToolCall } from '../render/session-format.js';
 import { getSpinnerConfig } from './chat-preview.js';
 
 const POS_KEY = 'pi-btw:window';
-const GLOBAL_TOPIC = '__all__';
+// Sentinel matching the server's btwGlobalParent for a btw opened with no parent
+// session. Today every page with a btw button has a parent id, so this is just a
+// safety fallback (and the migration home for the legacy single global btw).
+const GLOBAL_PARENT = '__global__';
 
 export function setupBtwPopup({
   documentImpl = document,
@@ -29,10 +32,14 @@ export function setupBtwPopup({
   fetchImpl,
   EventSourceImpl,
   cwd = '',
+  parentId = '',
   renderMarkdown,
 } = {}) {
   const button = documentImpl.getElementById('pi-btw-button');
   if (!button) return null;
+
+  // The SSE topic / query key identifying this window's parent session.
+  const parent = parentId || GLOBAL_PARENT;
 
   // On phones the floating window and the main chat composer fight for the same
   // cramped screen, so we keep them mutually exclusive there.
@@ -308,10 +315,11 @@ export function setupBtwPopup({
     }
   }
 
-  // Listen on the global topic so a "new" on another device switches us over.
+  // Listen on the parent's topic so a "new" on another device viewing the same
+  // page switches us over.
   function subscribeGlobal() {
     if (globalSource || !ES) return;
-    globalSource = new ES('/events?id=' + encodeURIComponent(GLOBAL_TOPIC));
+    globalSource = new ES('/events?id=' + encodeURIComponent(parent));
     globalSource.addEventListener('btw-changed', (e) => {
       try {
         const p = JSON.parse(e.data);
@@ -409,7 +417,6 @@ export function setupBtwPopup({
   // ── actions ──
   function setSession(id) {
     sessionId = id || '';
-    saveGeom({ sessionId });
     entries = [];
     pendingUser = null;
     streamingText = '';
@@ -428,7 +435,7 @@ export function setupBtwPopup({
     return doFetch('/api/btw/new', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ path: cwd }),
+      body: JSON.stringify({ path: cwd, parent: parentId }),
     })
       .then((r) => r.json())
       .then((data) => {
@@ -440,14 +447,14 @@ export function setupBtwPopup({
       });
   }
 
+  // Lazy "new": clear the window to its empty state without creating a session
+  // file. The fresh btw session is created on the first message send (see
+  // submitMessage), so pressing "new" and never typing leaves no empty
+  // throwaway behind — and the server's active pointer only moves once a real
+  // message exists.
   function startNewSession() {
-    if (els) els.newBtn.disabled = true;
-    createSession()
-      .catch(() => {})
-      .finally(() => {
-        if (els) els.newBtn.disabled = false;
-        if (els) els.input.focus();
-      });
+    setSession('');
+    if (els) els.input.focus();
   }
 
   async function submitMessage() {
@@ -558,8 +565,8 @@ export function setupBtwPopup({
     saveGeom({ open: true });
     subscribeGlobal();
     startStatusPolling();
-    // Sync to the persisted server-side btw session each time we open.
-    doFetch('/api/btw')
+    // Sync to this parent's persisted server-side btw session each time we open.
+    doFetch('/api/btw?parent=' + encodeURIComponent(parent))
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         const id = data && data.sessionId ? data.sessionId : '';

--- a/web/src/session/live/btw-popup.test.js
+++ b/web/src/session/live/btw-popup.test.js
@@ -39,8 +39,8 @@ function jsonResponse(body, ok = true) {
 // A fetch router that covers every endpoint the popup touches.
 function router(overrides = {}) {
   return vi.fn((url, opts) => {
-    if (url === '/api/btw') return jsonResponse(overrides.btw || { sessionId: '' });
-    if (url === '/api/btw/new') return jsonResponse(overrides.new || { id: 'new-sess.jsonl' });
+    if (url.startsWith('/api/btw/new')) return jsonResponse(overrides.new || { id: 'new-sess.jsonl' });
+    if (url.startsWith('/api/btw')) return jsonResponse(overrides.btw || { sessionId: '' });
     if (url.startsWith('/api/worker-status')) return jsonResponse(overrides.status || { state: 'idle' });
     if (url.startsWith('/api/session')) return jsonResponse(overrides.session || { entries: [] });
     if (url.startsWith('/api/chat/cancel')) return jsonResponse({ ok: true });
@@ -79,7 +79,7 @@ describe('btw popup', () => {
     expect(w.querySelector('.pi-btw-new')).not.toBeNull();
     expect(w.querySelector('.pi-btw-close')).not.toBeNull();
     expect(w.querySelector('#pi-btw-input')).not.toBeNull();
-    expect(fetchImpl).toHaveBeenCalledWith('/api/btw');
+    expect(fetchImpl).toHaveBeenCalledWith('/api/btw?parent=__global__');
     api.close();
   });
 
@@ -139,11 +139,18 @@ describe('btw popup', () => {
     api.close();
   });
 
-  it('creates a session then sends when none exists yet', async () => {
+  it('creates a session then sends when none exists yet, passing cwd + parent', async () => {
     const { win, doc } = makeEnv();
     const sent = [];
     const fetchImpl = router({ new: { id: 'new-sess.jsonl' }, sent });
-    const api = setupBtwPopup({ documentImpl: doc, windowImpl: win, fetchImpl, EventSourceImpl: FakeEventSource, cwd: '/repo/foo' });
+    const api = setupBtwPopup({
+      documentImpl: doc,
+      windowImpl: win,
+      fetchImpl,
+      EventSourceImpl: FakeEventSource,
+      cwd: '/repo/foo',
+      parentId: 'parent-1.jsonl',
+    });
 
     doc.getElementById('pi-btw-button').click();
     await flush();
@@ -152,24 +159,28 @@ describe('btw popup', () => {
     doc.getElementById('pi-btw-form').dispatchEvent(new win.Event('submit'));
     await flush();
 
-    expect(fetchImpl).toHaveBeenCalledWith('/api/btw/new', expect.objectContaining({ method: 'POST' }));
+    const call = fetchImpl.mock.calls.find((c) => String(c[0]).startsWith('/api/btw/new'));
+    expect(call[1].method).toBe('POST');
+    expect(JSON.parse(call[1].body)).toEqual({ path: '/repo/foo', parent: 'parent-1.jsonl' });
     expect(sent[0]).toContain('new-sess.jsonl');
     expect(doc.querySelector('.pi-btw-msg.user')).not.toBeNull();
     api.close();
   });
 
-  it('new button posts to /api/btw/new with the cwd', async () => {
+  it('new button is lazy: clears the window without creating a session', async () => {
     const { win, doc } = makeEnv();
-    const fetchImpl = router({ new: { id: 'fresh.jsonl' } });
-    const api = setupBtwPopup({ documentImpl: doc, windowImpl: win, fetchImpl, EventSourceImpl: FakeEventSource, cwd: '/repo/bar' });
+    const fetchImpl = router({ btw: { sessionId: 'sess-1.jsonl' } });
+    const api = setupBtwPopup({ documentImpl: doc, windowImpl: win, fetchImpl, EventSourceImpl: FakeEventSource });
 
     doc.getElementById('pi-btw-button').click();
     await flush();
     doc.querySelector('.pi-btw-new').click();
     await flush();
 
-    const call = fetchImpl.mock.calls.find((c) => c[0] === '/api/btw/new');
-    expect(JSON.parse(call[1].body)).toEqual({ path: '/repo/bar' });
+    // No session file is created until the first message is sent.
+    expect(fetchImpl.mock.calls.some((c) => String(c[0]).startsWith('/api/btw/new'))).toBe(false);
+    // The window resets to its empty prompt state.
+    expect(doc.querySelector('.pi-btw-empty')).not.toBeNull();
     api.close();
   });
 
@@ -213,15 +224,21 @@ describe('btw popup', () => {
     api.close();
   });
 
-  it('switches session in realtime on a global btw-changed event', async () => {
+  it('switches session in realtime on a per-parent btw-changed event', async () => {
     const { win, doc } = makeEnv();
     const fetchImpl = router({ btw: { sessionId: 'sess-1.jsonl' } });
-    const api = setupBtwPopup({ documentImpl: doc, windowImpl: win, fetchImpl, EventSourceImpl: FakeEventSource });
+    const api = setupBtwPopup({
+      documentImpl: doc,
+      windowImpl: win,
+      fetchImpl,
+      EventSourceImpl: FakeEventSource,
+      parentId: 'parent-1.jsonl',
+    });
 
     doc.getElementById('pi-btw-button').click();
     await flush();
 
-    const globalES = FakeEventSource.instances.find((e) => e.url.includes('__all__'));
+    const globalES = FakeEventSource.instances.find((e) => e.url.includes('parent-1.jsonl'));
     expect(globalES).toBeTruthy();
     globalES.emit('btw-changed', JSON.stringify({ sessionId: 'sess-2.jsonl' }));
     await flush();

--- a/web/src/session/live/command-menu.js
+++ b/web/src/session/live/command-menu.js
@@ -274,10 +274,6 @@ export function setupCommandMenu({
           .catch(() => showToast('Clone failed', documentImpl, windowImpl));
         break;
       }
-      case 'cat-gatekeeper':
-        closeMenu();
-        windowImpl.__piCatGatekeeper?.openSettings?.();
-        break;
       case 'version':
         closeMenu();
         openVersionModal();

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -480,10 +480,10 @@ export function runSessionApp({ target = window } = {}) {
 
       // Dynamically adjust the top header's vertical position to offset
       // layout viewport scroll/shift caused by mobile virtual keyboard.
-      const offsetTop = target.visualViewport.offsetTop;
+      const offsetTop = Math.max(0, target.visualViewport.offsetTop);
       const header = documentImpl.querySelector('.session-header-bar');
       if (header) {
-        header.style.transform = `translateY(${Math.max(0, offsetTop)}px)`;
+        header.style.transform = `translateY(${offsetTop}px)`;
       }
     };
     target.visualViewport.addEventListener('resize', handleVisualViewportChange);

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -469,7 +469,12 @@ export function runSessionApp({ target = window } = {}) {
     gitApi
   });
 
-  setupBtwPopup({ documentImpl, windowImpl: target, cwd: dataModel.header?.cwd || '' });
+  setupBtwPopup({
+    documentImpl,
+    windowImpl: target,
+    cwd: dataModel.header?.cwd || '',
+    parentId: getSessionSearchParams({ documentImpl, windowImpl: target }).get('id') || '',
+  });
 
   // Handle Visual Viewport changes to prevent mobile browsers from shifting
   // the top fixed header out of view when the virtual keyboard is open.

--- a/web/src/session/ui/right-sidebar.js
+++ b/web/src/session/ui/right-sidebar.js
@@ -224,13 +224,13 @@ export function setupRightSidebar({
   });
 
   // ── Init ──────────────────────────────────────────────────────────────────
-  // Load stored width, and load scratchpad if not collapsed
+  // Load stored width. Scratchpad content is server-rendered into the textarea
+  // so it's present on first paint (no placeholder→value flash); adopt it as the
+  // baseline instead of re-fetching, which would blank then refill the field.
   const savedWidth = loadWidth();
   if (savedWidth !== null) applyWidth(savedWidth);
 
-  if (!isCollapsed() && projectPath) {
-    loadScratchpad();
-  }
+  if (textarea) lastSaved = textarea.value;
 
   return { toggleSidebar };
 }


### PR DESCRIPTION
## Summary
- **feat(btw):** Scope the "btw" scratch-chat per session via a new `btw_sessions` registry keyed by parent session id, instead of one global pointer. Pressing "new" lazily creates the session on first message and orphans the prior chat; orphans are reaped when their parent is deleted. btw chats are hidden from the index by default with a `/settings` toggle, and the legacy global btw migrates under a `__global__` sentinel.
- **fix(session):** Eliminate scratchpad and sidebar-width flashes on load — server-render the saved scratchpad into the textarea on first paint and pre-apply stored sidebar widths via the inline boot script.
- **fix(mobile):** Keep the chat composer above the iOS keyboard.
- **feat(settings):** Move docs/GitHub links into `/settings` and drop the corresponding command-menu items.
- **fix(pwa):** Drop the cwd-copy toast below the session header.
- **test(session):** Add coverage for the server-rendered scratchpad path on the session page.

## Testing
- `go test ./internal/server/`
