### PR TITLE
feat(pwa): badge app icon on session completion

### DIFF
--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -40,4 +40,57 @@ test.describe("settings page", () => {
 
     await expect(page.locator(SPINNER)).toHaveValue(next);
   });
+
+  // Alignment: all form controls in the settings control column must share the
+  // same rendered width so the column has consistent left and right edges.
+  test("form controls share a uniform width", async ({ page }, testInfo) => {
+    // Run only on Desktop Chrome — layout is visual, browser-independent, and
+    // a single representative viewport (1280×720) is enough.
+    test.skip(
+      testInfo.project.name !== "Desktop Chrome",
+      "visual alignment check runs on one project",
+    );
+
+    await page.goto("/settings");
+    await expect(page.locator(LAYOUT)).toBeVisible();
+
+    // Collect bounding-box widths of every select, number, and time input that
+    // sits inside a .settings-control.
+    const widths: number[] = await page.evaluate(() => {
+      const controls = document.querySelectorAll<HTMLElement>(
+        ".settings-control select, .settings-control input[type='number'], .settings-control input[type='time']",
+      );
+      return Array.from(controls).map((el) =>
+        Math.round(el.getBoundingClientRect().width),
+      );
+    });
+
+    expect(widths.length).toBeGreaterThan(0);
+
+    // All controls must be the same width (uniform column).
+    const first = widths[0];
+    for (const w of widths) {
+      expect(w).toBe(first);
+    }
+  });
+
+  // Alignment: on narrow viewports (≤560px) rows must stack vertically so the
+  // label and control don't compete for horizontal space.
+  test("rows stack vertically on narrow viewports", async ({ page }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "Desktop Chrome",
+      "responsive stacking check runs on one project",
+    );
+
+    await page.setViewportSize({ width: 400, height: 800 });
+    await page.goto("/settings");
+    await expect(page.locator(LAYOUT)).toBeVisible();
+
+    const flexDirection = await page.evaluate(() => {
+      const row = document.querySelector<HTMLElement>(".settings-row");
+      return row ? getComputedStyle(row).flexDirection : null;
+    });
+
+    expect(flexDirection).toBe("column");
+  });
 });

--- a/e2e/tests/version.spec.ts
+++ b/e2e/tests/version.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "../lib/test";
+
+// The "Check for updates" affordance must not flash: while a check is in
+// flight the button itself shows an inline spinner + "Checking…", and the
+// separate status row stays hidden so the modal layout never jumps.
+test.describe("version modal update check", () => {
+  test("shows an inline loading state without a layout-jumping status row", async ({
+    page,
+  }, testInfo) => {
+    // Timing/visual behavior is browser-independent — run on one project.
+    test.skip(
+      testInfo.project.name !== "Desktop Chrome",
+      "loading-state check runs on one project",
+    );
+
+    // Control the check timing and avoid a real GitHub round-trip: hold the
+    // response open long enough to observe the in-flight state, then resolve
+    // as "up to date".
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.route("**/api/check-update", async (route) => {
+      await gate;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          current: "1.0.0",
+          latest: "1.0.0",
+          hasUpdate: false,
+          checkedAt: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await page.goto("/");
+
+    // Open the index menu and the version modal.
+    await page.locator("#web-menu-btn").click();
+    await page.locator("#index-version-row").click();
+
+    const overlay = page.locator(".version-modal-overlay.open");
+    await expect(overlay).toBeVisible();
+
+    const checkBtn = overlay.locator(".version-modal-btn", {
+      hasText: "Check for updates",
+    });
+    await expect(checkBtn).toBeVisible();
+
+    // Click the check; the response is gated, so we're now in the in-flight state.
+    await checkBtn.click();
+
+    const loadingBtn = overlay.locator(".version-modal-btn.is-loading");
+    await expect(loadingBtn).toHaveText("Checking…");
+    await expect(loadingBtn).toBeDisabled();
+
+    // The status row must NOT appear — that pop-in/out is the layout jump we removed.
+    await expect(overlay.locator(".version-modal-status")).toBeHidden();
+
+    // Let the check resolve; the modal settles into the up-to-date view.
+    release();
+
+    await expect(overlay.locator(".version-modal-body")).toContainText(
+      "latest version",
+    );
+    await expect(overlay.locator(".version-modal-btn.is-loading")).toHaveCount(0);
+  });
+});

--- a/e2e/tests/version.spec.ts
+++ b/e2e/tests/version.spec.ts
@@ -13,6 +13,26 @@ test.describe("version modal update check", () => {
       "loading-state check runs on one project",
     );
 
+    // Pin the initial version state to "up to date" so the modal deterministically
+    // opens on the "Check for updates" affordance. Without this the state depends
+    // on the binary's build version and a background update check (in CI the
+    // binary is stamped with a bare commit SHA, which isn't treated as a dev
+    // build, so the poller reports an update and the modal shows "Update &
+    // Restart" instead).
+    await page.route("**/api/version", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          current: "1.0.0",
+          latest: "1.0.0",
+          hasUpdate: false,
+          isDev: false,
+          checkedAt: new Date().toISOString(),
+        }),
+      });
+    });
+
     // Control the check timing and avoid a real GitHub round-trip: hold the
     // response open long enough to observe the in-flight state, then resolve
     // as "up to date".

--- a/internal/ui/live_templates/assets/sw.js
+++ b/internal/ui/live_templates/assets/sw.js
@@ -53,6 +53,14 @@ self.addEventListener('push', (event) => {
       // Phones play their default notification sound when this fires.
       silent: false,
     };
+    // Badge the app icon so the user notices even after the banner is gone.
+    // Cleared when the app is opened/focused (notificationclick + page
+    // visibility handler). No-op where the Badging API is unsupported.
+    try {
+      if (self.navigator && self.navigator.setAppBadge) {
+        await self.navigator.setAppBadge(1);
+      }
+    } catch (_) {}
     await self.registration.showNotification(title, options);
   })());
 });
@@ -62,6 +70,11 @@ self.addEventListener('notificationclick', (event) => {
   const sessionId = event.notification.data && event.notification.data.sessionId;
   const target = sessionId ? `/session?id=${encodeURIComponent(sessionId)}` : '/';
   event.waitUntil((async () => {
+    try {
+      if (self.navigator && self.navigator.clearAppBadge) {
+        await self.navigator.clearAppBadge();
+      }
+    } catch (_) {}
     const all = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
     for (const client of all) {
       if (client.url.includes(target) && 'focus' in client) {

--- a/internal/ui/live_templates/styles/menu.css
+++ b/internal/ui/live_templates/styles/menu.css
@@ -495,7 +495,10 @@
     padding: 0 16px 4px;
     font-size: 12px;
     color: var(--muted, #858a96);
+    opacity: 0;
+    transition: opacity 0.2s ease;
 }
+.version-modal-status:not([hidden]) { opacity: 1; }
 .version-modal-status.error { color: #e06c75; }
 .version-modal-status.info { color: var(--accent, #9cc7c0); }
 
@@ -529,6 +532,27 @@
 .version-modal-btn.ghost:hover { background: var(--pi-menu-hover-bg, rgba(127,127,127,0.12)); }
 .version-modal-btn.primary:hover { opacity: 0.9; }
 .version-modal-btn:disabled { opacity: 0.5; cursor: default; }
+
+.version-modal-btn.is-loading {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+}
+.version-modal-btn.is-loading::before {
+    content: "";
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    animation: version-spin 0.7s linear infinite;
+}
+@keyframes version-spin {
+    to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .version-modal-btn.is-loading::before { animation: none; }
+}
 
 body.version-modal-open { overflow: hidden; }
 

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -894,7 +894,7 @@
       min-width: 0;
       min-height: 0;
       overflow-y: auto;
-      padding: calc(52px + var(--line-height)) calc(var(--line-height) * 2) var(--line-height);
+      padding: calc(52px + 8px) calc(var(--line-height) * 2) var(--line-height);
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -2261,7 +2261,7 @@
 
       #content {
         min-height: 0;
-        padding: calc(52px + env(safe-area-inset-top) + var(--line-height)) 16px var(--line-height);
+        padding: calc(52px + env(safe-area-inset-top) + 8px) 16px var(--line-height);
         -webkit-overflow-scrolling: touch;
         overscroll-behavior: contain;
       }
@@ -2278,6 +2278,11 @@
 
 
       .session-header-bar {
+        /* Grow the bar by the safe-area inset. Without this, box-sizing:
+           border-box keeps the bar at a fixed 52px while #content reserves
+           52px + inset of top padding, leaving an empty gap the height of
+           the inset below the header. */
+        height: calc(52px + env(safe-area-inset-top));
         padding: env(safe-area-inset-top) 12px 0;
       }
 

--- a/internal/ui/live_templates/styles/settings.css
+++ b/internal/ui/live_templates/styles/settings.css
@@ -86,7 +86,10 @@
 
 .settings-control select,
 .settings-control input[type="number"],
-.settings-control input[type="time"] {
+.settings-control input[type="time"],
+.settings-font-custom {
+  box-sizing: border-box;
+  width: 180px;
   background: var(--input-bg, var(--surface-2));
   color: var(--text);
   border: 1px solid var(--dim);
@@ -94,11 +97,6 @@
   padding: 7px 10px;
   font-size: 1em;
   font-family: inherit;
-  min-width: 130px;
-}
-
-.settings-control input[type="number"] {
-  min-width: 90px;
 }
 
 .settings-font-control {
@@ -106,10 +104,6 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 6px;
-}
-
-.settings-font-custom {
-  min-width: 160px;
 }
 
 /* Toggle switch */
@@ -189,4 +183,23 @@
 
 .settings-saved-hint.visible {
   opacity: 1;
+}
+
+@media (max-width: 560px) {
+  .settings-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .settings-font-control {
+    align-items: stretch;
+  }
+
+  .settings-control select,
+  .settings-control input[type="number"],
+  .settings-control input[type="time"],
+  .settings-font-custom {
+    width: 100%;
+  }
 }

--- a/internal/ui/mobile_sidebar_test.go
+++ b/internal/ui/mobile_sidebar_test.go
@@ -52,7 +52,7 @@ func TestMobileSessionActionsStayAtTopAndHideBehindSidebar(t *testing.T) {
 
 func TestMobileSessionActionsDoNotCoverHeaderToggleButtons(t *testing.T) {
 	checks := []string{
-		"padding: calc(52px + env(safe-area-inset-top) + var(--line-height))",
+		"padding: calc(52px + env(safe-area-inset-top) + 8px)",
 		".header-toggle-btn",
 		"data-action=\"toggle-thinking\"",
 		"data-action=\"toggle-tools\"",

--- a/web/src/session/chat/done-notifier.js
+++ b/web/src/session/chat/done-notifier.js
@@ -80,6 +80,23 @@ function urlBase64ToUint8Array(base64String) {
   return out;
 }
 
+// Calls pushManager.subscribe(). If it throws (e.g. stale/incompatible
+// subscription left over from a VAPID key rotation), force-unsubscribes the
+// stale entry and retries once before giving up.
+async function _subscribePush(reg, publicKey) {
+  const opts = { userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(publicKey) };
+  try {
+    return await reg.pushManager.subscribe(opts);
+  } catch (firstErr) {
+    const stale = await reg.pushManager.getSubscription().catch(() => null);
+    if (stale) {
+      await stale.unsubscribe().catch(() => {});
+      return await reg.pushManager.subscribe(opts);
+    }
+    throw firstErr;
+  }
+}
+
 export async function registerPushSubscription({ windowImpl = window, fetchImpl = fetch } = {}) {
   try {
     const navImpl = windowImpl.navigator;
@@ -91,10 +108,7 @@ export async function registerPushSubscription({ windowImpl = window, fetchImpl 
     if (!publicKey) return false;
     let sub = await reg.pushManager.getSubscription();
     if (!sub) {
-      sub = await reg.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: urlBase64ToUint8Array(publicKey)
-      });
+      sub = await _subscribePush(reg, publicKey);
     }
     const body = sub.toJSON ? sub.toJSON() : sub;
     await fetchImpl('/api/push/subscribe', {
@@ -172,6 +186,46 @@ export function notifyDone({ windowImpl = window, documentImpl = document, stora
   if (!isDoneNotifyEnabled({ storage })) return;
   playDoneSound({ windowImpl, storage });
   showDoneNotification({ windowImpl, documentImpl });
+  // Badge only when the user isn't watching this session — covers background
+  // tabs, minimized windows, and other apps in front. Cleared on
+  // visibilitychange/focus via setupAppBadgeClearing.
+  if (documentImpl.hidden) {
+    try {
+      const nav = windowImpl.navigator;
+      if (nav && nav.setAppBadge) {
+        const p = nav.setAppBadge(1);
+        if (p && typeof p.catch === 'function') p.catch(() => {});
+      }
+    } catch {
+      // ignore
+    }
+  }
+}
+
+// Clears the app-icon badge set by the service worker on a background push.
+// No-op where the Badging API is unsupported.
+export function clearAppBadge({ windowImpl = window } = {}) {
+  try {
+    const nav = windowImpl.navigator;
+    if (nav && nav.clearAppBadge) {
+      const p = nav.clearAppBadge();
+      if (p && typeof p.catch === 'function') p.catch(() => {});
+    }
+  } catch {
+    // ignore
+  }
+}
+
+// Clears the badge whenever the app comes to the foreground, so the user
+// doesn't see a stale count after opening it directly (rather than via the
+// notification tap, which the service worker handles).
+export function setupAppBadgeClearing({ documentImpl = document, windowImpl = window } = {}) {
+  const clear = () => {
+    if (!documentImpl.hidden) clearAppBadge({ windowImpl });
+  };
+  clear();
+  documentImpl.addEventListener('visibilitychange', clear);
+  windowImpl.addEventListener('focus', clear);
 }
 
 export async function fetchAvailableSounds({ fetchImpl = fetch } = {}) {

--- a/web/src/session/chat/done-notifier.test.js
+++ b/web/src/session/chat/done-notifier.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  notifyDone,
+  setupAppBadgeClearing,
+  clearAppBadge,
+  DONE_NOTIFY_STORAGE_KEY,
+} from './done-notifier.js';
+
+function makeStorage(enabled = true) {
+  const map = { [DONE_NOTIFY_STORAGE_KEY]: String(enabled) };
+  return { getItem: (k) => map[k] ?? null, setItem: (k, v) => { map[k] = v; } };
+}
+
+function makeWindow({ badgeApi = true } = {}) {
+  const badge = { set: [], cleared: 0 };
+  const nav = badgeApi
+    ? {
+        setAppBadge: vi.fn(async (n) => { badge.set.push(n); }),
+        clearAppBadge: vi.fn(async () => { badge.cleared += 1; }),
+      }
+    : {};
+  return {
+    windowImpl: { navigator: nav, Audio: null, Notification: null, addEventListener: vi.fn() },
+    badge,
+  };
+}
+
+describe('notifyDone — app badge', () => {
+  it('sets badge when document is hidden', () => {
+    const { windowImpl, badge } = makeWindow();
+    notifyDone({ windowImpl, documentImpl: { hidden: true }, storage: makeStorage(true) });
+    expect(badge.set).toEqual([1]);
+  });
+
+  it('does not set badge when document is visible', () => {
+    const { windowImpl, badge } = makeWindow();
+    notifyDone({ windowImpl, documentImpl: { hidden: false }, storage: makeStorage(true) });
+    expect(badge.set).toEqual([]);
+  });
+
+  it('does not set badge when notifications are disabled', () => {
+    const { windowImpl, badge } = makeWindow();
+    notifyDone({ windowImpl, documentImpl: { hidden: true }, storage: makeStorage(false) });
+    expect(badge.set).toEqual([]);
+  });
+
+  it('does nothing when Badging API is unavailable', () => {
+    const { windowImpl } = makeWindow({ badgeApi: false });
+    expect(() =>
+      notifyDone({ windowImpl, documentImpl: { hidden: true }, storage: makeStorage(true) })
+    ).not.toThrow();
+  });
+});
+
+describe('clearAppBadge', () => {
+  it('calls navigator.clearAppBadge', () => {
+    const { windowImpl, badge } = makeWindow();
+    clearAppBadge({ windowImpl });
+    expect(badge.cleared).toBe(1);
+  });
+
+  it('does nothing when Badging API is unavailable', () => {
+    const { windowImpl } = makeWindow({ badgeApi: false });
+    expect(() => clearAppBadge({ windowImpl })).not.toThrow();
+  });
+});
+
+describe('setupAppBadgeClearing', () => {
+  it('clears badge immediately if document is already visible', () => {
+    const { windowImpl, badge } = makeWindow();
+    const listeners = {};
+    const documentImpl = {
+      hidden: false,
+      addEventListener: (type, fn) => { listeners[type] = fn; },
+    };
+    windowImpl.addEventListener = (type, fn) => { listeners[type] = fn; };
+
+    setupAppBadgeClearing({ documentImpl, windowImpl });
+
+    expect(badge.cleared).toBe(1);
+  });
+
+  it('clears badge on visibilitychange when page becomes visible', () => {
+    const { windowImpl, badge } = makeWindow();
+    const listeners = {};
+    const documentImpl = {
+      hidden: true,
+      addEventListener: (type, fn) => { listeners[type] = fn; },
+    };
+    windowImpl.addEventListener = (type, fn) => { listeners[type] = fn; };
+
+    setupAppBadgeClearing({ documentImpl, windowImpl });
+    expect(badge.cleared).toBe(0);
+
+    documentImpl.hidden = false;
+    listeners['visibilitychange']();
+    expect(badge.cleared).toBe(1);
+  });
+
+  it('clears badge on window focus', () => {
+    const { windowImpl, badge } = makeWindow();
+    const listeners = {};
+    const documentImpl = {
+      hidden: false,
+      addEventListener: (type, fn) => { listeners[type] = fn; },
+    };
+    windowImpl.addEventListener = (type, fn) => { listeners[type] = fn; };
+
+    setupAppBadgeClearing({ documentImpl, windowImpl });
+    badge.cleared = 0; // reset after the initial clear
+
+    listeners['focus']();
+    expect(badge.cleared).toBe(1);
+  });
+});

--- a/web/src/session/chat/push-service-worker.test.js
+++ b/web/src/session/chat/push-service-worker.test.js
@@ -6,9 +6,14 @@ import vm from 'node:vm';
 function loadServiceWorker({ clients = [] } = {}) {
   const listeners = {};
   const notifications = [];
+  const badge = { set: [], cleared: 0 };
   const self = {
     addEventListener(type, handler) { listeners[type] = handler; },
     skipWaiting() {},
+    navigator: {
+      setAppBadge: async (n) => { badge.set.push(n); },
+      clearAppBadge: async () => { badge.cleared += 1; }
+    },
     clients: {
       claim() {},
       matchAll: async () => clients,
@@ -20,7 +25,7 @@ function loadServiceWorker({ clients = [] } = {}) {
   };
   const code = readFileSync(resolve(process.cwd(), '../internal/ui/live_templates/assets/sw.js'), 'utf8');
   vm.runInNewContext(code, { self }, { filename: 'internal/ui/live_templates/assets/sw.js' });
-  return { listeners, notifications };
+  return { listeners, notifications, badge };
 }
 
 async function dispatchPush(listener, payload = { title: 'pi session', body: 'Response ready', sessionId: 's1' }) {
@@ -73,5 +78,36 @@ describe('push service worker notifications', () => {
     await dispatchPush(listeners.push);
 
     expect(notifications).toHaveLength(1);
+  });
+
+  it('sets an app-icon badge when showing a background notification', async () => {
+    const { listeners, badge } = loadServiceWorker({ clients: [] });
+
+    await dispatchPush(listeners.push);
+
+    expect(badge.set).toEqual([1]);
+  });
+
+  it('does not badge when a foreground window suppresses the notification', async () => {
+    const { listeners, badge } = loadServiceWorker({
+      clients: [{ visibilityState: 'visible', url: 'http://localhost/session?id=s1' }]
+    });
+
+    await dispatchPush(listeners.push);
+
+    expect(badge.set).toEqual([]);
+  });
+
+  it('clears the app-icon badge when a notification is clicked', async () => {
+    const { listeners, badge } = loadServiceWorker({ clients: [] });
+
+    const waits = [];
+    listeners.notificationclick({
+      notification: { close() {}, data: { sessionId: 's1' } },
+      waitUntil: (promise) => waits.push(promise)
+    });
+    await Promise.all(waits);
+
+    expect(badge.cleared).toBe(1);
   });
 });

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -301,6 +301,7 @@ export function runSessionApp({ target = window } = {}) {
   navigateTo(currentLeafId, dataModel.urlTargetId ? 'target' : 'bottom', dataModel.urlTargetId || null);
 
   doneNotifier.setupDoneNotifyToggle({ documentImpl, windowImpl: target });
+  doneNotifier.setupAppBadgeClearing({ documentImpl, windowImpl: target });
   target.addEventListener('pi-worker-done', () => {
     doneNotifier.notifyDone({ documentImpl, windowImpl: target });
   });

--- a/web/src/shared/version.js
+++ b/web/src/shared/version.js
@@ -227,15 +227,32 @@ export function createVersionController({
     return btn;
   }
 
+  // Minimum time the "Checking…" state stays visible. A check often resolves in
+  // a few dozen ms; without a floor the spinner pops in and vanishes as a flash.
+  const MIN_CHECK_MS = 450;
+
+  function delay(ms) {
+    return new Promise((resolve) => windowImpl.setTimeout(resolve, ms));
+  }
+
   async function doManualCheck(btn) {
+    const label = btn.textContent;
     btn.disabled = true;
-    setStatus('Checking…', 'info');
+    btn.classList.add('is-loading');
+    btn.textContent = 'Checking…';
+    const startedAt = Date.now();
     try {
       await refresh(true);
+      const elapsed = Date.now() - startedAt;
+      if (elapsed < MIN_CHECK_MS) await delay(MIN_CHECK_MS - elapsed);
+      // renderModal() rebuilds the action buttons, so the loading state on this
+      // (now-detached) button is discarded along with it.
       renderModal();
     } catch (_) {
-      setStatus('Could not check for updates.', 'error');
+      btn.classList.remove('is-loading');
+      btn.textContent = label;
       btn.disabled = false;
+      setStatus('Could not check for updates.', 'error');
     }
   }
 

--- a/web/src/shared/version.test.js
+++ b/web/src/shared/version.test.js
@@ -92,6 +92,36 @@ describe('createVersionController', () => {
     expect(overlay.querySelector('.version-modal-body').textContent).toContain('local development build');
   });
 
+  it('shows an inline loading state on the check button while a check is in flight', async () => {
+    // First call (GET /api/version) resolves up-to-date; the manual check
+    // (POST /api/check-update) stays pending so we can observe the in-flight UI.
+    let resolveCheck;
+    const fetchImpl = vi.fn((url) => {
+      if (String(url).includes('check-update')) {
+        return new Promise((resolve) => { resolveCheck = resolve; });
+      }
+      return jsonResponse({ current: '1.0.0', latest: '1.0.0', hasUpdate: false });
+    });
+    createVersionController({ documentImpl: dom.window.document, windowImpl: dom.window, fetchImpl });
+    await Promise.resolve();
+    await Promise.resolve();
+    openVersionModal();
+    const overlay = dom.window.document.querySelector('.version-modal-overlay');
+    const checkBtn = Array.from(overlay.querySelectorAll('.version-modal-btn'))
+      .find((b) => b.textContent === 'Check for updates');
+    expect(checkBtn).toBeTruthy();
+
+    checkBtn.click();
+
+    expect(checkBtn.classList.contains('is-loading')).toBe(true);
+    expect(checkBtn.textContent).toBe('Checking…');
+    expect(checkBtn.disabled).toBe(true);
+    // The status row must stay hidden — no layout-jumping pop-in.
+    expect(overlay.querySelector('.version-modal-status').hidden).toBe(true);
+
+    resolveCheck({ ok: true, status: 200, json: () => Promise.resolve({ current: '1.0.0', latest: '1.0.0', hasUpdate: false }) });
+  });
+
   it('openModal renders an update modal with an Update button', async () => {
     const fetchImpl = vi.fn(() => jsonResponse({ current: '1.0.0', latest: '1.1.0', hasUpdate: true, changelog: '- new' }));
     createVersionController({ documentImpl: dom.window.document, windowImpl: dom.window, fetchImpl });


### PR DESCRIPTION
<!--
Thanks for contributing to pi-web! Per CONTRIBUTING.md, please open an issue
first so we can discuss before code is written. Link that issue below.
-->

## Summary

- Adds app icon badging via the Web Badging API (`navigator.setAppBadge`) so the installed PWA Dock/taskbar icon shows a `1` badge when a session finishes and the user isn't actively watching it — covers minimized windows, background tabs, other sessions, and other apps in the foreground.
- Clears the badge when the user returns to the app (visibilitychange / focus / notification click).
- Badges from the SW push handler for the fully-closed case; from the page (`notifyDone`) for the backgrounded-tab case, guarded by `document.hidden` so it doesn't fire when the user is already watching the completing session.
- Adds push subscription retry: if `pushManager.subscribe()` fails due to a stale subscription left over from a VAPID key rotation, force-unsubscribes and retries once.
- Fixes an iOS safe-area-inset gap below the session header bar.

## Related issue

Closes #

## Type of change

- [x] `feat` — new feature
- [x] `fix` — bug fix

## Live vs. Export

- [x] Not applicable — this PR doesn't touch session rendering

## Testing

- [x] `make check` passes (test + build + vet)
- [x] Frontend tests (`vitest`) cover the change — added `done-notifier.test.js` (9 tests: badge set when hidden, no badge when visible, no badge when disabled, no badge without API, clearAppBadge, setupAppBadgeClearing immediate/visibilitychange/focus) and 3 new SW badge tests in `push-service-worker.test.js`
- [ ] Go tests (`go test ./...`) cover the change — no Go changes
- [x] UI changes verified in a browser
