### PR TITLE
feat(ask): pi-web-native ask_user_question with multi-select

### DIFF
--- a/.pi/extensions/pi-ask.ts
+++ b/.pi/extensions/pi-ask.ts
@@ -1,0 +1,264 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+// pi-ask ships pi-web's own `ask_user_question` tool so the browser question
+// card works without the user installing a third-party extension.
+//
+// It is intentionally active ONLY under pi-web's `pi --mode rpc` worker. In
+// that flow there is no TUI to collect an answer; instead the browser renders
+// the tool call, the user clicks an option, and pi-web sends the choice back as
+// an ordinary chat message (`"Question" = "Answer"`). The tool therefore does
+// not block on a TUI dialog — it records the questions, returns an
+// `awaitingChatReply` result, and tells the model to stop and wait for that
+// follow-up message.
+
+export interface AskQuestionOption {
+  label?: unknown;
+  description?: unknown;
+}
+
+export interface AskQuestion {
+  question?: unknown;
+  header?: unknown;
+  multiSelect?: unknown;
+  options?: unknown;
+}
+
+export interface AskToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  details: { awaitingChatReply: true; questionCount: number };
+}
+
+// pi-web spawns the worker as `pi --mode rpc`. `ctx.hasUI` is true in both
+// interactive and RPC mode, so it cannot distinguish them — argv can.
+export function isRpcMode(argv: string[] = process.argv): boolean {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--mode" || arg === "-mode") {
+      if (argv[i + 1] === "rpc") return true;
+    }
+    if (arg === "--mode=rpc" || arg === "-mode=rpc") return true;
+  }
+  return false;
+}
+
+function questionText(q: AskQuestion, index: number): string {
+  return typeof q?.question === "string" && q.question.trim()
+    ? q.question
+    : `Question ${index + 1}`;
+}
+
+export function buildAwaitingResult(questions: AskQuestion[]): AskToolResult {
+  const list = Array.isArray(questions) ? questions : [];
+  const count = list.length;
+  const summary = list
+    .map((q, i) => `  ${i + 1}. ${questionText(q, i)}`)
+    .join("\n");
+
+  const text =
+    `Presented ${count} question${count === 1 ? "" : "s"} to the user in pi-web. ` +
+    `The question card is shown inline in the conversation (there is no sidebar, ` +
+    `panel, or popup) — do not describe a UI location or invent one.\n` +
+    `Stop now and wait for the user's reply. It arrives as the next user ` +
+    `message formatted as "Question" = "Answer" (multi-select answers are ` +
+    `comma-separated). Keep any acknowledgement brief; do not answer on the ` +
+    `user's behalf or call this tool again until they respond.` +
+    (summary ? `\n\nQuestions awaiting an answer:\n${summary}` : "");
+
+  return {
+    content: [{ type: "text", text }],
+    details: { awaitingChatReply: true, questionCount: count },
+  };
+}
+
+// ── pi_web_ tool preference ─────────────────────────────────────────────
+// pi-web ships its tools under a `pi_web_` prefix to avoid name clashes with
+// third-party providers (e.g. ghoseb/pi-askuserquestion's `ask_user_question`).
+// Those bare-named providers generally crash in pi-web's headless RPC worker
+// (they rely on `ctx.ui.custom()`, which returns undefined in RPC mode). So when
+// a tool exists under both `X` and `pi_web_X`, we steer the model to the
+// `pi_web_` one: a soft system-prompt nudge plus a hard tool_call redirect.
+
+export const PI_WEB_PREFIX = "pi_web_";
+
+// Tools this extension registers — always treated as the canonical twin even if
+// `selectedTools` is unavailable on the first turn.
+export const OWN_PI_WEB_TOOLS = ["pi_web_ask_user_question"];
+
+// `selectedTools` may be an array of names or of tool-definition objects.
+export function extractToolNames(selectedTools: unknown): string[] {
+  if (!Array.isArray(selectedTools)) return [];
+  const names: string[] = [];
+  for (const t of selectedTools) {
+    if (typeof t === "string") {
+      names.push(t);
+    } else if (t && typeof t === "object") {
+      const n =
+        (t as { name?: unknown }).name ??
+        (t as { toolName?: unknown }).toolName ??
+        (t as { id?: unknown }).id;
+      if (typeof n === "string") names.push(n);
+    }
+  }
+  return names;
+}
+
+// Bare tool names X for which a `pi_web_X` twin is also active.
+export function findPiWebOverlaps(
+  activeNames: string[],
+  ownTools: string[] = OWN_PI_WEB_TOOLS,
+): string[] {
+  const twins = new Set<string>(ownTools);
+  for (const n of activeNames) {
+    if (n.startsWith(PI_WEB_PREFIX)) twins.add(n);
+  }
+  const overlaps: string[] = [];
+  for (const n of new Set(activeNames)) {
+    if (n.startsWith(PI_WEB_PREFIX)) continue;
+    if (twins.has(`${PI_WEB_PREFIX}${n}`)) overlaps.push(n);
+  }
+  return overlaps;
+}
+
+export function buildSteeringNote(overlaps: string[]): string {
+  const pairs = overlaps
+    .map((n) => `"${n}" -> "${PI_WEB_PREFIX}${n}"`)
+    .join(", ");
+  return (
+    `pi-web tool preference: this session runs inside pi-web. When a tool is ` +
+    `available under both a bare name and a "${PI_WEB_PREFIX}"-prefixed name, ` +
+    `always call the "${PI_WEB_PREFIX}"-prefixed one — the bare equivalents are ` +
+    `not supported here and will fail. Affected tools: ${pairs}.`
+  );
+}
+
+// If `toolName` is a bare name whose `pi_web_` twin is registered/active, return
+// that twin so the caller can redirect; otherwise null.
+export function redirectTwin(
+  toolName: unknown,
+  piWebTools: Set<string>,
+): string | null {
+  if (typeof toolName !== "string" || toolName.startsWith(PI_WEB_PREFIX)) {
+    return null;
+  }
+  const twin = `${PI_WEB_PREFIX}${toolName}`;
+  return piWebTools.has(twin) ? twin : null;
+}
+
+export default function (pi: ExtensionAPI) {
+  // Only pi-web's RPC worker can route answers back through the browser. In
+  // interactive/print/JSON modes this tool would have no way to be answered, so
+  // we don't register it and leave that mode to a real interactive provider.
+  if (!isRpcMode()) return;
+
+  // Named with the pi-web prefix (like pi_web_set_tab_title) so it never
+  // collides with a separately-installed `ask_user_question` provider such as
+  // ghoseb/pi-askuserquestion — a name clash makes pi refuse to load both.
+  pi.registerTool({
+    name: "pi_web_ask_user_question",
+    label: "Ask User Question",
+    description:
+      "Ask the user one or more structured multiple-choice questions when you " +
+      "need a decision before proceeding. The questions are shown in pi-web; " +
+      "the user picks options in the browser and their answer returns as a " +
+      "follow-up chat message. Prefer this over guessing when the user's intent " +
+      "is ambiguous and a small set of options would resolve it.",
+    promptSnippet:
+      "Use pi_web_ask_user_question to ask the user structured multiple-choice " +
+      "questions, then stop and wait for their reply.",
+    promptGuidelines: [
+      "Call pi_web_ask_user_question when a decision is ambiguous and 2-4 concrete options would resolve it, instead of guessing.",
+      "Keep each option label short; put rationale in the option description.",
+      "After calling pi_web_ask_user_question, stop and wait — the user's answer arrives as the next message.",
+    ],
+    parameters: Type.Object({
+      questions: Type.Array(
+        Type.Object({
+          question: Type.String({
+            description: "Full question text shown to the user.",
+          }),
+          header: Type.Optional(
+            Type.String({
+              description: "Short tab label for this question (max 12 chars).",
+            }),
+          ),
+          multiSelect: Type.Optional(
+            Type.Boolean({
+              description:
+                "true = the user may select multiple options; false = single choice.",
+            }),
+          ),
+          options: Type.Array(
+            Type.Object({
+              label: Type.String({
+                description: "The answer value returned when chosen.",
+              }),
+              description: Type.Optional(
+                Type.String({
+                  description: "Optional hint shown beneath the label.",
+                }),
+              ),
+            }),
+            {
+              minItems: 2,
+              maxItems: 4,
+              description: "2-4 answer options.",
+            },
+          ),
+        }),
+        {
+          minItems: 1,
+          maxItems: 4,
+          description: "1-4 questions to ask the user.",
+        },
+      ),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      const questions = Array.isArray((params as { questions?: unknown })?.questions)
+        ? ((params as { questions: AskQuestion[] }).questions)
+        : [];
+      return buildAwaitingResult(questions);
+    },
+  });
+
+  // Names active in the current prompt, refreshed each turn. Seeded with our own
+  // tool so the tool_call guard works even before the first before_agent_start.
+  let activePiWebTools = new Set<string>(OWN_PI_WEB_TOOLS);
+
+  // Soft nudge: when a bare/`pi_web_` overlap exists, tell the model to prefer
+  // the prefixed tool. Also refreshes the active-tool set for the guard below.
+  pi.on("before_agent_start", async (event) => {
+    const active = extractToolNames(
+      (event as { systemPromptOptions?: { selectedTools?: unknown } })
+        ?.systemPromptOptions?.selectedTools,
+    );
+    activePiWebTools = new Set<string>(OWN_PI_WEB_TOOLS);
+    for (const n of active) {
+      if (n.startsWith(PI_WEB_PREFIX)) activePiWebTools.add(n);
+    }
+
+    const overlaps = findPiWebOverlaps(active);
+    if (overlaps.length === 0) return undefined;
+    const basePrompt =
+      typeof (event as { systemPrompt?: unknown }).systemPrompt === "string"
+        ? (event as { systemPrompt: string }).systemPrompt
+        : "";
+    return { systemPrompt: `${basePrompt}\n\n${buildSteeringNote(overlaps)}` };
+  });
+
+  // Hard redirect: if the model calls a bare tool whose `pi_web_` twin exists,
+  // block it before it executes (preventing the third-party tool's RPC crash)
+  // and point the model at the supported tool.
+  pi.on("tool_call", async (event) => {
+    const name = (event as { toolName?: unknown }).toolName;
+    const twin = redirectTwin(name, activePiWebTools);
+    if (!twin) return undefined;
+    return {
+      block: true,
+      reason:
+        `pi-web ships its own "${twin}" — call that instead of "${String(name)}". ` +
+        `The bare "${String(name)}" tool is not supported in pi-web sessions ` +
+        `and fails in the headless RPC worker.`,
+    };
+  });
+}

--- a/internal/ui/ask_user_question_render_test.go
+++ b/internal/ui/ask_user_question_render_test.go
@@ -8,6 +8,7 @@ import (
 func TestAskUserQuestionToolHasDedicatedRenderer(t *testing.T) {
 	checks := []string{
 		"case 'ask_user_question':",
+		"case 'pi_web_ask_user_question':",
 		"renderAskUserQuestionTool(args, result)",
 		"ask-question-card",
 		"ask-question-option",
@@ -19,11 +20,37 @@ func TestAskUserQuestionToolHasDedicatedRenderer(t *testing.T) {
 	}
 }
 
+func TestAskUserQuestionHonorsMultiSelect(t *testing.T) {
+	checks := []string{
+		"const anyMultiSelect = questions.some(q => q && q.multiSelect === true);",
+		"const needsSubmit = isMulti || anyMultiSelect;",
+		"data-needs-submit=",
+		"data-multi-select=",
+	}
+	for _, check := range checks {
+		if !strings.Contains(exportJs, check) {
+			t.Fatalf("missing %q; multi-select questions must be answerable via collect-then-submit", check)
+		}
+	}
+}
+
+func TestAskUserQuestionAwaitingChatReplyStaysClickable(t *testing.T) {
+	checks := []string{
+		"const awaitingChatReply = result?.details?.awaitingChatReply === true;",
+		"|| awaitingChatReply",
+	}
+	for _, check := range checks {
+		if !strings.Contains(exportJs, check) {
+			t.Fatalf("missing %q; pi-ask awaitingChatReply results must render as pending/clickable, not answered", check)
+		}
+	}
+}
+
 func TestErroredAskUserQuestionKeepsFallbackOptionsClickable(t *testing.T) {
 	checks := []string{
 		"const questionToolFailed = result?.isError === true;",
 		"question UI failed",
-		"const canClick = !result || questionToolFailed;",
+		"const canClick = !result || questionToolFailed || awaitingChatReply;",
 		"Use these options as a fallback",
 	}
 	for _, check := range checks {

--- a/internal/ui/live_templates/export/app/50-render-entry.js
+++ b/internal/ui/live_templates/export/app/50-render-entry.js
@@ -111,17 +111,22 @@ function renderAskUserQuestionTool(args, result) {
   const questions = Array.isArray(args.questions) ? args.questions : [];
   const answers = result?.details?.answers || {};
   const cancelled = result?.details?.cancelled === true;
+  const awaitingChatReply = result?.details?.awaitingChatReply === true;
   const questionToolFailed = result?.isError === true;
-  const canClick = !result || questionToolFailed;
+  const canClick = !result || questionToolFailed || awaitingChatReply;
   const isInteractive = canClick || cancelled;
   const isMulti = questions.length > 1;
+  const anyMultiSelect = questions.some(q => q && q.multiSelect === true);
+  const needsSubmit = isMulti || anyMultiSelect;
 
-  let html = `<div class="ask-question-card" data-question-count="${questions.length}">`;
+  let html = `<div class="ask-question-card" data-question-count="${questions.length}" data-needs-submit="${needsSubmit}">`;
   html += '<div class="ask-question-title">Question for you</div>';
   if (questionToolFailed) {
     html += '<div class="ask-question-state error">question UI failed</div>';
   } else if (cancelled) {
     html += '<div class="ask-question-state error">cancelled</div>';
+  } else if (awaitingChatReply) {
+    html += '<div class="ask-question-state pending">waiting for response</div>';
   } else if (result) {
     html += '<div class="ask-question-state answered">answered</div>';
   } else {
@@ -136,7 +141,8 @@ function renderAskUserQuestionTool(args, result) {
     const questionText = typeof q.question === 'string' ? q.question : `Question ${qIndex + 1}`;
     const answer = answers[questionText];
     const options = Array.isArray(q.options) ? q.options : [];
-    html += `<div class="ask-question-block" data-question-text="${escapeHtml(questionText)}">`;
+    const multiSelect = q && q.multiSelect === true;
+    html += `<div class="ask-question-block" data-question-text="${escapeHtml(questionText)}" data-multi-select="${multiSelect}">`;
     if (q.header) html += `<div class="ask-question-header">${escapeHtml(String(q.header))}</div>`;
     html += `<div class="ask-question-text">${escapeHtml(questionText)}</div>`;
     if (options.length > 0) {
@@ -162,14 +168,14 @@ function renderAskUserQuestionTool(args, result) {
   });
 
   if (isInteractive) {
-    if (isMulti) {
+    if (needsSubmit) {
       html += '<div class="ask-question-actions" style="display:none"><button type="button" class="ask-question-submit-btn">Send answers</button></div>';
     } else if (questionToolFailed) {
       html += '<div class="ask-question-hint">Use these options as a fallback — click an option to send your answer to pi.</div>';
     } else if (cancelled) {
       html += '<div class="ask-question-hint">Click an option to send your answer to pi.</div>';
-    } else if (!result) {
-      html += '<div class="ask-question-hint">Use the chat composer below to answer this question.</div>';
+    } else if (!result || awaitingChatReply) {
+      html += '<div class="ask-question-hint">Click an option, or use the chat composer below, to answer this question.</div>';
     }
   }
 
@@ -298,7 +304,8 @@ function renderToolCall(call) {
       }
       break;
     }
-    case 'ask_user_question': {
+    case 'ask_user_question':
+    case 'pi_web_ask_user_question': {
       html += renderAskUserQuestionTool(args, result);
       break;
     }

--- a/tests/extensions/pi-ask.test.ts
+++ b/tests/extensions/pi-ask.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isRpcMode,
+  buildAwaitingResult,
+  extractToolNames,
+  findPiWebOverlaps,
+  buildSteeringNote,
+  redirectTwin,
+  OWN_PI_WEB_TOOLS,
+} from '../../.pi/extensions/pi-ask.ts';
+
+describe('isRpcMode', () => {
+  it('detects `--mode rpc`', () => {
+    expect(isRpcMode(['pi', '--mode', 'rpc'])).toBe(true);
+  });
+
+  it('detects `--mode=rpc`', () => {
+    expect(isRpcMode(['pi', '--mode=rpc'])).toBe(true);
+  });
+
+  it('is false for interactive (no mode flag)', () => {
+    expect(isRpcMode(['pi'])).toBe(false);
+  });
+
+  it('is false for other modes', () => {
+    expect(isRpcMode(['pi', '--mode', 'json'])).toBe(false);
+    expect(isRpcMode(['pi', '-p'])).toBe(false);
+  });
+
+  it('does not treat an `rpc` value of an unrelated flag as rpc mode', () => {
+    expect(isRpcMode(['pi', '--name', 'rpc'])).toBe(false);
+  });
+});
+
+describe('buildAwaitingResult', () => {
+  it('marks the result as awaiting a chat reply with the question count', () => {
+    const result = buildAwaitingResult([
+      { question: 'Pick a color', options: [{ label: 'Red' }, { label: 'Blue' }] },
+      { question: 'Pick a size', options: [{ label: 'S' }, { label: 'L' }] },
+    ]);
+    expect(result.details.awaitingChatReply).toBe(true);
+    expect(result.details.questionCount).toBe(2);
+    expect(result.content[0].type).toBe('text');
+  });
+
+  it('tells the model to stop and wait for the user message', () => {
+    const text = buildAwaitingResult([{ question: 'Proceed?', options: [] }]).content[0].text;
+    expect(text).toContain('Stop now');
+    expect(text).toContain('"Question" = "Answer"');
+    expect(text).toContain('Proceed?');
+  });
+
+  it('handles a missing/blank question with a positional fallback', () => {
+    const text = buildAwaitingResult([{ options: [] }]).content[0].text;
+    expect(text).toContain('Question 1');
+  });
+
+  it('tolerates non-array input', () => {
+    const result = buildAwaitingResult(undefined as unknown as []);
+    expect(result.details.questionCount).toBe(0);
+  });
+});
+
+describe('extractToolNames', () => {
+  it('reads an array of name strings', () => {
+    expect(extractToolNames(['bash', 'ask_user_question'])).toEqual([
+      'bash',
+      'ask_user_question',
+    ]);
+  });
+
+  it('reads tool-definition objects (name/toolName/id)', () => {
+    expect(
+      extractToolNames([{ name: 'bash' }, { toolName: 'read' }, { id: 'write' }]),
+    ).toEqual(['bash', 'read', 'write']);
+  });
+
+  it('returns [] for non-arrays', () => {
+    expect(extractToolNames(undefined)).toEqual([]);
+    expect(extractToolNames(null)).toEqual([]);
+    expect(extractToolNames('bash')).toEqual([]);
+  });
+});
+
+describe('findPiWebOverlaps', () => {
+  it('finds bare names whose pi_web_ twin is also active', () => {
+    const overlaps = findPiWebOverlaps([
+      'ask_user_question',
+      'pi_web_ask_user_question',
+      'bash',
+    ]);
+    expect(overlaps).toEqual(['ask_user_question']);
+  });
+
+  it('treats our own registered tools as twins even if not in the active list', () => {
+    // ghoseb's bare tool active, but pi_web twin only known via OWN_PI_WEB_TOOLS
+    expect(findPiWebOverlaps(['ask_user_question'])).toEqual([
+      'ask_user_question',
+    ]);
+    expect(OWN_PI_WEB_TOOLS).toContain('pi_web_ask_user_question');
+  });
+
+  it('returns [] when there is no overlap', () => {
+    expect(findPiWebOverlaps(['bash', 'read', 'pi_web_set_tab_title'])).toEqual([]);
+  });
+});
+
+describe('buildSteeringNote', () => {
+  it('names the affected tools and directs to the prefixed twin', () => {
+    const note = buildSteeringNote(['ask_user_question']);
+    expect(note).toContain('"ask_user_question" -> "pi_web_ask_user_question"');
+    expect(note).toContain('not supported');
+  });
+});
+
+describe('redirectTwin', () => {
+  const tools = new Set(['pi_web_ask_user_question']);
+
+  it('redirects a bare call whose twin is registered', () => {
+    expect(redirectTwin('ask_user_question', tools)).toBe('pi_web_ask_user_question');
+  });
+
+  it('does not redirect the prefixed tool itself', () => {
+    expect(redirectTwin('pi_web_ask_user_question', tools)).toBeNull();
+  });
+
+  it('does not redirect tools without a registered twin', () => {
+    expect(redirectTwin('bash', tools)).toBeNull();
+  });
+
+  it('tolerates non-string input', () => {
+    expect(redirectTwin(undefined, tools)).toBeNull();
+  });
+});

--- a/web/src/session/chat/chat-composer-runner.js
+++ b/web/src/session/chat/chat-composer-runner.js
@@ -673,8 +673,10 @@ export function runChatComposer({
         const parts = [];
         card.querySelectorAll('.ask-question-block').forEach(block => {
           const questionText = block.dataset.questionText || '';
-          const sel = block.querySelector('.ask-question-option-action.selected');
-          if (sel && questionText) parts.push(`"${questionText}" = "${sel.dataset.answer || ''}"`);
+          const answers = Array.from(block.querySelectorAll('.ask-question-option-action.selected'))
+            .map(el => el.dataset.answer || '')
+            .filter(Boolean);
+          if (answers.length && questionText) parts.push(`"${questionText}" = "${answers.join(', ')}"`);
         });
         if (parts.length === 0) return;
         card.querySelectorAll('.ask-question-option-action').forEach(b => { b.disabled = true; });
@@ -694,10 +696,10 @@ export function runChatComposer({
 
       const card = option.closest('.ask-question-card');
       const block = option.closest('.ask-question-block');
-      const questionCount = parseInt(card?.dataset.questionCount || '1', 10);
+      const needsSubmit = card?.dataset.needsSubmit === 'true';
 
-      if (questionCount === 1) {
-        // Single question: send immediately
+      if (!needsSubmit) {
+        // Single, single-select question: send immediately
         const question = option.dataset.question || 'Question';
         const answer = option.dataset.answer || option.textContent.trim();
         option.disabled = true;
@@ -706,10 +708,14 @@ export function runChatComposer({
         return;
       }
 
-      // Multi-question: mark selection, show submit button
+      // Collect-then-submit: toggle selection, then reveal the submit button
       if (block) {
-        block.querySelectorAll('.ask-question-option-action').forEach(b => b.classList.remove('selected'));
-        option.classList.add('selected');
+        if (block.dataset.multiSelect === 'true') {
+          option.classList.toggle('selected');
+        } else {
+          block.querySelectorAll('.ask-question-option-action').forEach(b => b.classList.remove('selected'));
+          option.classList.add('selected');
+        }
       }
       const actions = card?.querySelector('.ask-question-actions');
       if (actions) actions.style.display = '';

--- a/web/src/session/live/live-renderer.js
+++ b/web/src/session/live/live-renderer.js
@@ -131,20 +131,25 @@ export function createLiveRenderer({ documentImpl = document, markedImpl = marke
         var out = getResultText().trim();
         if (out) html += renderToolOutput(out);
       }
-    } else if (call.name === 'ask_user_question') {
+    } else if (call.name === 'ask_user_question' || call.name === 'pi_web_ask_user_question') {
       var questions = Array.isArray(args.questions) ? args.questions : [];
       var qaAnswers = result && result.details && result.details.answers ? result.details.answers : {};
       var qaCancelled = result && result.details && result.details.cancelled === true;
+      var qaAwaitingReply = !!(result && result.details && result.details.awaitingChatReply === true);
       var qaFailed = !!(result && result.isError);
-      var qaInteractive = !result || qaFailed || qaCancelled;
+      var qaInteractive = !result || qaFailed || qaCancelled || qaAwaitingReply;
       var qaMulti = questions.length > 1;
+      var qaAnyMultiSelect = questions.some(function(q){ return q && q.multiSelect === true; });
+      var qaNeedsSubmit = qaMulti || qaAnyMultiSelect;
       html = '<div class="tool-execution '+status+'">';
-      html += '<div class="ask-question-card" data-question-count="'+questions.length+'">';
+      html += '<div class="ask-question-card" data-question-count="'+questions.length+'" data-needs-submit="'+qaNeedsSubmit+'">';
       html += '<div class="ask-question-title">Question for you</div>';
       if (qaFailed) {
         html += '<div class="ask-question-state error">question UI failed</div>';
       } else if (qaCancelled) {
         html += '<div class="ask-question-state error">cancelled</div>';
+      } else if (qaAwaitingReply) {
+        html += '<div class="ask-question-state pending">waiting for response</div>';
       } else if (result) {
         html += '<div class="ask-question-state answered">answered</div>';
       } else {
@@ -154,7 +159,8 @@ export function createLiveRenderer({ documentImpl = document, markedImpl = marke
         var questionText = typeof q.question === 'string' ? q.question : 'Question '+(qi+1);
         var answer = qaAnswers[questionText];
         var options = Array.isArray(q.options) ? q.options : [];
-        html += '<div class="ask-question-block" data-question-text="'+escapeHtml(questionText)+'">';
+        var multiSelect = q && q.multiSelect === true;
+        html += '<div class="ask-question-block" data-question-text="'+escapeHtml(questionText)+'" data-multi-select="'+multiSelect+'">';
         if (q.header) html += '<div class="ask-question-header">'+escapeHtml(String(q.header))+'</div>';
         html += '<div class="ask-question-text">'+escapeHtml(questionText)+'</div>';
         if (options.length > 0) {
@@ -177,12 +183,12 @@ export function createLiveRenderer({ documentImpl = document, markedImpl = marke
         html += '</div>';
       });
       if (qaInteractive) {
-        if (qaMulti) {
+        if (qaNeedsSubmit) {
           html += '<div class="ask-question-actions" style="display:none"><button type="button" class="ask-question-submit-btn">Send answers</button></div>';
         } else if (qaFailed || qaCancelled) {
           html += '<div class="ask-question-hint">Click an option to send your answer to pi.</div>';
         } else {
-          html += '<div class="ask-question-hint">Use the chat composer below to answer this question.</div>';
+          html += '<div class="ask-question-hint">Click an option, or use the chat composer below, to answer this question.</div>';
         }
       }
       html += '</div>';

--- a/web/src/session/render/session-entry-renderer.js
+++ b/web/src/session/render/session-entry-renderer.js
@@ -136,17 +136,22 @@ export function createSessionEntryRenderer({
     const questions = Array.isArray(args.questions) ? args.questions : [];
     const answers = result?.details?.answers || {};
     const cancelled = result?.details?.cancelled === true;
+    const awaitingChatReply = result?.details?.awaitingChatReply === true;
     const questionToolFailed = result?.isError === true;
-    const canClick = !result || questionToolFailed;
+    const canClick = !result || questionToolFailed || awaitingChatReply;
     const isInteractive = canClick || cancelled;
     const isMulti = questions.length > 1;
+    const anyMultiSelect = questions.some(q => q && q.multiSelect === true);
+    const needsSubmit = isMulti || anyMultiSelect;
 
-    let html = `<div class="ask-question-card" data-question-count="${questions.length}">`;
+    let html = `<div class="ask-question-card" data-question-count="${questions.length}" data-needs-submit="${needsSubmit}">`;
     html += '<div class="ask-question-title">Question for you</div>';
     if (questionToolFailed) {
       html += '<div class="ask-question-state error">question UI failed</div>';
     } else if (cancelled) {
       html += '<div class="ask-question-state error">cancelled</div>';
+    } else if (awaitingChatReply) {
+      html += '<div class="ask-question-state pending">waiting for response</div>';
     } else if (result) {
       html += '<div class="ask-question-state answered">answered</div>';
     } else {
@@ -161,7 +166,8 @@ export function createSessionEntryRenderer({
       const questionText = typeof q.question === 'string' ? q.question : `Question ${qIndex + 1}`;
       const answer = answers[questionText];
       const options = Array.isArray(q.options) ? q.options : [];
-      html += `<div class="ask-question-block" data-question-text="${escapeHtml(questionText)}">`;
+      const multiSelect = q && q.multiSelect === true;
+      html += `<div class="ask-question-block" data-question-text="${escapeHtml(questionText)}" data-multi-select="${multiSelect}">`;
       if (q.header) html += `<div class="ask-question-header">${escapeHtml(String(q.header))}</div>`;
       html += `<div class="ask-question-text">${escapeHtml(questionText)}</div>`;
       if (options.length > 0) {
@@ -187,14 +193,14 @@ export function createSessionEntryRenderer({
     });
 
     if (isInteractive) {
-      if (isMulti) {
+      if (needsSubmit) {
         html += '<div class="ask-question-actions" style="display:none"><button type="button" class="ask-question-submit-btn">Send answers</button></div>';
       } else if (questionToolFailed) {
         html += '<div class="ask-question-hint">Use these options as a fallback — click an option to send your answer to pi.</div>';
       } else if (cancelled) {
         html += '<div class="ask-question-hint">Click an option to send your answer to pi.</div>';
-      } else if (!result) {
-        html += '<div class="ask-question-hint">Use the chat composer below to answer this question.</div>';
+      } else if (!result || awaitingChatReply) {
+        html += '<div class="ask-question-hint">Click an option, or use the chat composer below, to answer this question.</div>';
       }
     }
 
@@ -323,7 +329,8 @@ export function createSessionEntryRenderer({
         }
         break;
       }
-      case 'ask_user_question': {
+      case 'ask_user_question':
+      case 'pi_web_ask_user_question': {
         html += renderAskUserQuestionTool(args, result);
         break;
       }


### PR DESCRIPTION
## Summary

pi-web previously relied on a third-party `ask_user_question` provider that
crashes in the headless RPC worker (it calls `ctx.ui.custom()`, which returns
`undefined` in RPC mode). This PR makes the interactive question card a
first-class, self-contained pi-web feature.

- Add a bundled `pi-ask` extension (`.pi/extensions/pi-ask.ts`) that registers
  `pi_web_ask_user_question`. In RPC mode it records the questions and returns a
  `details.awaitingChatReply` result telling the model to stop and wait; the
  browser collects the answer and sends it back through the normal chat flow.
- Honor each question's `multiSelect` flag in the card (checkbox toggling +
  collect-then-submit) instead of inferring single/multi from question count.
- Render `awaitingChatReply` results as pending/clickable so the click-to-chat
  answer flow works; recognize both `ask_user_question` and
  `pi_web_ask_user_question` tool names.
- Steer the model to the `pi_web_` prefix via a `before_agent_start`
  system-prompt nudge plus a `tool_call` hard-redirect, so a separately
  installed bare `ask_user_question` is blocked before it can crash.

## Related issue

Closes #

## Type of change

- [x] `feat` — new feature

## Live vs. Export

- [x] Considered both the live app and the export snapshot
- [x] Kept `internal/ui/live_templates/` in sync with `web/src/session/` changes
- [x] No live-only chrome (Vite scripts, active composer, SSE/API) leaked into export

## Testing

- [x] `make check` passes (test + build + vet)
- [x] Frontend tests (`vitest`) cover the change
- [x] Go tests (`go test ./...`) cover the change
- [x] UI changes verified in a browser
