### PR TITLE
fix(update): avoid killing in-place self-update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build setup frontend-setup go-setup root-setup frontend-build frontend-test extension-test memory-test go-test vet test check clean dev release-patch release-minor release-major release-beta e2e e2e-setup
+.PHONY: build setup frontend-setup go-setup root-setup frontend-build frontend-test extension-test memory-test go-test install-test vet test check clean dev release-patch release-minor release-major release-beta e2e e2e-setup
 
 BINARY ?= pi-web
 WEB_DIR := web
@@ -47,12 +47,15 @@ memory-test:
 go-test: go-setup
 	go test ./...
 
+install-test:
+	bash tests/install/inplace_test.sh
+
 vet: go-setup
 	go vet ./...
 
-test: frontend-test extension-test memory-test go-test
+test: frontend-test extension-test memory-test go-test install-test
 
-check: frontend-test extension-test memory-test frontend-build go-test vet
+check: frontend-test extension-test memory-test frontend-build go-test install-test vet
 
 dev: frontend-setup go-setup
 	@echo "Starting dev mode (frontend watcher + Go hot-reloader)..."

--- a/install.sh
+++ b/install.sh
@@ -153,6 +153,7 @@ install_binary() {
   local src="$1"
   local tag="$2"
   local is_update="${3:-false}"
+  local inplace="${PI_WEB_INPLACE_UPDATE:-}"
 
   if [[ -f "$BINARY" ]] && [[ "$is_update" != "true" ]]; then
     # Interactive: ask before overwriting
@@ -164,8 +165,11 @@ install_binary() {
     fi
   fi
 
-  # Stop running instance before replacing
-  if [[ -f "$BINARY" ]]; then
+  # Stop running instance before replacing. Skipped for in-place self-updates:
+  # pi-web spawned this script (via `pi install`), so stopping the service here
+  # would kill the very npm process running it. pi-web triggers its own detached
+  # restart afterward (see internal/app/update.go).
+  if [[ -f "$BINARY" && -z "$inplace" ]]; then
     if [[ "$(uname -s)" == "Linux" ]]; then
       systemctl --user stop pi-web.service 2>/dev/null || true
     elif [[ "$(uname -s)" == "Darwin" ]]; then
@@ -181,6 +185,14 @@ install_binary() {
   if [[ ! -w "$INSTALL_DIR" ]]; then
     info "Installing to ${INSTALL_DIR} (requires sudo)..."
     sudo cp "$src" "$BINARY"
+  elif [[ -n "$inplace" ]]; then
+    # Atomic swap so the binary can be replaced while the old process still
+    # runs — a plain cp over a running executable fails with ETXTBSY on Linux.
+    # The temp file must share $BINARY's directory so the mv is a pure rename(2).
+    local staged="${BINARY}.new.$$"
+    cp "$src" "$staged"
+    chmod +x "$staged"
+    mv -f "$staged" "$BINARY"
   else
     cp "$src" "$BINARY"
   fi
@@ -397,6 +409,15 @@ main() {
 
   if ! install_binary "$tmp_binary" "$tag" "$is_update"; then
     # User chose not to overwrite
+    exit 0
+  fi
+
+  # In-place self-update: pi-web triggered this and restarts itself afterward
+  # via its own /api/restart. Skip env/service setup so we don't restart (and
+  # kill) the npm process running this script, or clobber the service's PATH.
+  if [[ -n "${PI_WEB_INPLACE_UPDATE:-}" ]]; then
+    info "Binary updated to ${tag}; pi-web will restart to apply it."
+    echo ""
     exit 0
   fi
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -13,10 +13,23 @@ import (
 // updater queries (see internal/updater).
 const installPackage = "npm:@ygncode/pi-web@beta"
 
+// inPlaceUpdateEnv signals install.sh (the package postinstall) that pi-web is
+// updating itself in place. install.sh then skips the service stop/restart:
+// this script runs inside the process tree that restart would kill, aborting
+// the in-flight npm install. pi-web restarts itself afterward via runRestart.
+const inPlaceUpdateEnv = "PI_WEB_INPLACE_UPDATE"
+
+// installCmd builds the `pi install` invocation used by the in-app updater.
+func installCmd(ctx context.Context) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "pi", "install", installPackage)
+	cmd.Env = append(os.Environ(), inPlaceUpdateEnv+"=1")
+	return cmd
+}
+
 // runInstall installs the latest pi-web package via the `pi` CLI. Output is
 // captured so a failure surfaces a useful message in the UI.
 func runInstall(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "pi", "install", installPackage)
+	cmd := installCmd(ctx)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := string(out)

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+// The in-app updater must hand install.sh the in-place flag so it skips the
+// service stop/restart (which would kill the npm process running it).
+func TestInstallCmdSignalsInPlaceUpdate(t *testing.T) {
+	cmd := installCmd(context.Background())
+
+	wantArgs := []string{"pi", "install", installPackage}
+	if !slices.Equal(cmd.Args, wantArgs) {
+		t.Fatalf("args = %v, want %v", cmd.Args, wantArgs)
+	}
+
+	want := inPlaceUpdateEnv + "=1"
+	if !slices.Contains(cmd.Env, want) {
+		t.Errorf("env missing %q; got %v", want, cmd.Env)
+	}
+}

--- a/tests/install/inplace_test.sh
+++ b/tests/install/inplace_test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Verifies install.sh's in-place self-update path: when PI_WEB_INPLACE_UPDATE is
+# set, it must NOT stop/restart the service (doing so kills the npm process that
+# spawned it — see internal/app/update.go), and must still swap the binary.
+# Without the flag, the normal path must still stop the running instance.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Run install.sh in a sandboxed HOME with all external commands shimmed.
+# $1: "inplace" or "normal".
+run_case() {
+  local mode="$1"
+  local workdir bindir shimdir calllog
+  workdir="$(mktemp -d)"
+  bindir="$workdir/bin"
+  shimdir="$workdir/shim"
+  calllog="$workdir/calls.log"
+  mkdir -p "$bindir" "$shimdir"
+
+  # curl shim: serve the GitHub "latest release" JSON and a fake binary download.
+  cat > "$shimdir/curl" <<'SHIM'
+#!/usr/bin/env bash
+out="" url=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case "${args[i]}" in
+    -o) out="${args[i+1]}" ;;
+    http*) url="${args[i]}" ;;
+  esac
+done
+if [[ "$url" == *api.github.com* ]]; then
+  echo '{"tag_name": "v9.9.9"}'
+elif [[ "$url" == *releases/download* ]]; then
+  printf '#!/bin/sh\necho v9.9.9\n' > "$out"
+fi
+exit 0
+SHIM
+
+  # Service managers / pkill / sudo: log the call so we can assert on it.
+  local tool
+  for tool in systemctl launchctl pkill sudo; do
+    cat > "$shimdir/$tool" <<SHIM
+#!/usr/bin/env bash
+echo "$tool \$*" >> "$calllog"
+[[ "$tool" == "sudo" ]] && exec "\$@"
+exit 0
+SHIM
+  done
+  chmod +x "$shimdir"/*
+  : > "$calllog"
+
+  # A stale binary so the "stop running instance" path is reachable in normal mode.
+  printf '#!/bin/sh\necho v0.0.0\n' > "$bindir/pi-web"
+  chmod +x "$bindir/pi-web"
+
+  local env_vars=(
+    "HOME=$workdir"
+    "PI_WEB_INSTALL_DIR=$bindir"
+    "PATH=$shimdir:/usr/bin:/bin"
+  )
+  [[ "$mode" == "inplace" ]] && env_vars+=("PI_WEB_INPLACE_UPDATE=1")
+
+  env -i "${env_vars[@]}" bash "$INSTALL_SH" </dev/null > "$workdir/out.log" 2>&1 \
+    || fail "[$mode] install.sh exited non-zero:"$'\n'"$(cat "$workdir/out.log")"
+
+  [[ -x "$bindir/pi-web" ]] || fail "[$mode] binary missing after install"
+  grep -q v9.9.9 "$bindir/pi-web" || fail "[$mode] binary not replaced with new version"
+
+  if [[ "$mode" == "inplace" ]]; then
+    [[ ! -s "$calllog" ]] \
+      || fail "[inplace] expected no service/pkill calls, got:"$'\n'"$(cat "$calllog")"
+  else
+    grep -Eq 'systemctl|launchctl|pkill' "$calllog" \
+      || fail "[normal] expected the running instance to be stopped, but nothing was called"
+  fi
+
+  echo "ok: $mode"
+  rm -rf "$workdir"
+}
+
+run_case inplace
+run_case normal
+echo "PASS: install.sh in-place self-update"


### PR DESCRIPTION
## Summary

- Fix in-app beta updates so `pi install` signals `install.sh` that pi-web is updating itself in place, avoiding service stop/restart from killing the npm install process.
- Add an in-place install path that atomically swaps the binary while the old process is still running, then lets pi-web restart itself afterward.
- Cover the updater command env and install script behavior, and wire the install script test into `make test` / `make check`.

## Related issue

N/A

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `style` — formatting / UI styling, no behavior change
- [x] `test` — adding or updating tests
- [ ] `chore` — build, tooling, or maintenance

## Live vs. Export

- [x] Not applicable — this PR doesn't touch session rendering
- [ ] Considered both the live app and the export snapshot
- [ ] Kept `internal/ui/live_templates/` in sync with `web/src/session/` changes
- [ ] No live-only chrome (Vite scripts, active composer, SSE/API) leaked into export

## Testing

- [ ] `make check` passes (test + build + vet)
- [ ] Frontend tests (`vitest`) cover the change
- [x] Go tests (`go test ./...`) cover the change
- [ ] UI changes verified in a browser

Additional commands run:

- `bash tests/install/inplace_test.sh`
- `go test ./internal/app`
