### PR TITLE
docs(github): add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report something in pi-web that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please fill out the sections
+        below so we can reproduce and triage it quickly.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen instead.
+      placeholder: When I open a session, the chat composer...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the behavior?
+      placeholder: |
+        1. Start pi-web with `...`
+        2. Open the session at `...`
+        3. Click `...`
+        4. See error
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: pi-web version
+      description: From the in-app version indicator or `pi-web --version`.
+      placeholder: v0.1.0
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: OS & browser
+      description: Operating system and the browser (with version) where you saw this.
+      placeholder: macOS 15.2, Chrome 130
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: pi-web server output or browser console errors. This is automatically formatted as code.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy
+      options:
+        - label: I have not pasted private session content; logs and screenshots are scrubbed of sensitive data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest an idea or improvement for pi-web
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        pi-web is early-stage. Per CONTRIBUTING.md, please open this issue to
+        discuss your idea first — the maintainer will triage it before inviting
+        any pull request.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem are you trying to solve? What's the use case?
+      placeholder: When viewing a session, I can't...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches or workarounds you've thought about.
+    validations:
+      required: false
+  - type: checkboxes
+    id: acknowledgement
+    attributes:
+      label: Acknowledgement
+      options:
+        - label: I understand the maintainer triages requests and will invite a PR only if this moves forward.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+<!--
+Thanks for contributing to pi-web! Per CONTRIBUTING.md, please open an issue
+first so we can discuss before code is written. Link that issue below.
+-->
+
+## Summary
+
+<!-- What changed and why. Focus on the "why" — the motivation behind the change. -->
+
+## Related issue
+
+Closes #
+
+## Type of change
+
+<!-- Match your PR title's conventional-commit type. Check all that apply. -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
+- [ ] `style` — formatting / UI styling, no behavior change
+- [ ] `test` — adding or updating tests
+- [ ] `chore` — build, tooling, or maintenance
+
+## Live vs. Export
+
+<!--
+If this PR touches session rendering, remember pi-web has two render paths
+(see AGENTS.md): the live app and the static export/Gist snapshot.
+-->
+
+- [ ] Not applicable — this PR doesn't touch session rendering
+- [ ] Considered both the live app and the export snapshot
+- [ ] Kept `internal/ui/live_templates/` in sync with `web/src/session/` changes
+- [ ] No live-only chrome (Vite scripts, active composer, SSE/API) leaked into export
+
+## Testing
+
+- [ ] `make check` passes (test + build + vet)
+- [ ] Frontend tests (`vitest`) cover the change
+- [ ] Go tests (`go test ./...`) cover the change
+- [ ] UI changes verified in a browser


### PR DESCRIPTION
## Summary
- Add a pull request template with summary, related issue, conventional-commit type, live-vs-export reminder, and a testing checklist
- Add structured YAML issue forms: `bug_report.yml` and `feature_request.yml`
- Add `config.yml` to disable blank issues (funnel reporters into the forms)

Reflects the project's conventional-commit style and the issues-first policy in `CONTRIBUTING.md`.

## Test plan
- [x] GitHub metadata only — no Go/JS build impact; `make check` unaffected
- [ ] Verify templates render on GitHub (new issue / new PR pickers)