### PR TITLE
feat(chat): list loaded skills with /skill in the composer

### DIFF
--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -57,3 +57,7 @@ func BuildAbortCommand(id string) map[string]any {
 func BuildSetThinkingLevelCommand(id, level string) map[string]any {
 	return map[string]any{"id": id, "type": "set_thinking_level", "level": level}
 }
+
+func BuildGetCommandsCommand(id string) map[string]any {
+	return map[string]any{"id": id, "type": "get_commands"}
+}

--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -52,6 +52,13 @@ func TestBuildPromptCommandOmitsSteerWhenIdle(t *testing.T) {
 	}
 }
 
+func TestBuildGetCommandsCommand(t *testing.T) {
+	cmd := BuildGetCommandsCommand("req-7")
+	if cmd["id"] != "req-7" || cmd["type"] != "get_commands" {
+		t.Fatalf("cmd = %#v", cmd)
+	}
+}
+
 func TestWriteRPCCommandWritesJSONLine(t *testing.T) {
 	var buf bytes.Buffer
 	if err := WriteCommand(&buf, map[string]any{"type": "get_state"}); err != nil {

--- a/internal/rpc/worker.go
+++ b/internal/rpc/worker.go
@@ -34,6 +34,8 @@ type piRPCWorker struct {
 	lastStreamActivity   atomic.Int64 // unix nanos; stream/turn events keep worker visually running
 	streamSink           StreamEventSink
 	streamPreview        *streamPreviewAccumulator
+	cachedCommands       []workers.SlashCommand
+	commandsCached       bool
 }
 
 // idleReportable is implemented by workers that can report when they were last
@@ -238,6 +240,55 @@ func (w *piRPCWorker) GetState(ctx context.Context) (workers.WorkerStatus, error
 	case <-ctx.Done():
 		w.removePending(id)
 		return workers.WorkerStatus{}, ctx.Err()
+	}
+}
+
+// GetCommands asks pi for the commands reachable via prompt (extensions, prompt
+// templates, and skills). The set is fixed for a worker's lifetime, so the
+// result is cached after the first successful call.
+func (w *piRPCWorker) GetCommands(ctx context.Context) ([]workers.SlashCommand, error) {
+	w.mu.Lock()
+	if w.commandsCached {
+		cached := append([]workers.SlashCommand(nil), w.cachedCommands...)
+		w.mu.Unlock()
+		return cached, nil
+	}
+	w.mu.Unlock()
+
+	id := w.nextID()
+	ch := make(chan response, 1)
+	w.mu.Lock()
+	w.pending[id] = ch
+	w.mu.Unlock()
+
+	w.writeMu.Lock()
+	err := WriteCommand(w.stdin, BuildGetCommandsCommand(id))
+	w.writeMu.Unlock()
+	if err != nil {
+		w.removePending(id)
+		return nil, err
+	}
+
+	select {
+	case res := <-ch:
+		if !res.Success {
+			if res.Error != "" {
+				return nil, errors.New(res.Error)
+			}
+			return nil, fmt.Errorf("rpc get_commands rejected")
+		}
+		var payload struct {
+			Commands []workers.SlashCommand `json:"commands"`
+		}
+		_ = json.Unmarshal(res.Data, &payload)
+		w.mu.Lock()
+		w.cachedCommands = payload.Commands
+		w.commandsCached = true
+		w.mu.Unlock()
+		return payload.Commands, nil
+	case <-ctx.Done():
+		w.removePending(id)
+		return nil, ctx.Err()
 	}
 }
 

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -23,6 +23,7 @@ type ChatSender interface {
 	GetState(ctx context.Context, sessionID string) (workers.WorkerStatus, error)
 	Status(sessionID string) workers.WorkerStatus
 	EnsureWorker(ctx context.Context, sessionID, sessionPath string) error
+	Commands(ctx context.Context, sessionID, sessionPath string, spawn bool) ([]workers.SlashCommand, bool, error)
 }
 
 func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
@@ -265,4 +266,40 @@ func (s *Server) handleSetThinkingLevel(w http.ResponseWriter, r *http.Request) 
 		status.ThinkingLevel = state.ThinkingLevel
 	}
 	writeJSON(w, 0, map[string]any{"ok": true, "thinkingLevel": status.ThinkingLevel})
+}
+
+// handleGetCommands lists the commands loaded by the session's worker, used by
+// the composer to show skills when the user types "/skill". With ?load=1 it
+// spawns the worker on demand (the "Load skills" button); otherwise it only
+// peeks at an already-running worker and reports workerReady=false if none.
+func (s *Server) handleGetCommands(w http.ResponseWriter, r *http.Request) {
+	resolved, err := sessions.ResolveByID(s.sessionsDir, r.URL.Query().Get("id"))
+	if err != nil {
+		if errors.Is(err, sessions.ErrInvalidSessionID) {
+			writeJSONError(w, http.StatusBadRequest, "invalid session id")
+			return
+		}
+		if errors.Is(err, sessions.ErrSessionNotFound) {
+			writeJSONError(w, http.StatusNotFound, "session not found")
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if s.chatSender == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "chat unavailable")
+		return
+	}
+	spawn := r.URL.Query().Get("load") == "1" || r.URL.Query().Get("load") == "true"
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	commands, workerReady, err := s.chatSender.Commands(ctx, resolved.Session.ID, resolved.Path, spawn)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if commands == nil {
+		commands = []workers.SlashCommand{}
+	}
+	writeJSON(w, 0, map[string]any{"commands": commands, "workerReady": workerReady})
 }

--- a/internal/server/chat_test.go
+++ b/internal/server/chat_test.go
@@ -36,6 +36,11 @@ type fakeSender struct {
 	setThinkingSessionID    string
 	setThinkingLevel        string
 	sendCh                  chan struct{}
+	commands                []workers.SlashCommand
+	commandsReady           bool
+	commandsErr             error
+	commandsSessionID       string
+	commandsSpawn           bool
 }
 
 func (f *fakeSender) Send(ctx context.Context, sessionID, sessionPath string, chat chat.Request) error {
@@ -91,6 +96,12 @@ func (f *fakeSender) EnsureWorker(ctx context.Context, sessionID, sessionPath st
 		f.ensureWorkerCh <- struct{}{}
 	}
 	return nil
+}
+
+func (f *fakeSender) Commands(ctx context.Context, sessionID, sessionPath string, spawn bool) ([]workers.SlashCommand, bool, error) {
+	f.commandsSessionID = sessionID
+	f.commandsSpawn = spawn
+	return f.commands, f.commandsReady, f.commandsErr
 }
 
 func TestHandleChatQueuesResolvedSession(t *testing.T) {
@@ -611,5 +622,60 @@ func waitForCondition(t *testing.T, timeout time.Duration, fn func() bool) {
 	}
 	if !fn() {
 		t.Fatal("condition not met before timeout")
+	}
+}
+
+func TestHandleGetCommandsListsSkills(t *testing.T) {
+	root := t.TempDir()
+	writeSessionFile(t, root, "--tmp--project--", "session.jsonl")
+	fake := &fakeSender{
+		commands:      []workers.SlashCommand{{Name: "skill:foo", Source: "skill", Description: "do foo"}},
+		commandsReady: true,
+	}
+	s := &Server{sessionsDir: root, chatSender: fake}
+	req := httptest.NewRequest(http.MethodGet, "/api/commands?id=session.jsonl&load=1", nil)
+	w := httptest.NewRecorder()
+	s.handleGetCommands(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if !fake.commandsSpawn {
+		t.Fatalf("expected spawn=true when load=1")
+	}
+	var got struct {
+		Commands    []workers.SlashCommand `json:"commands"`
+		WorkerReady bool                   `json:"workerReady"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.WorkerReady || len(got.Commands) != 1 || got.Commands[0].Name != "skill:foo" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestHandleGetCommandsPeekReportsNotReady(t *testing.T) {
+	root := t.TempDir()
+	writeSessionFile(t, root, "--tmp--project--", "session.jsonl")
+	fake := &fakeSender{commandsReady: false}
+	s := &Server{sessionsDir: root, chatSender: fake}
+	req := httptest.NewRequest(http.MethodGet, "/api/commands?id=session.jsonl", nil)
+	w := httptest.NewRecorder()
+	s.handleGetCommands(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if fake.commandsSpawn {
+		t.Fatalf("expected spawn=false without load param")
+	}
+	var got struct {
+		Commands    []workers.SlashCommand `json:"commands"`
+		WorkerReady bool                   `json:"workerReady"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.WorkerReady || len(got.Commands) != 0 {
+		t.Fatalf("got %+v, want not ready and empty commands", got)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,6 +203,7 @@ func (s *Server) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/set-model", s.auth.Wrap(s.handleSetModel))
 	mux.HandleFunc("/api/set-thinking-level", s.auth.Wrap(s.handleSetThinkingLevel))
 	mux.HandleFunc("/api/models", s.auth.Wrap(s.handleAvailableModels))
+	mux.HandleFunc("/api/commands", s.auth.Wrap(s.handleGetCommands))
 	mux.HandleFunc("/api/worker-status", s.auth.Wrap(s.handleWorkerStatus))
 	mux.HandleFunc("/share", s.auth.Wrap(s.handleShare))
 	mux.HandleFunc("/events", s.auth.Wrap(s.handleEvents))

--- a/internal/ui/live_templates/chat_composer.html
+++ b/internal/ui/live_templates/chat_composer.html
@@ -93,6 +93,14 @@
         >
             <div id="pi-chat-thinking-list" class="pi-chat-thinking-list"></div>
         </div>
+        <div
+            id="pi-chat-skill-popup"
+            class="pi-chat-skill-popup"
+            style="display: none"
+        >
+            <div class="pi-chat-skill-header">Loaded skills</div>
+            <div id="pi-chat-skill-list" class="pi-chat-skill-list"></div>
+        </div>
         <div class="pi-chat-toolbar">
             <div class="pi-chat-toolbar-left">
                 <button

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -3207,6 +3207,59 @@
     .thinking-level-item.selected.thinking-xhigh,
     .thinking-level-item:hover.thinking-xhigh { color: var(--thinkingXhigh); }
 
+    /* Skill list (/skill) — anchored above the composer shell like the model
+       popup, listing skills the worker has loaded. */
+    .pi-chat-skill-popup {
+      position: absolute;
+      bottom: calc(100% + 4px);
+      left: 0;
+      right: 0;
+      background: var(--container-bg, #1e1e2e);
+      border: 1px solid var(--dim);
+      border-radius: 6px;
+      box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);
+      z-index: 200;
+      max-height: 320px;
+      overflow-y: auto;
+    }
+    .pi-chat-skill-header {
+      padding: 8px 10px;
+      font-size: 11px;
+      color: var(--muted);
+      border-bottom: 1px solid var(--dim);
+    }
+    .pi-chat-skill-list { padding: 4px; }
+    .pi-chat-skill-item {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      padding: 6px 8px;
+      border-radius: 3px;
+      cursor: pointer;
+    }
+    .pi-chat-skill-item:hover { background: var(--selected-bg, #3a3a4a); }
+    .pi-chat-skill-name { color: var(--text); font-size: 12px; }
+    .pi-chat-skill-desc { color: var(--muted); font-size: 11px; }
+    .pi-chat-skill-empty {
+      padding: 10px;
+      color: var(--muted);
+      font-size: 11px;
+      text-align: center;
+    }
+    .pi-chat-skill-load {
+      display: block;
+      margin: 0 8px 8px;
+      padding: 6px 10px;
+      background: var(--selected-bg, #3a3a4a);
+      color: var(--text);
+      border: 1px solid var(--dim);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 11px;
+      cursor: pointer;
+    }
+    .pi-chat-skill-load:hover { border-color: var(--muted); }
+
     /* Share overlay */
     .share-overlay-backdrop {
       position: fixed;

--- a/internal/workers/manager.go
+++ b/internal/workers/manager.go
@@ -36,6 +36,22 @@ type ChatWorker interface {
 	Close() error
 }
 
+// SlashCommand is one entry from a worker's command palette — extensions, prompt
+// templates, and skills. Source distinguishes them; the browser filters for
+// skills (source "skill", named "skill:<name>").
+type SlashCommand struct {
+	Name        string `json:"name"`
+	Source      string `json:"source,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// CommandLister is implemented by workers that can report their loaded commands.
+// It is optional (queried via type assertion) so worker fakes need not implement
+// it; the Manager treats a worker without it as having no commands.
+type CommandLister interface {
+	GetCommands(ctx context.Context) ([]SlashCommand, error)
+}
+
 type Factory func(sessionID, sessionPath string) (ChatWorker, error)
 
 type Manager struct {
@@ -178,6 +194,38 @@ func (m *Manager) Abort(ctx context.Context, sessionID string) error {
 func (m *Manager) EnsureWorker(ctx context.Context, sessionID, sessionPath string) error {
 	_, err := m.workerFor(sessionID, sessionPath)
 	return err
+}
+
+// Commands returns the commands loaded by the session's worker, plus whether a
+// worker is (now) running. When none is running it reports ready=false without
+// starting one, unless spawn is true — then it starts the worker on demand
+// first. Used by the composer's /skill listing.
+func (m *Manager) Commands(ctx context.Context, sessionID, sessionPath string, spawn bool) ([]SlashCommand, bool, error) {
+	m.mu.Lock()
+	worker := m.workers[sessionID]
+	m.mu.Unlock()
+	if worker != nil && worker.Status().State == WorkerStateError {
+		worker = nil
+	}
+	if worker == nil {
+		if !spawn {
+			return nil, false, nil
+		}
+		var err error
+		worker, err = m.workerFor(sessionID, sessionPath)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	lister, ok := worker.(CommandLister)
+	if !ok {
+		return nil, true, nil
+	}
+	cmds, err := lister.GetCommands(ctx)
+	if err != nil {
+		return nil, true, err
+	}
+	return cmds, true, nil
 }
 
 func (m *Manager) Close() error {

--- a/internal/workers/manager_test.go
+++ b/internal/workers/manager_test.go
@@ -252,3 +252,53 @@ func TestEnsureWorkerCreatesWorkerWithoutSendingMessage(t *testing.T) {
 		t.Fatalf("status = %q, want idle", status.State)
 	}
 }
+
+type commandWorker struct {
+	fakeChatWorker
+	commands []SlashCommand
+}
+
+func (c *commandWorker) GetCommands(ctx context.Context) ([]SlashCommand, error) {
+	return c.commands, nil
+}
+
+func TestManagerCommandsPeekDoesNotSpawn(t *testing.T) {
+	created := 0
+	manager := NewManager(func(sessionID, sessionPath string) (ChatWorker, error) {
+		created++
+		return &commandWorker{commands: []SlashCommand{{Name: "skill:foo", Source: "skill"}}}, nil
+	})
+	cmds, ready, err := manager.Commands(context.Background(), "a.jsonl", "/tmp/a.jsonl", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ready {
+		t.Fatalf("ready = true, want false when no worker and peek-only")
+	}
+	if len(cmds) != 0 {
+		t.Fatalf("cmds = %v, want empty", cmds)
+	}
+	if created != 0 {
+		t.Fatalf("created = %d, want 0 (peek must not spawn a worker)", created)
+	}
+}
+
+func TestManagerCommandsSpawnsThenPeeks(t *testing.T) {
+	manager := NewManager(func(sessionID, sessionPath string) (ChatWorker, error) {
+		return &commandWorker{commands: []SlashCommand{{Name: "skill:foo", Source: "skill"}}}, nil
+	})
+	cmds, ready, err := manager.Commands(context.Background(), "a.jsonl", "/tmp/a.jsonl", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ready {
+		t.Fatalf("ready = false, want true after spawn")
+	}
+	if len(cmds) != 1 || cmds[0].Name != "skill:foo" {
+		t.Fatalf("cmds = %v, want [skill:foo]", cmds)
+	}
+	cmds2, ready2, err := manager.Commands(context.Background(), "a.jsonl", "/tmp/a.jsonl", false)
+	if err != nil || !ready2 || len(cmds2) != 1 {
+		t.Fatalf("peek after spawn: cmds=%v ready=%v err=%v", cmds2, ready2, err)
+	}
+}

--- a/web/src/session/chat/chat-api.js
+++ b/web/src/session/chat/chat-api.js
@@ -18,6 +18,11 @@ export function listModels({ fetchImpl = fetch } = {}) {
   return fetchImpl('/api/models');
 }
 
+export function getCommands(sessionId, { load = false, fetchImpl = fetch } = {}) {
+  const url = chatUrl('/api/commands', sessionId) + (load ? '&load=1' : '');
+  return fetchImpl(url);
+}
+
 export function setModel(sessionId, { provider, modelId }, { fetchImpl = fetch } = {}) {
   return fetchImpl(chatUrl('/api/set-model', sessionId), {
     method: 'POST',

--- a/web/src/session/chat/chat-api.test.js
+++ b/web/src/session/chat/chat-api.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { cancelChat, chatUrl, getWorkerStatus, listModels, sendChat, setModel, setThinkingLevel } from './chat-api.js';
+import { cancelChat, chatUrl, getCommands, getWorkerStatus, listModels, sendChat, setModel, setThinkingLevel } from './chat-api.js';
 
 describe('chat api helpers', () => {
   it('builds encoded session URLs', () => {
@@ -31,5 +31,13 @@ describe('chat api helpers', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ level: 'medium' })
     });
+  });
+
+  it('peeks commands without load by default and spawns with load', async () => {
+    const fetchImpl = vi.fn(() => Promise.resolve(new Response('{}')));
+    await getCommands('s.jsonl', { fetchImpl });
+    await getCommands('s.jsonl', { load: true, fetchImpl });
+    expect(fetchImpl).toHaveBeenNthCalledWith(1, '/api/commands?id=s.jsonl');
+    expect(fetchImpl).toHaveBeenNthCalledWith(2, '/api/commands?id=s.jsonl&load=1');
   });
 });

--- a/web/src/session/chat/chat-composer-runner.js
+++ b/web/src/session/chat/chat-composer-runner.js
@@ -12,6 +12,7 @@ export function runChatComposer({
   chatSelectors,
   modelSelector,
   thinkingSelector,
+  skillList,
   FormDataImpl = FormData,
   URLSearchParamsImpl = URLSearchParams,
   CustomEventImpl = CustomEvent,
@@ -25,6 +26,7 @@ export function runChatComposer({
   const __piChatSelectors = chatSelectors;
   const __piModelSelector = modelSelector;
   const __piThinkingSelector = thinkingSelector;
+  const __piSkillList = skillList;
   const FormData = FormDataImpl;
   const URLSearchParams = URLSearchParamsImpl;
   const CustomEvent = CustomEventImpl;
@@ -405,6 +407,7 @@ export function runChatComposer({
       textarea.addEventListener('input', () => {
         autoResizeTextarea();
         updateSendEnabled();
+        if (_skillListApi && _skillListApi.maybeShow) _skillListApi.maybeShow(textarea.value);
       });
       // Initial sizing in case the textarea was pre-filled (e.g. browser autofill).
       autoResizeTextarea();
@@ -868,6 +871,7 @@ export function runChatComposer({
 
   let _modelSelectorApi = null;
   let _thinkingSelectorApi = null;
+  let _skillListApi = null;
 
   function initPiChatControls() {
     setupCwdCopy();
@@ -893,6 +897,7 @@ export function runChatComposer({
 
     _modelSelectorApi = loadModelSelector();
     _thinkingSelectorApi = setupThinkingLevelSelector();
+    _skillListApi = loadSkillList();
   }
 
   if (document.readyState === 'loading') {
@@ -915,7 +920,20 @@ export function runChatComposer({
       setKnownModelLabel: (label) => { knownModelLabel = label; },
       getKnownModelLabel: () => knownModelLabel,
       setCurrentModelForThinking: (model) => { currentModelForThinking = model; },
-      setWorkerModelUpdate: (handler) => { onWorkerModelUpdate = handler; }
+      setWorkerModelUpdate: (handler) => { onWorkerModelUpdate = handler; },
+      onOpen: () => { if (_skillListApi && _skillListApi.close) _skillListApi.close(); }
+    });
+  }
+
+  // Skill list (/skill)
+  function loadSkillList() {
+    if (!__piSkillList || typeof __piSkillList.setupSkillList !== 'function') return null;
+    const sessionId = new URLSearchParams(window.location.search).get('id') || (document.getElementById('pi-chat-composer') || {}).dataset?.sessionId || '';
+    return __piSkillList.setupSkillList({
+      documentImpl: document,
+      sessionId,
+      chatApi: __piChatApi,
+      escapeHtml
     });
   }
 

--- a/web/src/session/chat/model-selector.js
+++ b/web/src/session/chat/model-selector.js
@@ -30,7 +30,8 @@ export function setupModelSelector({
   setKnownModelLabel = () => {},
   getKnownModelLabel = () => '',
   setCurrentModelForThinking = () => {},
-  setWorkerModelUpdate = () => {}
+  setWorkerModelUpdate = () => {},
+  onOpen = () => {}
 } = {}) {
   let allModels = [];
   let selectedModel = null;
@@ -57,6 +58,9 @@ export function setupModelSelector({
 
   function openPopup() {
     if (!popup) return;
+    // Dismiss any sibling popup (e.g. the /skill list) — the model button's
+    // click stops propagation, so their outside-click handlers never fire.
+    onOpen();
     popup.style.display = 'flex';
     if (popupSearch) {
       popupSearch.value = '';

--- a/web/src/session/chat/skill-list.js
+++ b/web/src/session/chat/skill-list.js
@@ -1,0 +1,140 @@
+// Skill listing for the chat composer. Typing exactly "/skill" in the message
+// box lists the skills loaded by the session's pi worker — commands the worker
+// reports with source "skill", named "skill:<name>". Picking one inserts its
+// "/skill:<name>" invocation into the composer.
+
+const SKILL_TRIGGER = '/skill';
+export const SKILL_LOAD_BUTTON_ID = 'pi-chat-skill-load';
+
+export function isSkillTrigger(value) {
+  return typeof value === 'string' && value.trim() === SKILL_TRIGGER;
+}
+
+// extractSkills narrows a get_commands list to skills and strips the "skill:"
+// prefix pi uses on their command names for display.
+export function extractSkills(commands) {
+  if (!Array.isArray(commands)) return [];
+  return commands
+    .filter((c) => c && c.source === 'skill')
+    .map((c) => {
+      const name = String(c.name || '');
+      return {
+        name,
+        displayName: name.startsWith('skill:') ? name.slice('skill:'.length) : name,
+        description: String(c.description || ''),
+      };
+    });
+}
+
+export function renderSkillList(skills, { workerReady = true, escapeHtml = String } = {}) {
+  if (!workerReady) {
+    return (
+      '<div class="pi-chat-skill-empty">No skills loaded yet</div>' +
+      `<button type="button" id="${SKILL_LOAD_BUTTON_ID}" class="pi-chat-skill-load">Load skills</button>`
+    );
+  }
+  if (!skills || skills.length === 0) {
+    return '<div class="pi-chat-skill-empty">No skills loaded</div>';
+  }
+  return skills
+    .map((s) => {
+      const desc = s.description
+        ? `<span class="pi-chat-skill-desc">${escapeHtml(s.description)}</span>`
+        : '';
+      return `<div class="pi-chat-skill-item" data-skill="${escapeHtml(s.name || '')}"><span class="pi-chat-skill-name">${escapeHtml(s.displayName)}</span>${desc}</div>`;
+    })
+    .join('');
+}
+
+export function setupSkillList({ documentImpl = document, sessionId, chatApi, escapeHtml = String } = {}) {
+  const popup = documentImpl.getElementById('pi-chat-skill-popup');
+  const list = documentImpl.getElementById('pi-chat-skill-list');
+
+  function close() {
+    if (popup) popup.style.display = 'none';
+  }
+
+  function show(html) {
+    if (!popup || !list) return;
+    list.innerHTML = html;
+    popup.style.display = 'block';
+  }
+
+  // Injecting the popup's DOM while the textarea is focused makes iOS Safari
+  // blur it (dismissing the keyboard and shifting focus). Re-assert focus after
+  // each render; preventScroll stops iOS's jump-to-element scroll.
+  function keepFocus() {
+    const textarea = documentImpl.getElementById('pi-chat-message');
+    if (textarea && documentImpl.activeElement !== textarea && typeof textarea.focus === 'function') {
+      textarea.focus({ preventScroll: true });
+    }
+  }
+
+  // fetchAndRender queries the commands endpoint and renders the result. When
+  // load is true the server spawns the worker first (the "Load skills" button);
+  // otherwise it only peeks at an already-running worker.
+  async function fetchAndRender(load) {
+    if (!chatApi || typeof chatApi.getCommands !== 'function') return;
+    show('<div class="pi-chat-skill-empty">Loading…</div>');
+    keepFocus();
+    try {
+      const res = await chatApi.getCommands(sessionId, { load });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'failed to load skills');
+      show(renderSkillList(extractSkills(data.commands), { workerReady: data.workerReady, escapeHtml }));
+    } catch (_) {
+      show('<div class="pi-chat-skill-empty">Failed to load skills</div>');
+    }
+    keepFocus();
+  }
+
+  // maybeShow opens the list when the composer is exactly "/skill", else hides
+  // it. Returns a promise so callers/tests can await the fetch.
+  function maybeShow(value) {
+    if (!isSkillTrigger(value)) {
+      close();
+      return Promise.resolve();
+    }
+    return fetchAndRender(false);
+  }
+
+  // load spawns the worker on demand and lists its skills.
+  function load() {
+    return fetchAndRender(true);
+  }
+
+  // insertSkill writes the skill's slash invocation into the composer. The name
+  // is already prefixed "skill:", so the invocation is "/skill:<name>".
+  function insertSkill(name) {
+    if (!name) return;
+    const textarea = documentImpl.getElementById('pi-chat-message');
+    if (!textarea) return;
+    textarea.value = `/${name} `;
+    if (typeof textarea.focus === 'function') textarea.focus();
+    if (typeof textarea.dispatchEvent === 'function') {
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    close();
+  }
+
+  documentImpl.addEventListener('click', (e) => {
+    const target = e && e.target;
+    if (target && target.id === SKILL_LOAD_BUTTON_ID) {
+      load();
+      return;
+    }
+    const item = target && typeof target.closest === 'function'
+      ? target.closest('.pi-chat-skill-item')
+      : null;
+    if (item && typeof item.getAttribute === 'function') {
+      insertSkill(item.getAttribute('data-skill'));
+      return;
+    }
+    if (popup && popup.style.display !== 'none') {
+      const textarea = documentImpl.getElementById('pi-chat-message');
+      if (!popup.contains(target) && target !== textarea) close();
+    }
+  });
+
+  return { maybeShow, load, insertSkill, close };
+}

--- a/web/src/session/chat/skill-list.test.js
+++ b/web/src/session/chat/skill-list.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { isSkillTrigger, extractSkills, renderSkillList, setupSkillList, SKILL_LOAD_BUTTON_ID } from './skill-list.js';
+
+describe('isSkillTrigger', () => {
+  it('matches exactly /skill ignoring surrounding whitespace', () => {
+    expect(isSkillTrigger('/skill')).toBe(true);
+    expect(isSkillTrigger('  /skill  ')).toBe(true);
+    expect(isSkillTrigger('/skill foo')).toBe(false);
+    expect(isSkillTrigger('/ski')).toBe(false);
+    expect(isSkillTrigger(null)).toBe(false);
+  });
+});
+
+describe('extractSkills', () => {
+  it('keeps only skill-source commands and strips the skill: prefix', () => {
+    const skills = extractSkills([
+      { name: 'skill:foo', source: 'skill', description: 'Foo' },
+      { name: 'compact', source: 'extension' },
+      { name: 'skill:bar', source: 'skill' },
+    ]);
+    expect(skills).toEqual([
+      { name: 'skill:foo', displayName: 'foo', description: 'Foo' },
+      { name: 'skill:bar', displayName: 'bar', description: '' },
+    ]);
+  });
+
+  it('tolerates non-arrays', () => {
+    expect(extractSkills(null)).toEqual([]);
+  });
+});
+
+describe('renderSkillList', () => {
+  it('shows a Load skills button when the worker is not ready', () => {
+    const html = renderSkillList([], { workerReady: false });
+    expect(html).toContain(SKILL_LOAD_BUTTON_ID);
+    expect(html).toContain('Load skills');
+  });
+
+  it('shows empty state when ready with no skills', () => {
+    expect(renderSkillList([], { workerReady: true })).toContain('No skills loaded');
+  });
+
+  it('renders one item per skill', () => {
+    const html = renderSkillList([{ name: 'skill:foo', displayName: 'foo', description: 'Do foo' }], { workerReady: true });
+    expect(html).toContain('data-skill="skill:foo"');
+    expect(html).toContain('foo');
+    expect(html).toContain('Do foo');
+  });
+});
+
+describe('setupSkillList', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <textarea id="pi-chat-message"></textarea>
+      <div id="pi-chat-skill-popup" style="display:none"><div id="pi-chat-skill-list"></div></div>
+    `;
+  });
+
+  function makeChatApi(payload) {
+    return {
+      getCommands: vi.fn(() => Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }))),
+    };
+  }
+
+  it('shows skills when the value is exactly /skill', async () => {
+    const chatApi = makeChatApi({ commands: [{ name: 'skill:foo', source: 'skill' }], workerReady: true });
+    const api = setupSkillList({ documentImpl: document, sessionId: 's', chatApi });
+    await api.maybeShow('/skill');
+    const popup = document.getElementById('pi-chat-skill-popup');
+    expect(popup.style.display).toBe('block');
+    expect(popup.innerHTML).toContain('data-skill="skill:foo"');
+    expect(chatApi.getCommands).toHaveBeenCalledWith('s', { load: false });
+  });
+
+  it('hides and does not fetch for non-trigger input', async () => {
+    const chatApi = makeChatApi({ commands: [], workerReady: true });
+    const api = setupSkillList({ documentImpl: document, sessionId: 's', chatApi });
+    await api.maybeShow('hello');
+    expect(chatApi.getCommands).not.toHaveBeenCalled();
+    expect(document.getElementById('pi-chat-skill-popup').style.display).toBe('none');
+  });
+
+  it('insertSkill writes the slash invocation and closes', () => {
+    const api = setupSkillList({ documentImpl: document, sessionId: 's', chatApi: makeChatApi({}) });
+    document.getElementById('pi-chat-skill-popup').style.display = 'block';
+    api.insertSkill('skill:foo');
+    expect(document.getElementById('pi-chat-message').value).toBe('/skill:foo ');
+    expect(document.getElementById('pi-chat-skill-popup').style.display).toBe('none');
+  });
+
+  it('load fetches with load:true to spawn the worker', async () => {
+    const chatApi = makeChatApi({ commands: [], workerReady: true });
+    const api = setupSkillList({ documentImpl: document, sessionId: 's', chatApi });
+    await api.load();
+    expect(chatApi.getCommands).toHaveBeenCalledWith('s', { load: true });
+  });
+});

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -22,6 +22,7 @@ import { setupBtwPopup } from './live/btw-popup.js';
 import * as chatSelectors from './chat/chat-selectors.js';
 import * as thinkingSelector from './chat/thinking-selector.js';
 import * as modelSelector from './chat/model-selector.js';
+import * as skillList from './chat/skill-list.js';
 import * as liveReloadRunner from './live/live-reload-runner.js';
 import * as liveScroll from './live/live-scroll.js';
 import * as liveStats from './live/live-stats.js';
@@ -456,6 +457,7 @@ export function runSessionApp({ target = window } = {}) {
     chatSelectors,
     modelSelector,
     thinkingSelector,
+    skillList,
     FormDataImpl: target.FormData,
     URLSearchParamsImpl: target.URLSearchParams,
     CustomEventImpl: target.CustomEvent,


### PR DESCRIPTION
## Summary

Clean, scope-focused redo of #29. Typing exactly `/skill` in the composer lists the skills the session's pi worker has loaded, so the user can pick one and insert its `/skill:<name>` invocation without recalling the exact name.

This time the diff is **/skill only** — none of the unrelated iOS composer fix that I mistakenly bundled into #29 (and that broke CI on `--keyboard-inset`). That work is kept on a separate branch.

## Behavior

- Type exactly `/skill` → popup lists loaded skills (name + description), anchored above the composer like the model picker.
- No worker running yet → a **"Load skills"** button spawns one on demand.
- Click a skill → inserts `/skill:<name> ` into the textarea, ready to send.
- Popup closes on outside-click / when the model picker opens.

## Implementation

- **Backend:** a cached `get_commands` RPC to the `pi --mode rpc` worker, surfaced via `GET /api/commands?id=<session>` (`&load=1` to spawn on demand). The worker capability is an optional interface (`CommandLister`), so existing workers/fakes are unaffected.
- **Frontend:** a `skill-list.js` module wired into the composer runner; popup markup in the chat composer template + scoped CSS.

## Checks

- `go test ./...` ✅ · `go vet ./...` ✅ · `make build` ✅
- Self check ci [workflow](https://github.com/lemotw/pi-web/actions/runs/26867967354) pass ✅
- Unit tests added on both sides (rpc builder, manager peek/spawn, handler, skill-list, chat-api).
- No composer/layout changes, so the e2e/layout suite is untouched.

## Test plan

- [ ] Open a session, type `/skill` → skills listed (or "Load skills" if no worker)
- [ ] Click "Load skills" with no worker → worker spawns, skills appear
- [ ] Click a skill → `/skill:<name> ` inserted into the composer
- [ ] Opening the model picker closes the `/skill` popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)