### PR TITLE
feat(session): artifacts panel and inline annotations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ Before making structural changes, read the relevant doc in `docs/`:
 | New to the codebase | `docs/architecture/system-overview.md` |
 | Changing frontend build/template embedding | `docs/dev/templates-vs-web.md` |
 | Working on chat, SSE, or live-reload | `docs/sequence-flows/chat.md`, `docs/sequence-flows/live-reload.md` |
+| Working on artifacts | `docs/sequence-flows/artifacts.md` |
+| Working on annotations | `docs/sequence-flows/annotations.md` |
 | Working on export/share | `docs/sequence-flows/share.md` |
 | Writing or debugging E2E / browser tests | `docs/dev/e2e-testing.md` |
 
@@ -40,6 +42,8 @@ The most important doc for frontend work is **`docs/dev/templates-vs-web.md`** â
 |-----------|---------|
 | `web/src/index/` | Sessions list page (Vite) |
 | `web/src/session/` | Session viewer â€” tree rendering, chat composer, live reload |
+| `web/src/session/artifacts/` | Artifact registry (path-keyed files + fenced snippets) + right-sidebar Artifacts panel (preview/source, help modal) |
+| `web/src/session/annotations/` | Inline review annotations (offset-anchored highlights, Annotations tab, send-to-pi); synced via the `annotations` SSE event |
 | `web/src/shared/` | API helpers, escape, storage, status events |
 | `internal/ui/live_templates/` | Go-embedded HTML shells for index/session pages |
 | `internal/ui/live_templates/export/` | Self-contained JS/vendor scripts for static Gist snapshots (no server, no chat, no SSE) |

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -51,6 +51,7 @@ pi-web/
 │   │   ├── new_session.go      # New-session creation logic
 │   │   ├── git.go              # /api/git/info, /api/git/rename-branch handlers
 │   │   ├── scratchpad.go       # Per-project scratchpad get/save (SQLite)
+│   │   ├── annotations.go      # Per-session review annotations: list/create/delete + SSE snapshot (SQLite)
 │   │   ├── projects.go         # Project visibility prefs: list/toggle/register + index filtering (SQLite)
 │   │   ├── sound.go            # /api/sounds + /sounds/ asset serving
 │   │   ├── push.go             # PushManager: VAPID, subscribe/unsubscribe, NotifyDone
@@ -118,10 +119,13 @@ when `RunInstall`/`RunRestart` are nil the corresponding endpoints respond `503`
 
 On `New`, the server opens (and migrates) a SQLite database at
 `~/.pi/agent/pi-web.sqlite` — a `scratchpads` table keyed by project path, a
-`project_prefs` table recording which projects are enabled, and an `app_settings`
-key/value table holding the project-filter master switch (default off). See
-`projects.go`. A `PushManager` (when configured) persists web-push subscriptions
-and VAPID keys under the agent dir.
+`project_prefs` table recording which projects are enabled, an `app_settings`
+key/value table holding the project-filter master switch (default off), and an
+`annotations` table holding per-session review notes (keyed by session id; see
+`annotations.go`). See `projects.go`. The pool is capped to a single connection
+(`SetMaxOpenConns(1)`) so concurrent writers queue instead of failing with
+"database is locked". A `PushManager` (when configured) persists web-push
+subscriptions and VAPID keys under the agent dir.
 
 ### `sessions.Session`
 
@@ -211,6 +215,7 @@ type piRPCWorker struct {
 | `/api/git/info` | GET | `handleGitInfo` | Branch / dirty / PR-URL info for a project |
 | `/api/git/rename-branch` | POST | `handleGitRenameBranch` | Rename the current git branch |
 | `/api/scratchpad` | GET/POST | `handleGetScratchpad` / `handleSaveScratchpad` | Per-project scratchpad (SQLite) |
+| `/api/annotations` | GET/POST/DELETE | `handleAnnotations` | Per-session review annotations; mutations broadcast an `annotations` SSE snapshot (SQLite) |
 | `/api/projects` | GET/POST | `handleApiProjects` / `handleUpdateProject` | List projects + filter state; enable/disable/register/remove, bulk enable-all/disable-all, enable-filter/disable-filter (SQLite) |
 | `/api/sounds` | GET | `handleApiSounds` | List available notification sounds |
 | `/sounds/` | GET | `handleSounds` | Serve a sound asset (no auth) |
@@ -262,7 +267,7 @@ Request ──▶ auth.Wrap(handler)
 The server maintains a slice of `sseClient` structs. Each client subscribes to a `sessID`:
 
 - `__all__` — index page subscribes here; receives `new-session`, `status-snapshot`, `status-delta`
-- Specific session ID — session page subscribes here; receives `reload` when the file changes
+- Specific session ID — session page subscribes here; receives `reload` when the file changes, `chat-preview` during streaming, and `annotations` (a full annotation snapshot) whenever a note is created/deleted for that session
 
 Broadcasting is fire-and-forget with a buffered channel (16). If the client is slow, keyless events are dropped rather than blocking. Duplicate `reload` and `new-session` events are coalesced per-client while pending.
 

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -54,7 +54,9 @@ Session frontend modules are split by ownership:
 - `web/src/session/navigation/` — session path rendering, header/message navigation, copy-link wiring
 - `web/src/session/chat/` — chat composer, attachments, model and thinking controls
 - `web/src/session/live/` — session SSE/live reload, fork modal, share overlay, command/session palettes, update indicator
-- `web/src/session/ui/` — session page interaction wiring, sidebars, search filters
+- `web/src/session/ui/` — session page interaction wiring, sidebars (incl. the right-sidebar Scratchpad / Artifacts / Annotations tab switcher), search filters
+- `web/src/session/artifacts/` — artifact registry (path-keyed detection of files the agent wrote/edited/renamed, plus sizeable fenced code blocks) and the right-sidebar Artifacts panel (source view, sandboxed HTML/SVG + Markdown preview, copy/download, help modal)
+- `web/src/session/annotations/` — inline review annotations: API client, offset-anchored highlighting, the selection→note flow, the Annotations tab list, and "send notes to pi" (syncs across tabs via the `annotations` SSE event)
 - `web/src/session/cat-gatekeeper/` — the cat gate overlay + its settings
 
 `internal/ui/live_templates/export/app/*.js` is not the source of live interactive session runtime behavior. It is kept only for static/share exports.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,7 @@ pi-web is a local HTTP server that lets you browse and interact with your pi cod
 | Live Updates | Server-Sent Events (SSE) |
 | Chat RPC | JSONL over stdin/stdout via `pi --mode rpc` |
 | Session Storage | JSONL files on disk; pi-web creates new session files and appends `session_info` for browser rename |
-| Local DB | SQLite (`~/.pi/agent/pi-web.sqlite`) for per-project scratchpads, project visibility prefs, and server-backed user settings |
+| Local DB | SQLite (`~/.pi/agent/pi-web.sqlite`) for per-project scratchpads, per-session review annotations, project visibility prefs, and server-backed user settings |
 | Auth | Token cookie/query/header (optional on localhost) |
 
 ## Component Diagram
@@ -57,6 +57,7 @@ pi-web is a local HTTP server that lets you browse and interact with your pi cod
 │   GET  /api/worker-status → handleWorkerStatus                           │
 │   GET  /api/git/info  / POST /api/git/rename-branch                      │
 │   GET/POST /api/scratchpad → scratchpad (SQLite)                         │
+│   GET/POST/DELETE /api/annotations → review annotations (SQLite, SSE)    │
 │   GET/POST /api/settings → user settings (SQLite, write-through cache)   │
 │   GET/POST /api/projects → project visibility prefs (SQLite)             │
 │   GET  /api/sounds  /  GET /sounds/…   (notification sounds)             │
@@ -130,7 +131,7 @@ name, while pi-web itself continues listening only on localhost.
 ├── session-status/
 │   ├── 2026-01-15T10-30-00.000Z_a1b2c3d4.jsonl   ← terminal writes here
 │   └── …
-├── pi-web.sqlite           ← scratchpads + project visibility prefs + user settings
+├── pi-web.sqlite           ← scratchpads + annotations + project visibility prefs + user settings
 └── pi-web/
     ├── pi-web-state.json   ← server state file
     ├── custom-themes.css   ← optional user custom theme

--- a/docs/sequence-flows/README.md
+++ b/docs/sequence-flows/README.md
@@ -8,4 +8,6 @@ This directory documents the key runtime sequences in pi-web.
 | [session-viewing.md](./session-viewing.md) | Loading and rendering a session page |
 | [chat.md](./chat.md) | Sending a chat message via the web UI |
 | [live-reload.md](./live-reload.md) | How file changes propagate to the browser |
+| [artifacts.md](./artifacts.md) | Detecting (path-keyed/edit-aware), rendering, and sandbox-previewing artifacts |
+| [annotations.md](./annotations.md) | Anchoring, persisting, syncing, and sending review notes |
 | [share.md](./share.md) | Exporting a session to a private GitHub Gist |

--- a/docs/sequence-flows/annotations.md
+++ b/docs/sequence-flows/annotations.md
@@ -1,0 +1,160 @@
+# Sequence Flow: Annotations
+
+Annotations are reviewer-authored notes anchored to a span of a rendered session
+entry **or** an artifact's source. They are persisted server-side (SQLite),
+synced across open tabs over SSE, and can be packaged into a message back to the
+agent ("send notes to pi").
+
+They are **not** session data — they never touch the append-only JSONL. They are
+overlay metadata keyed by session id.
+
+## Anchoring model
+
+An annotation does not store a DOM range (those die on re-render). It stores a
+**stable text anchor**:
+
+| Field | Meaning |
+|-------|---------|
+| `anchorId` | `entry-<id>` for a transcript message, or `artifact-<id>` for an artifact's source `<pre>` |
+| `startOffset` / `endOffset` | character offsets `[start, end)` into the anchor element's `textContent` |
+| `original` | the anchored text at creation time (for display + drift awareness) |
+| `text` | the reviewer's note |
+| `kind` | `comment` (the only kind today) |
+| `source` | `local` (room for imported/remote annotations later) |
+
+Because the session view rebuilds `#messages` on navigation/live-reload and the
+artifact panel rebuilds its host on every selection, highlights are **recomputed
+from offsets** rather than kept as live nodes. See "Highlight (re)application".
+
+Frontend modules (`web/src/session/annotations/`):
+
+- `annotation-range.js` — selection → `{anchorId, start, end, text}`, and
+  wrapping a `[start,end)` range in `<mark class="pi-annotation">`
+- `annotation-api.js` — `list` / `create` / `remove` against `/api/annotations`
+- `annotation-layer.js` — orchestration: selection popover, the note modal,
+  highlight application, the Annotations tab list, and send-to-pi
+
+Backend: `internal/server/annotations.go` (table, handlers, SSE broadcast),
+wired in `server.go`.
+
+## Create flow
+
+```
+┌─────────┐   ┌───────────────────┐   ┌──────────┐   ┌─────────────┐
+│  User   │   │ annotation-layer  │   │  Server  │   │ Other tabs  │
+│ (browser)│  │  (this tab)       │   │          │   │ (same sess) │
+└────┬────┘   └─────────┬─────────┘   └────┬─────┘   └──────┬──────┘
+     │                  │                  │                │
+     │ select text in   │                  │                │
+     │ #messages /      │                  │                │
+     │ artifact source  │                  │                │
+     │─────────────────▶│ mouseup OR       │                │
+     │                  │ selectionchange  │                │
+     │                  │ (debounced)      │                │
+     │                  │── getSelectionInfo (anchorId,start,end,text)
+     │                  │── show "Comment" button at selection rect
+     │                  │                  │                │
+     │ tap "Comment"    │                  │                │
+     │─────────────────▶│── open note modal (focus textarea)
+     │ type note, Save  │                  │                │
+     │─────────────────▶│                  │                │
+     │                  │── optimistic add + render highlight (mark)
+     │                  │   POST /api/annotations?session=ID │
+     │                  │─────────────────▶│                │
+     │                  │                  │── INSERT row   │
+     │                  │                  │── broadcastAnnotations(ID)
+     │                  │                  │   SSE: annotations (snapshot)
+     │                  │                  │───────────────────────────▶
+     │                  │   200 { annotation } (real id)    │
+     │                  │◀─────────────────│                │
+     │                  │── refresh(): GET /api/annotations → reconcile
+     │                  │                  │                │── setAnnotations(snapshot)
+     │                  │                  │                │   re-render highlights + list
+```
+
+Key points:
+
+- **Trigger.** `mouseup` covers desktop; `selectionchange` (debounced ~250ms)
+  covers touch, where finishing a selection often fires no `mouseup`. Both call
+  the same `maybeShowFromSelection()`.
+- **Note input is a modal**, not an inline box — on mobile it must not be
+  confused with the chat composer and must sit above the keyboard.
+- **Optimistic + guarded.** The note is added locally and highlighted before the
+  POST resolves. A monotonic load counter ensures a slow in-flight `list()` can't
+  clobber a newer optimistic create or SSE snapshot.
+
+## Load flow
+
+On session page init (`session.js`), `annotationLayer.init()` calls
+`refresh()` → `GET /api/annotations?session=<id>` → `applyHighlights` across all
+scopes + render the Annotations tab list + update the tab count badge.
+
+## Delete flow
+
+Clicking a note's delete button optimistically removes it, then
+`DELETE /api/annotations?session=<id>&id=<annId>`. The server removes the row and
+broadcasts a fresh `annotations` snapshot.
+
+## Storage & endpoint
+
+SQLite table `annotations` (`~/.pi/agent/pi-web.sqlite`), keyed by session id,
+indexed on `session_id`. The DB pool is capped to one connection
+(`SetMaxOpenConns(1)`) so concurrent writers queue rather than failing with
+"database is locked".
+
+| Method | Path | Handler | Notes |
+|--------|------|---------|-------|
+| GET | `/api/annotations?session=<id>` | `handleListAnnotations` | `{ annotations: [...] }` |
+| POST | `/api/annotations?session=<id>` | `handleCreateAnnotation` | body = annotation; server fills `id`/`kind`/`source`/`createdAt`; upsert by `id` |
+| DELETE | `/api/annotations?session=<id>&id=<annId>` | `handleDeleteAnnotation` | |
+
+Every POST/DELETE calls `broadcastAnnotations(sessionID)`.
+
+## SSE event
+
+| Event | Topic | Payload | Trigger |
+|-------|-------|---------|---------|
+| `annotations` | `sessID` | `{ "type": "snapshot", "annotations": [...] }` | a note is created/deleted for that session |
+
+A **snapshot** (full set) is sent rather than granular add/remove events — the
+client just calls `setAnnotations(...)` and re-renders. Wiring:
+`live/live-events.js` (`onAnnotations`) ← `live/live-reload-runner.js` ←
+`session.js` (`onAnnotations: (list) => annotationLayer.setAnnotations(list)`).
+
+## Highlight (re)application
+
+`applyHighlights(scope, annotations)` unwraps existing `.pi-annotation` marks in
+a scope, then for each annotation finds its anchor by id and wraps the
+`[start,end)` run in a `<mark class="pi-annotation" data-annotation-id>`.
+
+The layer holds **scopes** = `[#messages, #artifact-panel-host]`. A single
+`MutationObserver` watches them; when a scope re-renders, `reapply()` runs
+(disconnect → apply to every scope → reconnect, so it never observes its own
+mutations). The Annotations tab "jump" on an artifact note first asks the panel
+to select that artifact (so its source `<pre>` exists) before scrolling.
+
+## Send to pi
+
+The Annotations tab's "Send N notes to pi" button formats the set and fills (does
+**not** submit) the chat composer (`#pi-chat-message`). Notes are grouped:
+
+- artifact notes under `In <file path>:` with a `Line N` / `Lines N-M` reference
+  computed from the offsets against the file content;
+- transcript notes under `In this conversation:`.
+
+The message opens with an explicit, directive framing ("…continuation of our
+current task, not a new or separate request") so a weaker model treats it as
+follow-up edits rather than a fresh conversation.
+
+## Live-only
+
+Like artifacts, the annotation layer mounts only on the live session page
+(`IsLive`). Exported Gist snapshots have no annotation host, server, or SSE, so
+the layer is a no-op there.
+
+---
+
+**E2E coverage:** `e2e/tests/annotations.spec.ts` annotates a transcript message
+and an artifact's source, asserts the highlight + Annotations entry, deletes a
+note, and verifies send-to-pi fills the composer with the file path + line
+number. See [docs/dev/e2e-testing.md](../dev/e2e-testing.md).

--- a/docs/sequence-flows/annotations.md
+++ b/docs/sequence-flows/annotations.md
@@ -149,6 +149,11 @@ The message opens with an explicit, directive framing ("…continuation of our
 current task, not a new or separate request") so a weaker model treats it as
 follow-up edits rather than a fresh conversation.
 
+On mobile the sidebar is a full-screen overlay, so sending fires the layer's
+`onSend` callback — `session.js` wires it to collapse the right sidebar (mobile
+only) before the composer is focused, so the filled composer is actually visible
+and ready to type into.
+
 ## Live-only
 
 Like artifacts, the annotation layer mounts only on the live session page

--- a/docs/sequence-flows/annotations.md
+++ b/docs/sequence-flows/annotations.md
@@ -82,6 +82,9 @@ Key points:
 - **Optimistic + guarded.** The note is added locally and highlighted before the
   POST resolves. A monotonic load counter ensures a slow in-flight `list()` can't
   clobber a newer optimistic create or SSE snapshot.
+- **Reveal on save.** Saving fires the layer's `onCreate` callback, which
+  `session.js` wires to open the right sidebar if it's collapsed and switch to the
+  Annotations tab — so the just-created note is always visible where it lands.
 
 ## Load flow
 

--- a/docs/sequence-flows/artifacts.md
+++ b/docs/sequence-flows/artifacts.md
@@ -1,0 +1,144 @@
+# Sequence Flow: Artifacts
+
+Artifacts are substantial, self-contained outputs surfaced from a session into
+the right-sidebar **Artifacts** tab: files the agent wrote/edited, plus sizeable
+fenced code blocks. They are **derived from the transcript at render time** — not
+a new message type the agent emits — so the registry is pure and re-runs on every
+session reload.
+
+Artifacts are **live-only**: the panel host exists only on the live session page
+(`IsLive`), never in exported Gist snapshots.
+
+Frontend modules (`web/src/session/artifacts/`):
+
+- `artifact-registry.js` — pure, DOM-free detection → an array of descriptors
+- `artifact-panel.js` — the right-sidebar panel (list, source view, preview,
+  copy/download, help modal)
+
+Wired in `session.js`: `collectArtifacts(dataModel.entries)` feeds the panel on
+load and again on every live-reload (`syncDataModelEntries`).
+
+## Detection: path-keyed, edit-aware
+
+The registry reconstructs each file's **latest state** by replaying the
+*structured* tool calls in order. File artifacts are keyed by **path** (not by
+tool-call id), so multiple operations on one file collapse into one card.
+
+| Tool call | Effect on the path-keyed artifact |
+|-----------|-----------------------------------|
+| `write` `{path, content}` | create the artifact, or replace its content if the path already exists |
+| `edit` `{path, edits:[{oldText,newText}]}` | apply each edit (first-match) to the current content; ignored if the path was never written in-session (no baseline) |
+| `bash` `{command}` | only plain `mv` / `git mv` / `rm` (see below) rename or remove the artifact, and only once the tool result lands without error |
+| `bashExecution` (user-run) | same `mv`/`rm` recognition, gated on `exitCode === 0` |
+
+Sizeable fenced code blocks in assistant text become **snippet** artifacts
+(previewable languages always; others only at ≥ `minCodeBlockLines`, default 6).
+Snippets are keyed per occurrence, not by path.
+
+### The bash recognizer (and why it's conservative)
+
+`parseFileOps(command)` recognizes only the plain forms — `mv a b`,
+`git mv a b`, `mv a b c… dir/`, `rm a b…` — honoring `'…'`/`"…"` quotes. It
+**bails entirely** (returns `[]`) if the command contains any shell feature it
+won't interpret:
+
+```
+UNSAFE_SHELL = /[|&;<>$`*?(){}\n]/
+```
+
+So `mv a b && echo`, `sed -i …`, redirects, globs, variables, loops, and
+multi-source moves without a directory destination are all left alone. Matches
+are by **exact path** against a known artifact, and only applied on success.
+
+The result:
+
+- **write / edit → always accurate** (structured, machine-readable).
+- **simple mv / git mv / rm → correctly tracked** (recognized patterns).
+- **arbitrary shell → silently skipped** — a file changed via `sed`/redirects can
+  go stale. This tradeoff is surfaced to users in the Artifacts **help (?)**
+  modal ("changes made through other shell commands … may show an older version
+  … check the file on disk").
+
+This is intentional: pi-web is a read-only transcript viewer and does **not**
+read the working directory (the files may differ or not exist when viewing an old
+or exported session), so the transcript's structured calls are the only ground
+truth.
+
+### Descriptor shape
+
+```
+{ id, kind: 'code'|'preview', previewType: ''|'html'|'svg'|'markdown',
+  title, lang, content, filePath, entryId, anchorId, source }
+```
+
+`id` stays stable across edits/renames (it's the first write's `art-<callId>`),
+so an artifact's source-view anchor (`artifact-<id>`) and any annotations on it
+survive in-place changes.
+
+## Rendering pipeline
+
+```
+┌─────────┐   ┌────────────────────┐   ┌──────────────────────────┐
+│ session │   │ artifact-registry  │   │ artifact-panel           │
+│  .js    │   │ (pure)             │   │ (right-sidebar host)     │
+└────┬────┘   └─────────┬──────────┘   └────────────┬─────────────┘
+     │ load / reload    │                           │
+     │─ collectArtifacts(entries) ─▶                │
+     │   [descriptors]  │                           │
+     │─ panel.setArtifacts(descriptors) ───────────▶│
+     │                  │                           │── render list + selected source
+     │                  │                           │   (hljs highlight, lazy)
+     │ user clicks list item ──────────────────────▶│── selectArtifact(id) → source view
+     │ user clicks "Preview" (preview-kind) ───────▶│── Source ⇄ Preview toggle
+```
+
+The list and source view live in the **Artifacts** tab of the right sidebar
+(Scratchpad / Artifacts / Annotations switcher in `web/src/session/ui/`). A
+count badge reflects the number of artifacts; the help (?) button appears only
+on the Artifacts tab.
+
+## Preview (Source ⇄ Preview), and its security model
+
+Previewable artifacts carry a `previewType`. The toggle defaults to **Source**
+(click-to-run — nothing executes on load):
+
+| `previewType` | How it renders |
+|---------------|----------------|
+| `markdown` | rendered inline via the app's sanitizing markdown parser (strips raw HTML) — no iframe |
+| `html` / `svg` | executed in a **sandboxed `<iframe>`** |
+
+The HTML/SVG iframe is the load-bearing security boundary:
+
+- `sandbox="allow-scripts"` **without** `allow-same-origin` → unique opaque
+  origin: no access to the parent DOM, cookies, `localStorage`, or `PI_WEB_TOKEN`.
+- Content is set via the `srcdoc` **property** (never concatenated into parent
+  HTML), so it can't execute in the parent document.
+- An injected CSP meta blocks all network: `default-src 'none'; img-src data:;
+  style-src 'unsafe-inline'; font-src data:; script-src 'unsafe-inline'` — inline
+  styles/scripts run so the preview is functional, but nothing can exfiltrate.
+- `referrerpolicy="no-referrer"`.
+
+## Annotating artifacts
+
+The source `<pre>` carries `id="artifact-<id>"`, making it an annotation anchor.
+The annotation layer registers the artifact panel host as a scope, so selecting
+text in an artifact's source works exactly like annotating a transcript message
+(offsets are measured against the `<pre>`'s text content). See
+[annotations.md](./annotations.md).
+
+## Live vs. export
+
+| | Live (`/session`) | Export (Gist) |
+|---|---|---|
+| Artifacts host (`#artifact-panel-host`) | rendered (`IsLive`) | absent |
+| Panel + registry | active, refreshes over SSE | not mounted (no-op) |
+
+**Never** inject the artifacts panel into the export output — it depends on a
+live backend. See [docs/dev/templates-vs-web.md](../dev/templates-vs-web.md).
+
+---
+
+**E2E coverage:** `e2e/tests/artifacts.spec.ts` covers listing (write + fenced
+block), selecting source, the sandboxed HTML preview, inline Markdown preview, a
+`bash mv` rename collapsing to one card, downloads, and the help (?) modal. See
+[docs/dev/e2e-testing.md](../dev/e2e-testing.md).

--- a/docs/sequence-flows/artifacts.md
+++ b/docs/sequence-flows/artifacts.md
@@ -12,11 +12,14 @@ Artifacts are **live-only**: the panel host exists only on the live session page
 Frontend modules (`web/src/session/artifacts/`):
 
 - `artifact-registry.js` — pure, DOM-free detection → an array of descriptors
+- `artifact-filter.js` — pure, DOM-free narrowing of that array by the user's
+  Artifacts settings (enable toggle + include-glob list)
 - `artifact-panel.js` — the right-sidebar panel (list, source view, preview,
   copy/download, help modal)
 
-Wired in `session.js`: `collectArtifacts(dataModel.entries)` feeds the panel on
-load and again on every live-reload (`syncDataModelEntries`).
+Wired in `session.js` (`refreshArtifacts`): `collectArtifacts(dataModel.entries)`
+detects everything, `filterArtifacts(...)` narrows it by settings, and the result
+feeds the panel on load and again on every live-reload (`syncDataModelEntries`).
 
 ## Detection: path-keyed, edit-aware
 
@@ -117,6 +120,35 @@ The HTML/SVG iframe is the load-bearing security boundary:
   style-src 'unsafe-inline'; font-src data:; script-src 'unsafe-inline'` — inline
   styles/scripts run so the preview is functional, but nothing can exfiltrate.
 - `referrerpolicy="no-referrer"`.
+
+## Filtering & settings
+
+Two server-backed settings (mirrored to localStorage via `settings-store.js`,
+defaults in `internal/server/settings.go`) control what the panel shows:
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `pi-web:v1:artifacts:enabled` | `true` | When `false`, the whole **Artifacts tab is hidden** (and if it was active, the sidebar falls back to Scratchpad). |
+| `pi-web:v1:artifacts:include` | `*.md, *.html` | Comma/space-separated glob list. Empty = show everything. |
+
+`filterArtifacts(artifacts, { enabled, include })` (pure) applies them:
+
+- **Disabled** → returns nothing.
+- **Empty include** → everything passes (all files + snippets).
+- **Non-empty include** → file artifacts are kept only if their path matches a
+  pattern; **chat snippets are dropped** (they have no `filePath` to match). This
+  is the deliberate "filter hides snippets" rule.
+
+Glob dialect is intentionally simple (not gitignore): a pattern without `/`
+matches the **basename** (`*.md`); a pattern with `/` matches the **full path**
+(`artifacts/**`); `*` is a non-slash run and `**` spans slashes; a bare `.md`
+token is normalized to `*.md`.
+
+The registry itself is unchanged — it always detects everything, so toggling the
+filter never loses data. When the include list hides detected artifacts, the
+panel's empty state shows a count + a link to Settings rather than a bare "no
+artifacts" message. Settings live in the **Artifacts** section of `/settings`
+(`internal/ui/live_templates/settings.html`).
 
 ## Annotating artifacts
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -11,13 +11,22 @@ export default async function globalSetup() {
   // intercepting clicks — which silently breaks click-based tests on CI runners
   // in that window (e.g. UTC night). Seed it off in the server-side store so
   // every page hydrates with it disabled.
+  // Also disable auto-titling: with the stub model it appends a session_info
+  // line and broadcasts a "reload" at an unpredictable moment, re-rendering
+  // #messages and racing tests that assert on freshly-created DOM (e.g.
+  // annotation highlights). Deterministic test env > background titling.
   const res = await fetch(`${baseURL}/api/settings`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ settings: { "pi-web:v1:cat:enabled": "false" } }),
+    body: JSON.stringify({
+      settings: {
+        "pi-web:v1:cat:enabled": "false",
+        "pi-web:v1:auto-title:enabled": "false",
+      },
+    }),
   });
   if (!res.ok) {
-    throw new Error(`failed to disable cat gatekeeper: HTTP ${res.status}`);
+    throw new Error(`failed to seed test settings: HTTP ${res.status}`);
   }
 
   const state: ServerState = { baseURL, agentDir, sessionsDir, pid: child.pid! };

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -18,10 +18,15 @@ export default async function globalSetup() {
   const res = await fetch(`${baseURL}/api/settings`, {
     method: "POST",
     headers: { "content-type": "application/json" },
+    // Show all artifacts by default (empty include filter). The product default
+    // is "*.md, *.html", which would hide the .go writes and code snippets the
+    // artifacts behavior tests assert on. The dedicated filter tests opt into a
+    // filter explicitly; everything else runs unfiltered for determinism.
     body: JSON.stringify({
       settings: {
         "pi-web:v1:cat:enabled": "false",
         "pi-web:v1:auto-title:enabled": "false",
+        "pi-web:v1:artifacts:include": "",
       },
     }),
   });

--- a/e2e/lib/test.ts
+++ b/e2e/lib/test.ts
@@ -26,6 +26,9 @@ export const test = base.extend<Fixtures>({
     await page.addInitScript(() => {
       try {
         localStorage.setItem("pi-web:v1:cat:enabled", "false");
+        // Mirror the server-seeded "show all" artifact filter for the synchronous
+        // pre-hydration read. Filter tests override this with their own init script.
+        localStorage.setItem("pi-web:v1:artifacts:include", "");
       } catch {
         /* ignore */
       }

--- a/e2e/tests/annotations.spec.ts
+++ b/e2e/tests/annotations.spec.ts
@@ -15,6 +15,16 @@ async function openRightSidebar(page: import("@playwright/test").Page) {
   }
 }
 
+async function collapseRightSidebar(page: import("@playwright/test").Page) {
+  const collapsed = await page.evaluate(() =>
+    document.body.classList.contains("right-sidebar-collapsed"),
+  );
+  if (!collapsed) {
+    await page.locator("#toggle-right-sidebar-btn").click();
+  }
+  await expect(page.locator("body")).toHaveClass(/right-sidebar-collapsed/);
+}
+
 /**
  * Select a word inside the first assistant message and fire mouseup so the
  * annotation popover appears, then save a note. Selection is built in-page for
@@ -168,5 +178,27 @@ test.describe("annotations", () => {
     await page.locator('.annotation-item [data-action="delete"]').click();
     await expect(page.locator(".annotation-item")).toHaveCount(0);
     await expect(page.locator("#messages mark.pi-annotation")).toHaveCount(0);
+  });
+
+  test("saving a note reveals the sidebar on the Annotations tab", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const { entries } = buildSession({ cwd: realWorkingDir() });
+    const name = uniqueSessionName(testInfo, "ann");
+    const id = writeSession(sessionsDir, name, entries);
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+
+    // Start with the sidebar hidden, then annotate without touching it manually.
+    await collapseRightSidebar(page);
+    await annotateFirstMessage(page, "open me");
+
+    // onCreate should have opened the sidebar and switched to the Notes tab —
+    // no openRightSidebar() / tab click here on purpose.
+    await expect(page.locator("body")).not.toHaveClass(/right-sidebar-collapsed/);
+    await expect(page.locator("#right-tab-notes")).toHaveClass(/active/);
+    await expect(page.locator("#right-pane-notes")).toBeVisible();
+    await expect(page.locator(".annotation-item .annotation-note")).toHaveText("open me");
   });
 });

--- a/e2e/tests/annotations.spec.ts
+++ b/e2e/tests/annotations.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from "../lib/test";
+import {
+  buildSession,
+  realWorkingDir,
+  uniqueSessionName,
+  writeSession,
+} from "../lib/sessions";
+
+async function openRightSidebar(page: import("@playwright/test").Page) {
+  const collapsed = await page.evaluate(() =>
+    document.body.classList.contains("right-sidebar-collapsed"),
+  );
+  if (collapsed) {
+    await page.locator("#toggle-right-sidebar-btn").click();
+  }
+}
+
+/**
+ * Select a word inside the first assistant message and fire mouseup so the
+ * annotation popover appears, then save a note. Selection is built in-page for
+ * cross-browser determinism (no flaky mouse-drag coordinates).
+ */
+async function annotateFirstMessage(
+  page: import("@playwright/test").Page,
+  note: string,
+) {
+  const selected = await page.evaluate(() => {
+    const messages = document.getElementById("messages")!;
+    const walker = document.createTreeWalker(messages, NodeFilter.SHOW_TEXT);
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+      const m = node.nodeValue && node.nodeValue.match(/[A-Za-z]{4,}/);
+      if (m) {
+        const startOff = node.nodeValue!.indexOf(m[0]);
+        const range = document.createRange();
+        range.setStart(node, startOff);
+        range.setEnd(node, startOff + m[0].length);
+        const sel = window.getSelection()!;
+        sel.removeAllRanges();
+        sel.addRange(range);
+        document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+        return m[0];
+      }
+    }
+    return "";
+  });
+
+  await page.locator('.annotation-popover [data-action="start-comment"]').click();
+  await page.locator(".annotation-note-input").fill(note);
+  await page.locator('[data-action="save-note"]').click();
+  return selected;
+}
+
+test.describe("annotations", () => {
+  test("annotate a message, highlight it, and send the note to pi", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const { entries } = buildSession({ cwd: realWorkingDir() });
+    const name = uniqueSessionName(testInfo, "ann");
+    const id = writeSession(sessionsDir, name, entries);
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+
+    // Annotate while the sidebar is closed: the popover lives over #messages and
+    // needs no sidebar, and on mobile an open sidebar's backdrop would block it.
+    const word = await annotateFirstMessage(page, "rename this");
+
+    // Inline highlight on the chosen word.
+    const mark = page.locator("#messages mark.pi-annotation");
+    await expect(mark).toHaveText(word);
+
+    // Notes tab badge + entry.
+    await openRightSidebar(page);
+    await expect(page.locator("#annotation-tab-count")).toHaveText("1");
+    await page.locator("#right-tab-notes").click();
+    await expect(page.locator(".annotation-item .annotation-note")).toHaveText("rename this");
+
+    // Send to pi fills (not submits) the composer.
+    await page.locator('[data-action="send-to-pi"]').click();
+    await expect(page.locator("#pi-chat-message")).toHaveValue(/rename this/);
+  });
+
+  test("annotate text inside an artifact's source", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const { entries, lastId } = buildSession({ cwd: realWorkingDir() });
+    const writeId = `e2e-art-${Date.now()}`;
+    entries.push({
+      type: "message",
+      id: writeId,
+      parentId: lastId,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: `wc-${Date.now()}`,
+            name: "write",
+            arguments: { file_path: "widget.go", content: 'package widget\n\nfunc New() {}\n' },
+          },
+        ],
+        timestamp: Date.now(),
+      },
+    });
+    const name = uniqueSessionName(testInfo, "ann");
+    const id = writeSession(sessionsDir, name, entries);
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await openRightSidebar(page);
+    await page.locator("#right-tab-artifacts").click();
+    await page.locator(".artifact-list-item", { hasText: "widget.go" }).click();
+
+    // Select a word inside the artifact source and open the popover.
+    const word = await page.evaluate(() => {
+      const pre = document.querySelector("pre.artifact-source")!;
+      const walker = document.createTreeWalker(pre, NodeFilter.SHOW_TEXT);
+      let node: Node | null;
+      while ((node = walker.nextNode())) {
+        const m = node.nodeValue && node.nodeValue.match(/[A-Za-z]{4,}/);
+        if (m) {
+          const off = node.nodeValue!.indexOf(m[0]);
+          const range = document.createRange();
+          range.setStart(node, off);
+          range.setEnd(node, off + m[0].length);
+          const sel = window.getSelection()!;
+          sel.removeAllRanges();
+          sel.addRange(range);
+          document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+          return m[0];
+        }
+      }
+      return "";
+    });
+
+    await page.locator('.annotation-popover [data-action="start-comment"]').click();
+    await page.locator(".annotation-note-input").fill("refactor this");
+    await page.locator('[data-action="save-note"]').click();
+
+    // Highlight lands inside the artifact source, and the note shows in Notes.
+    await expect(page.locator("pre.artifact-source mark.pi-annotation")).toHaveText(word);
+    await page.locator("#right-tab-notes").click();
+    await expect(page.locator(".annotation-item .annotation-note")).toHaveText("refactor this");
+
+    // Sending to pi references the file path + line number, not just the quote.
+    await page.locator('[data-action="send-to-pi"]').click();
+    await expect(page.locator("#pi-chat-message")).toHaveValue(/In widget\.go:/);
+    await expect(page.locator("#pi-chat-message")).toHaveValue(/Line \d+ —/);
+  });
+
+  test("delete a note", async ({ page, sessionsDir }, testInfo) => {
+    const { entries } = buildSession({ cwd: realWorkingDir() });
+    const name = uniqueSessionName(testInfo, "ann");
+    const id = writeSession(sessionsDir, name, entries);
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await annotateFirstMessage(page, "remove me");
+    // Wait for the highlight (confirms the annotation persisted) before opening
+    // the Notes tab, so we don't race the create round-trip.
+    await expect(page.locator("#messages mark.pi-annotation")).toHaveCount(1);
+
+    await openRightSidebar(page);
+    await page.locator("#right-tab-notes").click();
+    await expect(page.locator(".annotation-item")).toHaveCount(1);
+
+    await page.locator('.annotation-item [data-action="delete"]').click();
+    await expect(page.locator(".annotation-item")).toHaveCount(0);
+    await expect(page.locator("#messages mark.pi-annotation")).toHaveCount(0);
+  });
+});

--- a/e2e/tests/annotations.spec.ts
+++ b/e2e/tests/annotations.spec.ts
@@ -201,4 +201,39 @@ test.describe("annotations", () => {
     await expect(page.locator("#right-pane-notes")).toBeVisible();
     await expect(page.locator(".annotation-item .annotation-note")).toHaveText("open me");
   });
+
+  test("sending notes to pi collapses the sidebar and focuses the composer on mobile", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const { entries } = buildSession({ cwd: realWorkingDir() });
+    const name = uniqueSessionName(testInfo, "ann");
+    const id = writeSession(sessionsDir, name, entries);
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+
+    // Create a note; onCreate opens the sidebar on the Notes tab, where the
+    // "Send … to pi" button lives.
+    await annotateFirstMessage(page, "ship it");
+    const sendBtn = page.locator('[data-action="send-to-pi"]');
+    await expect(sendBtn).toBeVisible();
+
+    const mobile = await page.evaluate(() =>
+      window.matchMedia("(max-width: 900px)").matches,
+    );
+
+    await sendBtn.click();
+
+    // The composer is filled regardless of layout.
+    await expect(page.locator("#pi-chat-message")).toHaveValue(/ship it/);
+
+    if (mobile) {
+      // The overlay sidebar gets out of the way and the composer takes focus.
+      await expect(page.locator("body")).toHaveClass(/right-sidebar-collapsed/);
+      await expect(page.locator("#pi-chat-message")).toBeFocused();
+    } else {
+      // Desktop keeps the sidebar in place beside the content.
+      await expect(page.locator("body")).not.toHaveClass(/right-sidebar-collapsed/);
+    }
+  });
 });

--- a/e2e/tests/artifacts.spec.ts
+++ b/e2e/tests/artifacts.spec.ts
@@ -346,11 +346,18 @@ test.describe("artifacts panel", () => {
     await seedArtifactSetting(page, "pi-web:v1:artifacts:enabled", "false");
     await page.goto(`/session?id=${encodeURIComponent(id)}`);
 
-    // The tab element exists but is hidden via its `hidden` property.
-    const tabHidden = await page
-      .locator("#right-tab-artifacts")
-      .evaluate((el) => (el as HTMLElement).hidden);
-    expect(tabHidden).toBe(true);
+    // Open the sidebar so its tabs are laid out (collapsed on mobile).
+    const collapsed = await page.evaluate(() =>
+      document.body.classList.contains("right-sidebar-collapsed"),
+    );
+    if (collapsed) await page.locator("#toggle-right-sidebar-btn").click();
+
+    // The Artifacts tab is actually not rendered (visibility, not just the
+    // `hidden` property) while its siblings remain visible — guards against the
+    // CSS `display` rule overriding the `[hidden]` attribute.
+    await expect(page.locator("#right-tab-scratchpad")).toBeVisible();
+    await expect(page.locator("#right-tab-notes")).toBeVisible();
+    await expect(page.locator("#right-tab-artifacts")).toBeHidden();
     // Scratchpad remains the active tab.
     await expect(page.locator("#right-tab-scratchpad")).toHaveClass(/active/);
   });

--- a/e2e/tests/artifacts.spec.ts
+++ b/e2e/tests/artifacts.spec.ts
@@ -89,6 +89,54 @@ function sessionWithRename() {
   return entries;
 }
 
+/**
+ * One assistant turn producing a mix of artifacts so include filters have
+ * something to keep and something to drop:
+ *   - write notes.md       (matches *.md)
+ *   - write page.html      (matches *.html)
+ *   - write src/widget.go  (matches neither)
+ *   - a fenced ```html block → snippet (no path; dropped by any non-empty filter)
+ */
+function sessionWithMixedArtifacts() {
+  const { entries, lastId } = buildSession();
+  const id = `e2e-mixed-${Date.now()}`;
+  entries.push({
+    type: "message",
+    id,
+    parentId: lastId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Snippet:\n\n```html\n<b>hi</b>\n```" },
+        { type: "toolCall", id: `mc1-${Date.now()}`, name: "write", arguments: { file_path: "notes.md", content: "# Notes\n" } },
+        { type: "toolCall", id: `mc2-${Date.now()}`, name: "write", arguments: { file_path: "page.html", content: "<h1>Page</h1>\n" } },
+        { type: "toolCall", id: `mc3-${Date.now()}`, name: "write", arguments: { file_path: "src/widget.go", content: "package widget\n" } },
+      ],
+      timestamp: Date.now(),
+    },
+  });
+  return entries;
+}
+
+/** Seed an artifact setting in localStorage before the page's scripts run. */
+async function seedArtifactSetting(
+  page: import("@playwright/test").Page,
+  key: string,
+  value: string,
+) {
+  await page.addInitScript(
+    ([k, v]) => {
+      try {
+        localStorage.setItem(k, v);
+      } catch {
+        /* ignore */
+      }
+    },
+    [key, value] as const,
+  );
+}
+
 async function openArtifactsTab(page: import("@playwright/test").Page) {
   // The right sidebar is open by default on desktop but collapsed on mobile;
   // toggle it open only when collapsed so we don't accidentally close it.
@@ -249,5 +297,61 @@ test.describe("artifacts panel", () => {
       page.locator('.artifact-action[data-action="download"]').click(),
     ]);
     expect(download.suggestedFilename()).toBe("widget.go");
+  });
+
+  test("include filter keeps matching files and drops others + snippets", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithMixedArtifacts());
+
+    await seedArtifactSetting(page, "pi-web:v1:artifacts:include", "*.md, *.html");
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await openArtifactsTab(page);
+
+    // notes.md + page.html survive; src/widget.go and the html snippet are hidden.
+    await expect(page.locator("#artifact-tab-count")).toHaveText("2");
+    await expect(page.locator(".artifact-list-item")).toHaveCount(2);
+    await expect(page.locator(".artifact-list-item", { hasText: "notes.md" })).toBeVisible();
+    await expect(page.locator(".artifact-list-item", { hasText: "page.html" })).toBeVisible();
+    await expect(page.locator(".artifact-list-item", { hasText: "widget.go" })).toHaveCount(0);
+  });
+
+  test("empty-state hint links to Settings when the filter hides everything", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithMixedArtifacts());
+
+    // A filter that matches none of the four artifacts.
+    await seedArtifactSetting(page, "pi-web:v1:artifacts:include", "*.rs");
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await openArtifactsTab(page);
+
+    await expect(page.locator(".artifact-list-item")).toHaveCount(0);
+    const empty = page.locator(".artifact-empty");
+    await expect(empty).toContainText("hidden by your filter");
+    await expect(empty.locator('a[href="/settings"]')).toBeVisible();
+  });
+
+  test("disabling artifacts hides the tab and falls back to Scratchpad", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithArtifacts());
+
+    await seedArtifactSetting(page, "pi-web:v1:artifacts:enabled", "false");
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+
+    // The tab element exists but is hidden via its `hidden` property.
+    const tabHidden = await page
+      .locator("#right-tab-artifacts")
+      .evaluate((el) => (el as HTMLElement).hidden);
+    expect(tabHidden).toBe(true);
+    // Scratchpad remains the active tab.
+    await expect(page.locator("#right-tab-scratchpad")).toHaveClass(/active/);
   });
 });

--- a/e2e/tests/artifacts.spec.ts
+++ b/e2e/tests/artifacts.spec.ts
@@ -361,4 +361,31 @@ test.describe("artifacts panel", () => {
     // Scratchpad remains the active tab.
     await expect(page.locator("#right-tab-scratchpad")).toHaveClass(/active/);
   });
+
+  test("reflects a setting change from another tab live (no reload)", async ({
+    page,
+    context,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithArtifacts());
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    const collapsed = await page.evaluate(() =>
+      document.body.classList.contains("right-sidebar-collapsed"),
+    );
+    if (collapsed) await page.locator("#toggle-right-sidebar-btn").click();
+    await expect(page.locator("#right-tab-artifacts")).toBeVisible();
+
+    // A second tab in the same context flips the setting; the shared-localStorage
+    // write fires a `storage` event in the open session, which re-runs the filter.
+    const other = await context.newPage();
+    await other.goto("/");
+    await other.evaluate(() =>
+      localStorage.setItem("pi-web:v1:artifacts:enabled", "false"),
+    );
+
+    await expect(page.locator("#right-tab-artifacts")).toBeHidden();
+    await other.close();
+  });
 });

--- a/e2e/tests/artifacts.spec.ts
+++ b/e2e/tests/artifacts.spec.ts
@@ -1,0 +1,253 @@
+import { test, expect } from "../lib/test";
+import { buildSession, uniqueSessionName, writeSession } from "../lib/sessions";
+
+/**
+ * Build a session whose assistant turn produces two artifacts:
+ *   - a fenced ```html block  → preview-kind artifact
+ *   - a `write` of src/widget.go → code-kind artifact
+ */
+function sessionWithArtifacts() {
+  const { entries, lastId } = buildSession();
+  const id = `e2e-artifact-${Date.now()}`;
+  entries.push({
+    type: "message",
+    id,
+    parentId: lastId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Rendered the hero markup:\n\n```html\n<section class="hero">\n  <h1>Hello</h1>\n  <p>World</p>\n</section>\n```',
+        },
+        {
+          type: "toolCall",
+          id: `wc-${Date.now()}`,
+          name: "write",
+          arguments: {
+            file_path: "src/widget.go",
+            content: 'package widget\n\nfunc New() string {\n\treturn "hi"\n}\n',
+          },
+        },
+      ],
+      timestamp: Date.now(),
+    },
+  });
+  return entries;
+}
+
+function sessionWithMarkdown() {
+  const { entries, lastId } = buildSession();
+  const id = `e2e-md-${Date.now()}`;
+  entries.push({
+    type: "message",
+    id,
+    parentId: lastId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: `mc-${Date.now()}`,
+          name: "write",
+          arguments: { file_path: "notes.md", content: "# Heading\n\nSome **bold** text.\n" },
+        },
+      ],
+      timestamp: Date.now(),
+    },
+  });
+  return entries;
+}
+
+function sessionWithRename() {
+  const { entries, lastId } = buildSession();
+  const writeId = `e2e-w-${Date.now()}`;
+  const bashId = `bc-${Date.now()}`;
+  entries.push({
+    type: "message",
+    id: writeId,
+    parentId: lastId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      content: [
+        { type: "toolCall", id: `wc-${Date.now()}`, name: "write", arguments: { file_path: "daytrip.md", content: "# Trip\n" } },
+        { type: "toolCall", id: bashId, name: "bash", arguments: { command: "mv daytrip.md day-trip.md" } },
+      ],
+      timestamp: Date.now(),
+    },
+  });
+  entries.push({
+    type: "message",
+    id: `tr-${Date.now()}`,
+    parentId: writeId,
+    timestamp: new Date().toISOString(),
+    message: { role: "toolResult", toolCallId: bashId, isError: false, content: [{ type: "text", text: "ok" }] },
+  });
+  return entries;
+}
+
+async function openArtifactsTab(page: import("@playwright/test").Page) {
+  // The right sidebar is open by default on desktop but collapsed on mobile;
+  // toggle it open only when collapsed so we don't accidentally close it.
+  const collapsed = await page.evaluate(() =>
+    document.body.classList.contains("right-sidebar-collapsed"),
+  );
+  if (collapsed) {
+    await page.locator("#toggle-right-sidebar-btn").click();
+  }
+  await page.locator("#right-tab-artifacts").click();
+  await expect(page.locator("#right-pane-artifacts")).toBeVisible();
+}
+
+test.describe("artifacts panel", () => {
+  test("lists write + fenced-block artifacts with a count badge", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithArtifacts());
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await openArtifactsTab(page);
+
+    await expect(page.locator("#artifact-tab-count")).toHaveText("2");
+    await expect(page.locator(".artifact-list-item")).toHaveCount(2);
+    await expect(
+      page.locator(".artifact-list-item", { hasText: "widget.go" }),
+    ).toBeVisible();
+    // Exactly one previewable artifact (the html block) carries the badge.
+    await expect(page.locator(".artifact-list-item .artifact-badge")).toHaveCount(1);
+  });
+
+  test("selecting an artifact shows its source", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithArtifacts());
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await openArtifactsTab(page);
+
+    await page.locator(".artifact-list-item", { hasText: "widget.go" }).click();
+    await expect(page.locator(".artifact-view-title")).toHaveText("widget.go");
+    await expect(page.locator(".artifact-source")).toContainText("package widget");
+
+    await page.locator(".artifact-list-item .artifact-badge").click();
+    await expect(page.locator(".artifact-source")).toContainText('class="hero"');
+  });
+
+  test("runs a preview-kind artifact in a sandboxed iframe", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithArtifacts());
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await openArtifactsTab(page);
+
+    // The previewable artifact is the html block (it carries the badge).
+    await page.locator(".artifact-list-item .artifact-badge").click();
+    const runBtn = page.locator('.artifact-action[data-action="toggle-preview"]');
+    await expect(runBtn).toHaveText("Run preview");
+    // Click-to-run: nothing executes until the user opts in.
+    await expect(page.locator("iframe.artifact-preview")).toHaveCount(0);
+
+    await runBtn.click();
+
+    const frame = page.locator("iframe.artifact-preview");
+    await expect(frame).toBeVisible();
+    await expect(frame).toHaveAttribute("sandbox", "allow-scripts");
+    // The iframe actually renders the markup (opaque-origin srcdoc document).
+    await expect(
+      page.frameLocator("iframe.artifact-preview").locator("h1"),
+    ).toHaveText("Hello");
+    await expect(runBtn).toHaveText("Show source");
+
+    // Toggling back removes the frame and restores the source view.
+    await runBtn.click();
+    await expect(page.locator("iframe.artifact-preview")).toHaveCount(0);
+    await expect(page.locator(".artifact-source")).toContainText('class="hero"');
+  });
+
+  test("previews a markdown artifact inline (not an iframe)", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithMarkdown());
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await openArtifactsTab(page);
+
+    await page.locator(".artifact-list-item", { hasText: "notes.md" }).click();
+    const previewBtn = page.locator('.artifact-action[data-action="toggle-preview"]');
+    await expect(previewBtn).toHaveText("Preview");
+
+    await previewBtn.click();
+
+    // Rendered markdown, no iframe.
+    await expect(page.locator(".artifact-markdown h1")).toHaveText("Heading");
+    await expect(page.locator(".artifact-markdown strong")).toHaveText("bold");
+    await expect(page.locator("iframe.artifact-preview")).toHaveCount(0);
+  });
+
+  test("follows a rename via bash mv (one card, new name)", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithRename());
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await openArtifactsTab(page);
+
+    await expect(page.locator(".artifact-list-item")).toHaveCount(1);
+    await expect(page.locator(".artifact-list-item", { hasText: "day-trip.md" })).toBeVisible();
+  });
+
+  test("explains artifacts and limitations via the help (?) button", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithArtifacts());
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await openArtifactsTab(page);
+
+    const helpBtn = page.locator("#artifact-help-btn");
+    await expect(helpBtn).toBeVisible();
+    await helpBtn.click();
+
+    const modal = page.locator("#artifact-help-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText("How artifacts work");
+    await expect(modal).toContainText("other shell commands");
+
+    await page.locator(".artifact-help-close").click();
+    await expect(modal).toBeHidden();
+  });
+
+  test("downloads the selected artifact with its filename", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const name = uniqueSessionName(testInfo, "art");
+    const id = writeSession(sessionsDir, name, sessionWithArtifacts());
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+    await openArtifactsTab(page);
+
+    await page.locator(".artifact-list-item", { hasText: "widget.go" }).click();
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator('.artifact-action[data-action="download"]').click(),
+    ]);
+    expect(download.suggestedFilename()).toBe("widget.go");
+  });
+});

--- a/internal/server/annotations.go
+++ b/internal/server/annotations.go
@@ -1,0 +1,194 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Annotations are reviewer-authored notes anchored to a span of a rendered
+// session entry (or artifact). They are NOT session data — they live in the
+// app database, keyed by session id, and never touch the append-only JSONL.
+const annotationsSchema = `CREATE TABLE IF NOT EXISTS annotations (
+	id           TEXT PRIMARY KEY,
+	session_id   TEXT NOT NULL,
+	anchor_id    TEXT NOT NULL,
+	start_offset INTEGER NOT NULL,
+	end_offset   INTEGER NOT NULL,
+	kind         TEXT NOT NULL,
+	text         TEXT,
+	original     TEXT,
+	source       TEXT,
+	created_at   INTEGER
+)`
+
+const annotationsIndex = `CREATE INDEX IF NOT EXISTS idx_annotations_session ON annotations (session_id)`
+
+type annotation struct {
+	ID          string `json:"id"`
+	SessionID   string `json:"sessionId"`
+	AnchorID    string `json:"anchorId"`
+	StartOffset int    `json:"startOffset"`
+	EndOffset   int    `json:"endOffset"`
+	Kind        string `json:"kind"`
+	Text        string `json:"text"`
+	Original    string `json:"original"`
+	Source      string `json:"source"`
+	CreatedAt   int64  `json:"createdAt"`
+}
+
+func newAnnotationID() string {
+	b := make([]byte, 12)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("ann-%d", time.Now().UnixNano())
+	}
+	return "ann-" + hex.EncodeToString(b)
+}
+
+func (s *Server) listAnnotations(sessionID string) ([]annotation, error) {
+	out := []annotation{}
+	if s.db == nil || sessionID == "" {
+		return out, nil
+	}
+	rows, err := s.db.Query(`SELECT id, session_id, anchor_id, start_offset, end_offset, kind, text, original, source, created_at
+		FROM annotations WHERE session_id = ? ORDER BY created_at, id`, sessionID)
+	if err != nil {
+		return out, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var a annotation
+		if err := rows.Scan(&a.ID, &a.SessionID, &a.AnchorID, &a.StartOffset, &a.EndOffset,
+			&a.Kind, &a.Text, &a.Original, &a.Source, &a.CreatedAt); err != nil {
+			return out, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// broadcastAnnotations pushes the full annotation set for a session to every SSE
+// client on that session topic. A snapshot (rather than granular add/remove
+// events) keeps the client simple: it just re-renders.
+func (s *Server) broadcastAnnotations(sessionID string) {
+	anns, err := s.listAnnotations(sessionID)
+	if err != nil {
+		return
+	}
+	msg, err := formatSSEJSONEvent("annotations", map[string]any{"type": "snapshot", "annotations": anns})
+	if err != nil {
+		return
+	}
+	s.broadcast(sessionID, msg)
+}
+
+func (s *Server) handleAnnotations(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleListAnnotations(w, r)
+	case http.MethodPost:
+		s.handleCreateAnnotation(w, r)
+	case http.MethodDelete:
+		s.handleDeleteAnnotation(w, r)
+	default:
+		w.Header().Set("Allow", "GET, POST, DELETE")
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (s *Server) handleListAnnotations(w http.ResponseWriter, r *http.Request) {
+	session := r.URL.Query().Get("session")
+	if session == "" {
+		writeJSONError(w, http.StatusBadRequest, "session query parameter is required")
+		return
+	}
+	if s.db == nil {
+		writeJSONError(w, http.StatusInternalServerError, "database is unavailable")
+		return
+	}
+	anns, err := s.listAnnotations(session)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to query annotations: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"annotations": anns})
+}
+
+func (s *Server) handleCreateAnnotation(w http.ResponseWriter, r *http.Request) {
+	session := r.URL.Query().Get("session")
+	if session == "" {
+		writeJSONError(w, http.StatusBadRequest, "session query parameter is required")
+		return
+	}
+	if s.db == nil {
+		writeJSONError(w, http.StatusInternalServerError, "database is unavailable")
+		return
+	}
+
+	var a annotation
+	if err := json.NewDecoder(r.Body).Decode(&a); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	if a.AnchorID == "" {
+		writeJSONError(w, http.StatusBadRequest, "anchorId is required")
+		return
+	}
+	if a.EndOffset < a.StartOffset || a.StartOffset < 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid offsets")
+		return
+	}
+
+	a.SessionID = session
+	if a.ID == "" {
+		a.ID = newAnnotationID()
+	}
+	if a.Kind == "" {
+		a.Kind = "comment"
+	}
+	if a.Source == "" {
+		a.Source = "local"
+	}
+	if a.CreatedAt == 0 {
+		a.CreatedAt = time.Now().UnixMilli()
+	}
+
+	_, err := s.db.Exec(`INSERT INTO annotations
+		(id, session_id, anchor_id, start_offset, end_offset, kind, text, original, source, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			anchor_id=excluded.anchor_id, start_offset=excluded.start_offset, end_offset=excluded.end_offset,
+			kind=excluded.kind, text=excluded.text, original=excluded.original`,
+		a.ID, a.SessionID, a.AnchorID, a.StartOffset, a.EndOffset, a.Kind, a.Text, a.Original, a.Source, a.CreatedAt)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to save annotation: "+err.Error())
+		return
+	}
+
+	s.broadcastAnnotations(session)
+	writeJSON(w, http.StatusOK, map[string]any{"annotation": a})
+}
+
+func (s *Server) handleDeleteAnnotation(w http.ResponseWriter, r *http.Request) {
+	session := r.URL.Query().Get("session")
+	id := r.URL.Query().Get("id")
+	if session == "" || id == "" {
+		writeJSONError(w, http.StatusBadRequest, "session and id query parameters are required")
+		return
+	}
+	if s.db == nil {
+		writeJSONError(w, http.StatusInternalServerError, "database is unavailable")
+		return
+	}
+
+	if _, err := s.db.Exec(`DELETE FROM annotations WHERE id = ? AND session_id = ?`, id, session); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to delete annotation: "+err.Error())
+		return
+	}
+
+	s.broadcastAnnotations(session)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}

--- a/internal/server/annotations_test.go
+++ b/internal/server/annotations_test.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func newAnnotationsDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := db.Exec(annotationsSchema); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(annotationsIndex); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func postAnnotation(t *testing.T, s *Server, session, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/annotations?session="+session, bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	s.handleAnnotations(w, req)
+	return w
+}
+
+func TestAnnotationsCreateAndList(t *testing.T) {
+	s := &Server{db: newAnnotationsDB(t)}
+
+	w := postAnnotation(t, s, "s1.jsonl", `{"anchorId":"entry-e2","startOffset":3,"endOffset":10,"text":"fix this","original":"the world"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create status = %d: %s", w.Code, w.Body.String())
+	}
+	var created struct {
+		Annotation annotation `json:"annotation"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if created.Annotation.ID == "" {
+		t.Fatal("expected a generated id")
+	}
+	if created.Annotation.Kind != "comment" || created.Annotation.Source != "local" {
+		t.Fatalf("expected defaults applied, got kind=%q source=%q", created.Annotation.Kind, created.Annotation.Source)
+	}
+	if created.Annotation.CreatedAt == 0 {
+		t.Fatal("expected createdAt to be set")
+	}
+
+	// List returns it, scoped to the session.
+	req := httptest.NewRequest(http.MethodGet, "/api/annotations?session=s1.jsonl", nil)
+	lw := httptest.NewRecorder()
+	s.handleAnnotations(lw, req)
+	if lw.Code != http.StatusOK {
+		t.Fatalf("list status = %d", lw.Code)
+	}
+	var listed struct {
+		Annotations []annotation `json:"annotations"`
+	}
+	if err := json.Unmarshal(lw.Body.Bytes(), &listed); err != nil {
+		t.Fatal(err)
+	}
+	if len(listed.Annotations) != 1 {
+		t.Fatalf("expected 1 annotation, got %d", len(listed.Annotations))
+	}
+	if listed.Annotations[0].Text != "fix this" || listed.Annotations[0].AnchorID != "entry-e2" {
+		t.Fatalf("unexpected annotation: %+v", listed.Annotations[0])
+	}
+
+	// A different session sees none.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/annotations?session=other.jsonl", nil)
+	lw2 := httptest.NewRecorder()
+	s.handleAnnotations(lw2, req2)
+	var listed2 struct {
+		Annotations []annotation `json:"annotations"`
+	}
+	_ = json.Unmarshal(lw2.Body.Bytes(), &listed2)
+	if len(listed2.Annotations) != 0 {
+		t.Fatalf("expected session scoping, got %d", len(listed2.Annotations))
+	}
+}
+
+func TestAnnotationsUpsertAndDelete(t *testing.T) {
+	s := &Server{db: newAnnotationsDB(t)}
+
+	// Create with an explicit id, then upsert (same id) updates text in place.
+	postAnnotation(t, s, "s1.jsonl", `{"id":"a1","anchorId":"entry-e2","startOffset":0,"endOffset":4,"text":"first"}`)
+	postAnnotation(t, s, "s1.jsonl", `{"id":"a1","anchorId":"entry-e2","startOffset":0,"endOffset":4,"text":"second"}`)
+
+	anns, err := s.listAnnotations("s1.jsonl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(anns) != 1 || anns[0].Text != "second" {
+		t.Fatalf("expected single upserted annotation 'second', got %+v", anns)
+	}
+
+	// Delete removes it.
+	req := httptest.NewRequest(http.MethodDelete, "/api/annotations?session=s1.jsonl&id=a1", nil)
+	w := httptest.NewRecorder()
+	s.handleAnnotations(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete status = %d", w.Code)
+	}
+	anns, _ = s.listAnnotations("s1.jsonl")
+	if len(anns) != 0 {
+		t.Fatalf("expected 0 after delete, got %d", len(anns))
+	}
+}
+
+func TestAnnotationsValidation(t *testing.T) {
+	s := &Server{db: newAnnotationsDB(t)}
+
+	cases := []struct {
+		name, session, body string
+		method              string
+		query               string
+		want                int
+	}{
+		{name: "missing session", session: "", body: `{"anchorId":"entry-e2","startOffset":0,"endOffset":1}`, want: http.StatusBadRequest},
+		{name: "missing anchor", session: "s1.jsonl", body: `{"startOffset":0,"endOffset":1}`, want: http.StatusBadRequest},
+		{name: "bad offsets", session: "s1.jsonl", body: `{"anchorId":"entry-e2","startOffset":5,"endOffset":2}`, want: http.StatusBadRequest},
+		{name: "invalid json", session: "s1.jsonl", body: `{not json`, want: http.StatusBadRequest},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := postAnnotation(t, s, c.session, c.body)
+			if w.Code != c.want {
+				t.Fatalf("got %d, want %d (%s)", w.Code, c.want, w.Body.String())
+			}
+		})
+	}
+
+	// Unsupported method.
+	req := httptest.NewRequest(http.MethodPut, "/api/annotations?session=s1.jsonl", nil)
+	w := httptest.NewRecorder()
+	s.handleAnnotations(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for PUT, got %d", w.Code)
+	}
+
+	// Nil db.
+	sNoDB := &Server{}
+	wNoDB := postAnnotation(t, sNoDB, "s1.jsonl", `{"anchorId":"entry-e2","startOffset":0,"endOffset":1}`)
+	if wNoDB.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for nil db, got %d", wNoDB.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -120,6 +120,11 @@ func New(deps Deps) *Server {
 	if dbErr != nil {
 		fmt.Fprintf(os.Stderr, "failed to open sqlite database: %v\n", dbErr)
 	} else {
+		// SQLite allows only one writer at a time; multiple pooled connections
+		// racing to write surface as "database is locked" errors (e.g. concurrent
+		// annotation writes). Serialize on a single connection so writes queue
+		// instead of failing.
+		db.SetMaxOpenConns(1)
 		_, err := db.Exec(`CREATE TABLE IF NOT EXISTS scratchpads (
 			project_path TEXT PRIMARY KEY,
 			content TEXT,
@@ -144,6 +149,12 @@ func New(deps Deps) *Server {
 		}
 		if _, err := db.Exec(btwSessionsSchema); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to create btw_sessions table: %v\n", err)
+		}
+		if _, err := db.Exec(annotationsSchema); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create annotations table: %v\n", err)
+		}
+		if _, err := db.Exec(annotationsIndex); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create annotations index: %v\n", err)
 		}
 		migrateLegacyBtwSession(db)
 	}
@@ -229,6 +240,7 @@ func (s *Server) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/git/rename-branch", s.auth.Wrap(s.handleGitRenameBranch))
 	mux.HandleFunc("/custom-themes.css", s.auth.Wrap(s.handleCustomThemes))
 	mux.HandleFunc("/api/scratchpad", s.getPostHandler(s.handleGetScratchpad, s.handleSaveScratchpad))
+	mux.HandleFunc("/api/annotations", s.auth.Wrap(s.handleAnnotations))
 	mux.HandleFunc("/api/settings", s.getPostHandler(s.handleGetSettings, s.handleSaveSettings))
 	mux.HandleFunc("/api/btw", s.auth.Wrap(s.handleGetBtw))
 	mux.HandleFunc("/api/btw/new", s.auth.Wrap(s.handleNewBtw))

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -50,6 +50,8 @@ var settingDefaults = map[string]string{
 	"pi-web:v1:auto-title:enabled": "true",
 	"pi-web:v1:auto-title:mode":    "each-turn",
 	"pi-web:v1:auto-title:model":   "",
+	"pi-web:v1:artifacts:enabled":  "true",
+	"pi-web:v1:artifacts:include":  "*.md, *.html",
 }
 
 // getSettings returns every server-backed setting: defaults overlaid with any

--- a/internal/ui/live_templates/session.html
+++ b/internal/ui/live_templates/session.html
@@ -97,8 +97,8 @@
       <div class="right-sidebar-header">
         <div class="right-sidebar-tabs" role="tablist">
           <button type="button" id="right-tab-scratchpad" class="right-sidebar-tab active" role="tab" data-pane="scratchpad" aria-selected="true">Scratchpad</button>
-          <button type="button" id="right-tab-artifacts" class="right-sidebar-tab" role="tab" data-pane="artifacts" aria-selected="false">Artifacts<span id="artifact-tab-count" class="right-sidebar-tab-count" hidden>0</span></button>
           <button type="button" id="right-tab-notes" class="right-sidebar-tab" role="tab" data-pane="notes" aria-selected="false">Annotations<span id="annotation-tab-count" class="right-sidebar-tab-count" hidden>0</span></button>
+          <button type="button" id="right-tab-artifacts" class="right-sidebar-tab" role="tab" data-pane="artifacts" aria-selected="false">Artifacts<span id="artifact-tab-count" class="right-sidebar-tab-count" hidden>0</span></button>
         </div>
         <div class="right-sidebar-actions">
           <button id="artifact-help-btn" class="right-sidebar-btn artifact-help-btn" title="How artifacts work" aria-label="How artifacts work">

--- a/internal/ui/live_templates/session.html
+++ b/internal/ui/live_templates/session.html
@@ -95,14 +95,25 @@
     <div id="right-sidebar-resizer" class="right-sidebar-resizer" role="separator" aria-orientation="vertical" aria-label="Resize scratchpad sidebar"></div>
     <aside id="right-sidebar" class="right-sidebar">
       <div class="right-sidebar-header">
-        <h3>Scratchpad</h3>
+        <div class="right-sidebar-tabs" role="tablist">
+          <button type="button" id="right-tab-scratchpad" class="right-sidebar-tab active" role="tab" data-pane="scratchpad" aria-selected="true">Scratchpad</button>
+          <button type="button" id="right-tab-artifacts" class="right-sidebar-tab" role="tab" data-pane="artifacts" aria-selected="false">Artifacts<span id="artifact-tab-count" class="right-sidebar-tab-count" hidden>0</span></button>
+          <button type="button" id="right-tab-notes" class="right-sidebar-tab" role="tab" data-pane="notes" aria-selected="false">Annotations<span id="annotation-tab-count" class="right-sidebar-tab-count" hidden>0</span></button>
+        </div>
         <div class="right-sidebar-actions">
-          <button id="expand-right-sidebar" class="right-sidebar-btn" title="Expand scratchpad">
+          <button id="artifact-help-btn" class="right-sidebar-btn artifact-help-btn" title="How artifacts work" aria-label="How artifacts work">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
+              <line x1="12" y1="17" x2="12.01" y2="17"/>
+            </svg>
+          </button>
+          <button id="expand-right-sidebar" class="right-sidebar-btn" title="Expand panel">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"/>
             </svg>
           </button>
-          <button id="close-right-sidebar" class="right-sidebar-btn" title="Hide scratchpad (⌘⇧N)">
+          <button id="close-right-sidebar" class="right-sidebar-btn" title="Hide panel (⌘⇧N)">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <line x1="18" y1="6" x2="6" y2="18"></line>
               <line x1="6" y1="6" x2="18" y2="18"></line>
@@ -111,13 +122,37 @@
         </div>
       </div>
       <div class="right-sidebar-content">
-        <textarea id="scratchpad-textarea" class="scratchpad-textarea" placeholder="Write project-level notes, scratchpad, tasks...">{{.Scratchpad}}</textarea>
+        <div id="right-pane-scratchpad" class="right-sidebar-pane active" role="tabpanel" aria-labelledby="right-tab-scratchpad">
+          <textarea id="scratchpad-textarea" class="scratchpad-textarea" placeholder="Write project-level notes, scratchpad, tasks...">{{.Scratchpad}}</textarea>
+        </div>
+        <div id="right-pane-artifacts" class="right-sidebar-pane" role="tabpanel" aria-labelledby="right-tab-artifacts" hidden>
+          <div id="artifact-panel-host" class="artifact-panel-host"></div>
+        </div>
+        <div id="right-pane-notes" class="right-sidebar-pane" role="tabpanel" aria-labelledby="right-tab-notes" hidden>
+          <div id="annotation-list-host" class="annotation-list-host"></div>
+        </div>
       </div>
       <div class="right-sidebar-footer">
         <span id="scratchpad-status" class="scratchpad-status">Saved</span>
       </div>
     </aside>
     <div id="right-sidebar-backdrop" class="right-sidebar-backdrop"></div>
+    <div id="artifact-help-modal" class="artifact-help-modal" hidden>
+      <div class="artifact-help-backdrop" data-action="close-artifact-help"></div>
+      <div class="artifact-help-card" role="dialog" aria-modal="true" aria-labelledby="artifact-help-title">
+        <div class="artifact-help-header">
+          <h3 id="artifact-help-title">How artifacts work</h3>
+          <button class="artifact-help-close" data-action="close-artifact-help" aria-label="Close">&times;</button>
+        </div>
+        <div class="artifact-help-body">
+          <p><strong>Artifacts</strong> are the files the agent wrote and the larger code blocks it shared, pulled out of the conversation so you can find, read, copy, or download them in one place.</p>
+          <p><strong>Viewing.</strong> Pick one from the list to see its source. HTML, SVG, and Markdown files also have a <em>Preview</em> toggle — HTML/SVG run in a secure sandbox, Markdown renders as formatted text.</p>
+          <p><strong>Annotating.</strong> Select text in an artifact's source to leave a note. Your notes collect in the <em>Annotations</em> tab, where you can jump back to them or send them to the agent.</p>
+          <p><strong>Staying up to date.</strong> Files the agent <em>writes</em> or <em>edits</em> update automatically, and simple renames or deletes (<code>mv</code>, <code>git mv</code>, <code>rm</code>) are tracked too. But changes made through other shell commands — like <code>sed</code> or output redirects — can't be followed from the conversation, so once in a while an artifact may show an older version. When in doubt, check the file on disk.</p>
+          <p class="artifact-help-note">Artifacts are part of the live view only and aren't included in exported snapshots.</p>
+        </div>
+      </div>
+    </div>
     {{end}}
     <div id="image-modal" class="image-modal">
       <img id="modal-image" src="" alt="">

--- a/internal/ui/live_templates/settings.html
+++ b/internal/ui/live_templates/settings.html
@@ -165,6 +165,31 @@
   </section>
 
   <section class="settings-section">
+    <div class="settings-section-title">Artifacts</div>
+    <div class="settings-row">
+      <div class="settings-row-label">
+        <span class="name">Show Artifacts panel</span>
+        <span class="hint">Surface files the agent wrote and sizeable code blocks in a right-sidebar tab. When off, the tab is hidden.</span>
+      </div>
+      <div class="settings-control">
+        <label class="settings-toggle">
+          <input type="checkbox" data-setting="pi-web:v1:artifacts:enabled" data-setting-bool>
+          <span class="slider"></span>
+        </label>
+      </div>
+    </div>
+    <div class="settings-row">
+      <div class="settings-row-label">
+        <span class="name">Include filter</span>
+        <span class="hint">Comma-separated globs (e.g. <code>*.md, *.html, artifacts/**</code>). Only matching files are shown. Leave empty to show everything; any filter also hides loose chat code snippets.</span>
+      </div>
+      <div class="settings-control">
+        <input type="text" data-setting="pi-web:v1:artifacts:include" placeholder="*.md, *.html" spellcheck="false" autocapitalize="off" autocomplete="off">
+      </div>
+    </div>
+  </section>
+
+  <section class="settings-section">
     <div class="settings-section-title">Notifications</div>
     <div class="settings-row">
       <div class="settings-row-label">

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -599,10 +599,177 @@
       letter-spacing: 0.05em;
     }
 
+    .right-sidebar-tabs {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      flex: 1 1 auto;
+      min-width: 0;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }
+
+    .right-sidebar-tabs::-webkit-scrollbar {
+      display: none;
+    }
+
+    .right-sidebar-tab {
+      flex: 0 0 auto;
+      padding: 3px 8px;
+      font-family: inherit;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: 3px;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      white-space: nowrap;
+      transition: color 0.15s, background 0.15s, border-color 0.15s;
+    }
+
+    .right-sidebar-tab:hover {
+      color: var(--text);
+    }
+
+    .right-sidebar-tab.active {
+      color: var(--text);
+      background: var(--selectedBg);
+      border-color: var(--dim);
+    }
+
+    .right-sidebar-tab-count {
+      font-size: 10px;
+      font-weight: 600;
+      line-height: 1;
+      padding: 2px 5px;
+      border-radius: 8px;
+      background: var(--dim);
+      color: var(--text);
+    }
+
+    .right-sidebar-pane {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .right-sidebar-pane[hidden] {
+      display: none;
+    }
+
     .right-sidebar-actions {
       display: flex;
       align-items: center;
       gap: 4px;
+      flex: 0 0 auto;
+    }
+
+    /* The help (?) button is relevant only to the Artifacts tab. */
+    .artifact-help-btn {
+      display: none;
+    }
+
+    #right-sidebar[data-active-tab="artifacts"] .artifact-help-btn {
+      display: inline-flex;
+    }
+
+    .artifact-help-modal {
+      position: fixed;
+      inset: 0;
+      z-index: 1400;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+
+    .artifact-help-modal[hidden] {
+      display: none;
+    }
+
+    .artifact-help-backdrop {
+      position: absolute;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.55);
+    }
+
+    .artifact-help-card {
+      position: relative;
+      max-width: 460px;
+      width: 100%;
+      max-height: 80vh;
+      overflow-y: auto;
+      background: var(--surface, var(--chrome-bg));
+      border: 1px solid var(--borderMuted);
+      border-radius: 10px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+    }
+
+    .artifact-help-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--dim);
+    }
+
+    .artifact-help-header h3 {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .artifact-help-close {
+      width: 26px;
+      height: 26px;
+      font-size: 20px;
+      line-height: 1;
+      color: var(--muted);
+      background: transparent;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    .artifact-help-close:hover {
+      color: var(--text);
+      background: var(--hover);
+    }
+
+    .artifact-help-body {
+      padding: 14px 16px 18px;
+    }
+
+    .artifact-help-body p {
+      margin: 0 0 11px;
+      font-size: 13px;
+      line-height: 1.55;
+      color: var(--text);
+    }
+
+    .artifact-help-body code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12px;
+      padding: 1px 4px;
+      border-radius: 3px;
+      background: var(--selectedBg);
+    }
+
+    .artifact-help-note {
+      color: var(--muted) !important;
+      font-size: 12px !important;
+      border-top: 1px solid var(--dim);
+      padding-top: 11px;
+      margin-bottom: 0 !important;
     }
 
     .right-sidebar-btn {
@@ -677,6 +844,440 @@
 
     .scratchpad-status.saved {
       color: var(--muted);
+    }
+
+    /* ── Artifacts panel (right sidebar "Artifacts" tab) ── */
+    .artifact-panel-host {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .artifact-panel {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .artifact-empty {
+      padding: 16px 8px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .artifact-list {
+      flex-shrink: 0;
+      max-height: 35%;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      padding-bottom: 6px;
+      margin-bottom: 6px;
+      border-bottom: 1px solid var(--dim);
+    }
+
+    .artifact-list-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      width: 100%;
+      text-align: left;
+      padding: 5px 7px;
+      font-family: inherit;
+      font-size: 12px;
+      color: var(--muted);
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: 3px;
+      cursor: pointer;
+      transition: color 0.15s, background 0.15s, border-color 0.15s;
+    }
+
+    .artifact-list-item:hover {
+      color: var(--text);
+      background: var(--hover);
+    }
+
+    .artifact-list-item.active {
+      color: var(--text);
+      background: var(--selectedBg);
+      border-color: var(--dim);
+    }
+
+    .artifact-item-title {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .artifact-item-lang {
+      flex-shrink: 0;
+      font-size: 10px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .artifact-badge {
+      flex-shrink: 0;
+      font-size: 9px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 1px 5px;
+      border-radius: 8px;
+      background: var(--accent);
+      color: var(--chrome-bg);
+    }
+
+    .artifact-view {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .artifact-view-header {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding-bottom: 6px;
+    }
+
+    .artifact-view-title {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .artifact-view-actions {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      flex-shrink: 0;
+    }
+
+    .artifact-action {
+      padding: 3px 8px;
+      font-family: inherit;
+      font-size: 11px;
+      color: var(--muted);
+      background: transparent;
+      border: 1px solid var(--dim);
+      border-radius: 3px;
+      cursor: pointer;
+      transition: color 0.15s, background 0.15s, border-color 0.15s;
+    }
+
+    .artifact-action:hover {
+      color: var(--text);
+      background: var(--hover);
+      border-color: var(--borderMuted);
+    }
+
+    .artifact-action.copied {
+      color: var(--accent);
+      border-color: var(--accent);
+    }
+
+    .artifact-action.active {
+      color: var(--text);
+      background: var(--selectedBg);
+      border-color: var(--accent);
+    }
+
+    .artifact-view-body {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .artifact-preview {
+      flex: 1;
+      min-height: 0;
+      width: 100%;
+      border: 1px solid var(--dim);
+      border-radius: 4px;
+      background: #fff;
+    }
+
+    .artifact-markdown {
+      flex: 1;
+      min-height: 0;
+      overflow: auto;
+      padding: 4px 2px;
+      font-size: 13px;
+    }
+
+    .artifact-source {
+      flex: 1;
+      min-height: 0;
+      margin: 0;
+      overflow: auto;
+      font-size: 12px;
+      line-height: var(--line-height);
+    }
+
+    .artifact-source code {
+      white-space: pre;
+    }
+
+    /* ── Annotations (Notes tab + inline highlights) ── */
+    .annotation-list-host {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .annotation-empty {
+      padding: 16px 8px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .annotation-list {
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .annotation-item {
+      position: relative;
+      padding: 7px 26px 7px 8px;
+      border: 1px solid var(--dim);
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .annotation-item:hover {
+      background: var(--hover);
+      border-color: var(--borderMuted);
+    }
+
+    .annotation-delete {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      width: 18px;
+      height: 18px;
+      line-height: 1;
+      padding: 0;
+      font-size: 14px;
+      color: var(--muted);
+      background: transparent;
+      border: none;
+      border-radius: 3px;
+      cursor: pointer;
+    }
+
+    .annotation-delete:hover {
+      color: var(--error);
+      background: var(--hover);
+    }
+
+    .annotation-quote {
+      font-size: 11px;
+      color: var(--muted);
+      border-left: 2px solid var(--accent);
+      padding-left: 6px;
+      margin-bottom: 4px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .annotation-note {
+      font-size: 12px;
+      color: var(--text);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .annotation-footer {
+      flex-shrink: 0;
+      padding-top: 8px;
+    }
+
+    .annotation-send {
+      width: 100%;
+      padding: 6px 8px;
+      font-family: inherit;
+      font-size: 12px;
+      color: var(--chrome-bg);
+      background: var(--accent);
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    .annotation-send:hover {
+      opacity: 0.9;
+    }
+
+    mark.pi-annotation {
+      background: color-mix(in srgb, var(--accent) 28%, transparent);
+      color: inherit;
+      border-radius: 2px;
+      padding: 0 1px;
+      box-decoration-break: clone;
+      -webkit-box-decoration-break: clone;
+    }
+
+    .annotation-flash {
+      animation: annotation-flash-kf 1.2s ease-out;
+    }
+
+    @keyframes annotation-flash-kf {
+      0%, 30% { background: color-mix(in srgb, var(--accent) 22%, transparent); }
+      100% { background: transparent; }
+    }
+
+    .annotation-popover {
+      position: fixed;
+      /* Above the mobile right-sidebar overlay (z-index 1200) so the popover is
+         clickable when annotating an artifact's source inside the panel. */
+      z-index: 1300;
+      background: var(--chrome-bg);
+      border: 1px solid var(--borderMuted);
+      border-radius: 6px;
+      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+      padding: 6px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-width: 240px;
+    }
+
+    .annotation-popover[hidden] {
+      display: none;
+    }
+
+    /* Comfortable touch target so it's easy to hit next to the native menu. */
+    .annotation-pop-btn {
+      padding: 9px 16px;
+      min-height: 38px;
+      font-family: inherit;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--accent);
+      background: transparent;
+      border: 1px solid var(--accent);
+      border-radius: 6px;
+      cursor: pointer;
+    }
+
+    .annotation-pop-btn:hover {
+      color: var(--chrome-bg);
+      background: var(--accent);
+    }
+
+    /* ── Annotation note input (modal) ── */
+    .annotation-note-modal {
+      position: fixed;
+      inset: 0;
+      z-index: 1500;
+      display: flex;
+      align-items: flex-start;
+      justify-content: center;
+      padding: 12vh 16px 16px;
+    }
+
+    .annotation-note-modal[hidden] {
+      display: none;
+    }
+
+    .annotation-note-backdrop {
+      position: absolute;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+    }
+
+    .annotation-note-card {
+      position: relative;
+      width: 100%;
+      max-width: 420px;
+      background: var(--surface, var(--chrome-bg));
+      border: 1px solid var(--borderMuted);
+      border-radius: 10px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+      padding: 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .annotation-note-quote {
+      font-size: 12px;
+      color: var(--muted);
+      border-left: 2px solid var(--accent);
+      padding-left: 8px;
+      max-height: 3.6em;
+      overflow: hidden;
+    }
+
+    .annotation-note-input {
+      width: 100%;
+      box-sizing: border-box;
+      font-family: inherit;
+      font-size: 15px; /* >=16px-ish avoids iOS zoom-on-focus jank */
+      color: var(--text);
+      background: var(--bg);
+      border: 1px solid var(--dim);
+      border-radius: 6px;
+      padding: 10px;
+      resize: vertical;
+      outline: none;
+    }
+
+    .annotation-note-actions {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+    }
+
+    .annotation-note-save,
+    .annotation-note-cancel {
+      padding: 9px 16px;
+      min-height: 38px;
+      font-family: inherit;
+      font-size: 13px;
+      border-radius: 6px;
+      cursor: pointer;
+      border: 1px solid var(--dim);
+    }
+
+    .annotation-note-save {
+      color: var(--chrome-bg);
+      background: var(--accent);
+      border-color: var(--accent);
+      font-weight: 600;
+    }
+
+    .annotation-note-cancel {
+      color: var(--muted);
+      background: transparent;
     }
 
     /* ── Right sidebar expanded popup overlay ── */

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -633,6 +633,10 @@
       transition: color 0.15s, background 0.15s, border-color 0.15s;
     }
 
+    .right-sidebar-tab[hidden] {
+      display: none;
+    }
+
     .right-sidebar-tab:hover {
       color: var(--text);
     }

--- a/internal/ui/live_templates/styles/settings.css
+++ b/internal/ui/live_templates/styles/settings.css
@@ -86,7 +86,8 @@
 
 .settings-control select,
 .settings-control input[type="number"],
-.settings-control input[type="time"] {
+.settings-control input[type="time"],
+.settings-control input[type="text"] {
   background: var(--input-bg, var(--surface-2));
   color: var(--text);
   border: 1px solid var(--dim);
@@ -99,6 +100,10 @@
 
 .settings-control input[type="number"] {
   min-width: 90px;
+}
+
+.settings-control input[type="text"] {
+  min-width: 220px;
 }
 
 .settings-font-control {

--- a/web/src/session/annotations/annotation-api.js
+++ b/web/src/session/annotations/annotation-api.js
@@ -1,0 +1,33 @@
+/**
+ * annotation-api.js — thin client for the /api/annotations endpoint.
+ * Annotations are keyed by session id and persisted server-side (SQLite).
+ */
+export function createAnnotationApi({ sessionId, fetchImpl = fetch } = {}) {
+  const base = `/api/annotations?session=${encodeURIComponent(sessionId)}`;
+
+  async function list() {
+    const res = await fetchImpl(base);
+    if (!res.ok) throw new Error(`list annotations: HTTP ${res.status}`);
+    const data = await res.json();
+    return Array.isArray(data.annotations) ? data.annotations : [];
+  }
+
+  async function create(annotation) {
+    const res = await fetchImpl(base, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(annotation)
+    });
+    if (!res.ok) throw new Error(`create annotation: HTTP ${res.status}`);
+    const data = await res.json();
+    return data.annotation;
+  }
+
+  async function remove(id) {
+    const res = await fetchImpl(`${base}&id=${encodeURIComponent(id)}`, { method: 'DELETE' });
+    if (!res.ok) throw new Error(`delete annotation: HTTP ${res.status}`);
+    return true;
+  }
+
+  return { list, create, remove };
+}

--- a/web/src/session/annotations/annotation-api.test.js
+++ b/web/src/session/annotations/annotation-api.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAnnotationApi } from './annotation-api.js';
+
+function jsonResponse(body, ok = true, status = 200) {
+  return { ok, status, json: async () => body };
+}
+
+describe('annotation api', () => {
+  it('lists annotations for a session', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ annotations: [{ id: 'a1' }] }));
+    const api = createAnnotationApi({ sessionId: 's 1.jsonl', fetchImpl });
+    const out = await api.list();
+    expect(out).toEqual([{ id: 'a1' }]);
+    expect(fetchImpl).toHaveBeenCalledWith('/api/annotations?session=s%201.jsonl');
+  });
+
+  it('returns [] when the payload has no array', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({}));
+    const api = createAnnotationApi({ sessionId: 's1', fetchImpl });
+    expect(await api.list()).toEqual([]);
+  });
+
+  it('creates an annotation via POST', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ annotation: { id: 'a9' } }));
+    const api = createAnnotationApi({ sessionId: 's1', fetchImpl });
+    const created = await api.create({ anchorId: 'entry-e1', startOffset: 0, endOffset: 2, text: 'x' });
+    expect(created).toEqual({ id: 'a9' });
+    const [url, opts] = fetchImpl.mock.calls[0];
+    expect(url).toBe('/api/annotations?session=s1');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toMatchObject({ anchorId: 'entry-e1', text: 'x' });
+  });
+
+  it('deletes an annotation via DELETE', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+    const api = createAnnotationApi({ sessionId: 's1', fetchImpl });
+    await api.remove('a1');
+    expect(fetchImpl).toHaveBeenCalledWith('/api/annotations?session=s1&id=a1', { method: 'DELETE' });
+  });
+
+  it('throws on a non-ok response', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({}, false, 500));
+    const api = createAnnotationApi({ sessionId: 's1', fetchImpl });
+    await expect(api.list()).rejects.toThrow(/HTTP 500/);
+  });
+});

--- a/web/src/session/annotations/annotation-layer.js
+++ b/web/src/session/annotations/annotation-layer.js
@@ -19,6 +19,7 @@ export function createAnnotationLayer({
   countEl = null,
   escapeHtml,
   onSelectArtifact = null,
+  onCreate = null,
   resolveArtifact = null,
   selectionDelayMs = 250,
   documentImpl = document,
@@ -288,6 +289,8 @@ export function createAnnotationLayer({
     noteModal.hidden = true;
     windowImpl.getSelection?.()?.removeAllRanges?.();
     setAnnotations([...annotations, optimistic]); // optimistic; bumps the load guard
+    // Surface the just-created note: open the sidebar if hidden and switch to it.
+    if (typeof onCreate === 'function') onCreate();
     try {
       await api.create(payload);
     } finally {

--- a/web/src/session/annotations/annotation-layer.js
+++ b/web/src/session/annotations/annotation-layer.js
@@ -20,6 +20,7 @@ export function createAnnotationLayer({
   escapeHtml,
   onSelectArtifact = null,
   onCreate = null,
+  onSend = null,
   resolveArtifact = null,
   selectionDelayMs = 250,
   documentImpl = document,
@@ -167,6 +168,9 @@ export function createAnnotationLayer({
     if (!composerEl || annotations.length === 0) return;
     composerEl.value = formatForPi();
     composerEl.dispatchEvent(new windowImpl.Event('input', { bubbles: true }));
+    // Let the host get out of the way (e.g. collapse the mobile overlay sidebar)
+    // before focusing, so the composer is actually visible when the keyboard opens.
+    if (typeof onSend === 'function') onSend();
     composerEl.focus();
   }
 

--- a/web/src/session/annotations/annotation-layer.js
+++ b/web/src/session/annotations/annotation-layer.js
@@ -1,0 +1,368 @@
+/**
+ * annotation-layer.js — selection → comment, highlight rendering, Notes tab,
+ * and "send notes to pi". Persists via /api/annotations (annotation-api.js) and
+ * stays in sync across tabs via the SSE `annotations` snapshot event.
+ *
+ * Annotations anchor to any registered scope: the transcript (#messages) and the
+ * artifact panel host. Highlights are re-applied whenever a scope re-renders
+ * (navigation, live reload, artifact selection) via a MutationObserver.
+ */
+import { getSelectionInfo, applyHighlights } from './annotation-range.js';
+
+export function createAnnotationLayer({
+  sessionId,
+  api,
+  messagesEl,
+  scopes,
+  listHost,
+  composerEl = null,
+  countEl = null,
+  escapeHtml,
+  onSelectArtifact = null,
+  resolveArtifact = null,
+  selectionDelayMs = 250,
+  documentImpl = document,
+  windowImpl = window,
+  rangeApi = { getSelectionInfo, applyHighlights }
+} = {}) {
+  const allScopes = (Array.isArray(scopes) && scopes.length ? scopes : [messagesEl]).filter(Boolean);
+  if (!api || allScopes.length === 0 || !listHost) {
+    return { init() {}, setAnnotations() {}, reapply() {}, refresh() {}, destroy() {} };
+  }
+
+  let annotations = [];
+  let pending = null; // selection info awaiting a note
+  let observer = null;
+  // Monotonic guard: a slow in-flight list() must not clobber newer state set by
+  // a later refresh, an optimistic create, or an SSE snapshot.
+  let loadSeq = 0;
+  const esc = typeof escapeHtml === 'function' ? escapeHtml : (s) => String(s);
+
+  // ── highlight (re)application ─────────────────────────────────────────────
+  function reapply() {
+    observer?.disconnect();
+    for (const scope of allScopes) {
+      rangeApi.applyHighlights(scope, annotations, { documentImpl });
+    }
+    observer?.takeRecords?.();
+    if (observer) {
+      for (const scope of allScopes) observer.observe(scope, { childList: true, subtree: true });
+    }
+  }
+
+  function render() {
+    reapply();
+    renderList();
+    if (countEl) {
+      countEl.textContent = String(annotations.length);
+      countEl.hidden = annotations.length === 0;
+    }
+  }
+
+  function setAnnotations(list) {
+    loadSeq += 1; // supersede any in-flight refresh
+    annotations = Array.isArray(list) ? list : [];
+    render();
+  }
+
+  async function refresh() {
+    const seq = loadSeq + 1;
+    loadSeq = seq;
+    try {
+      const list = await api.list();
+      if (seq !== loadSeq) return; // a newer update superseded this load
+      annotations = Array.isArray(list) ? list : [];
+      render();
+    } catch { /* keep current */ }
+  }
+
+  // ── Notes list ────────────────────────────────────────────────────────────
+  function renderList() {
+    if (annotations.length === 0) {
+      listHost.innerHTML = '<div class="annotation-empty">Select text in a message or artifact to add a note.</div>';
+      return;
+    }
+    let html = '<div class="annotation-list">';
+    for (const a of annotations) {
+      html += `<div class="annotation-item" data-annotation-id="${esc(a.id)}" data-anchor-id="${esc(a.anchorId)}">`
+        + `<button type="button" class="annotation-delete" data-action="delete" title="Delete note">×</button>`
+        + (a.original ? `<div class="annotation-quote">${esc(a.original)}</div>` : '')
+        + (a.text ? `<div class="annotation-note">${esc(a.text)}</div>` : '')
+        + `</div>`;
+    }
+    html += '</div>';
+    html += `<div class="annotation-footer"><button type="button" class="annotation-send" data-action="send-to-pi">Send ${annotations.length} note${annotations.length === 1 ? '' : 's'} to pi</button></div>`;
+    listHost.innerHTML = html;
+  }
+
+  function offsetToLine(content, offset) {
+    let line = 1;
+    const limit = Math.min(Math.max(0, offset), content.length);
+    for (let i = 0; i < limit; i += 1) {
+      if (content[i] === '\n') line += 1;
+    }
+    return line;
+  }
+
+  // "Line N" for a single line, "Lines N-M" for a span. end is exclusive, so the
+  // last selected character is at end-1.
+  function lineLabel(content, start, end) {
+    if (typeof content !== 'string' || content.length === 0) return '';
+    const a = offsetToLine(content, start);
+    const b = offsetToLine(content, Math.max(start, end - 1));
+    return a === b ? `Line ${a}` : `Lines ${a}-${b}`;
+  }
+
+  // Quote the anchored text on a single line so a multi-line selection doesn't
+  // break the structure of the message we hand to the agent.
+  function quote(s) {
+    return `"${String(s || '').replace(/\s+/g, ' ').trim()}"`;
+  }
+
+  function formatForPi() {
+    const fileGroups = new Map(); // path -> [{ label, original, text }]
+    const convo = [];
+    for (const a of annotations) {
+      const anchorId = a.anchorId || '';
+      if (anchorId.indexOf('artifact-') === 0) {
+        const art = resolveArtifact ? resolveArtifact(anchorId.slice('artifact-'.length)) : null;
+        const path = (art && (art.filePath || art.title)) || '(artifact)';
+        const label = art ? lineLabel(art.content, a.startOffset, a.endOffset) : '';
+        if (!fileGroups.has(path)) fileGroups.set(path, []);
+        fileGroups.get(path).push({ label, original: a.original, text: a.text });
+      } else {
+        convo.push(a);
+      }
+    }
+
+    // Lead with an explicit, directive framing: this continues the current task,
+    // so a weaker model doesn't treat the notes as a new/unrelated conversation.
+    const out = [
+      "Here are my review notes on this session — changes I want you to make to the work we've already done together in this conversation. Please go through each note below and apply it. This is a continuation of our current task, not a new or separate request.",
+      ''
+    ];
+    for (const [path, items] of fileGroups) {
+      out.push(`In ${path}:`);
+      for (const it of items) {
+        out.push('');
+        out.push(it.label ? `${it.label} — ${quote(it.original)}` : quote(it.original));
+        if (it.text) out.push(`  ${it.text}`);
+      }
+      out.push('');
+    }
+    if (convo.length > 0) {
+      out.push('In this conversation:');
+      for (const a of convo) {
+        out.push('');
+        out.push(quote(a.original));
+        if (a.text) out.push(`  ${a.text}`);
+      }
+      out.push('');
+    }
+    return out.join('\n').trimEnd() + '\n';
+  }
+
+  function sendToPi() {
+    if (!composerEl || annotations.length === 0) return;
+    composerEl.value = formatForPi();
+    composerEl.dispatchEvent(new windowImpl.Event('input', { bubbles: true }));
+    composerEl.focus();
+  }
+
+  listHost.addEventListener('click', async (e) => {
+    const del = e.target.closest?.('[data-action="delete"]');
+    if (del) {
+      const item = del.closest('.annotation-item');
+      const id = item?.dataset.annotationId;
+      if (!id) return;
+      setAnnotations(annotations.filter((a) => a.id !== id)); // optimistic
+      try { await api.remove(id); } finally { refresh(); }
+      return;
+    }
+    if (e.target.closest?.('[data-action="send-to-pi"]')) {
+      sendToPi();
+      return;
+    }
+    const item = e.target.closest?.('.annotation-item');
+    if (item) {
+      const anchorId = item.dataset.anchorId || '';
+      // Artifact anchors only exist when that artifact is open in source view;
+      // ask the panel to select it first so the highlight + scroll land.
+      if (anchorId.indexOf('artifact-') === 0 && onSelectArtifact) {
+        onSelectArtifact(anchorId.slice('artifact-'.length));
+      }
+      const anchor = documentImpl.getElementById(anchorId);
+      if (anchor) {
+        anchor.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        anchor.classList.add('annotation-flash');
+        windowImpl.setTimeout(() => anchor.classList.remove('annotation-flash'), 1200);
+      }
+    }
+  });
+
+  // ── floating "Comment" button (appears next to the selection) ─────────────
+  const popover = documentImpl.createElement('div');
+  popover.className = 'annotation-popover';
+  popover.hidden = true;
+  documentImpl.body.appendChild(popover);
+
+  // ── note input as a clear modal ──────────────────────────────────────────
+  // A centered dialog (not a tiny inline box) so on mobile it can't be mistaken
+  // for the chat composer and is comfortable to type into above the keyboard.
+  const noteModal = documentImpl.createElement('div');
+  noteModal.className = 'annotation-note-modal';
+  noteModal.hidden = true;
+  noteModal.innerHTML =
+    '<div class="annotation-note-backdrop" data-action="cancel-note"></div>'
+    + '<div class="annotation-note-card" role="dialog" aria-modal="true" aria-label="Add a note">'
+    + '<div class="annotation-note-quote"></div>'
+    + '<textarea class="annotation-note-input" placeholder="Add a note…" rows="3"></textarea>'
+    + '<div class="annotation-note-actions">'
+    + '<button type="button" class="annotation-note-cancel" data-action="cancel-note">Cancel</button>'
+    + '<button type="button" class="annotation-note-save" data-action="save-note">Save note</button>'
+    + '</div></div>';
+  documentImpl.body.appendChild(noteModal);
+  const noteInput = noteModal.querySelector('.annotation-note-input');
+  const noteQuote = noteModal.querySelector('.annotation-note-quote');
+
+  function hidePopover() {
+    popover.hidden = true;
+    popover.innerHTML = '';
+  }
+
+  function noteModalOpen() {
+    return !noteModal.hidden;
+  }
+
+  function positionPopover(rect) {
+    const top = Math.max(8, rect.bottom + 10);
+    const left = Math.min(Math.max(8, rect.left), windowImpl.innerWidth - 150);
+    popover.style.position = 'fixed';
+    popover.style.top = `${top}px`;
+    popover.style.left = `${left}px`;
+  }
+
+  function showCommentButton(rect) {
+    popover.innerHTML = '<button type="button" class="annotation-pop-btn" data-action="start-comment">Comment</button>';
+    positionPopover(rect);
+    popover.hidden = false;
+  }
+
+  function openNoteInput() {
+    if (!pending) return;
+    hidePopover();
+    noteQuote.textContent = `"${String(pending.text || '').replace(/\s+/g, ' ').trim()}"`;
+    noteInput.value = '';
+    noteModal.hidden = false;
+    noteInput.focus(); // within the tap gesture, so the keyboard opens for THIS field
+  }
+
+  function closeNote() {
+    noteModal.hidden = true;
+    pending = null;
+  }
+
+  async function saveComment() {
+    if (!pending) return;
+    const note = noteInput.value.trim();
+    const optimistic = {
+      id: `tmp-${Date.now()}`,
+      anchorId: pending.anchorId,
+      startOffset: pending.start,
+      endOffset: pending.end,
+      kind: 'comment',
+      text: note,
+      original: pending.text,
+      source: 'local',
+      createdAt: Date.now()
+    };
+    const payload = {
+      anchorId: optimistic.anchorId,
+      startOffset: optimistic.startOffset,
+      endOffset: optimistic.endOffset,
+      kind: 'comment',
+      text: note,
+      original: optimistic.original
+    };
+    pending = null;
+    noteModal.hidden = true;
+    windowImpl.getSelection?.()?.removeAllRanges?.();
+    setAnnotations([...annotations, optimistic]); // optimistic; bumps the load guard
+    try {
+      await api.create(payload);
+    } finally {
+      refresh();
+    }
+  }
+
+  popover.addEventListener('mousedown', (e) => e.preventDefault()); // keep selection alive on desktop
+  popover.addEventListener('click', (e) => {
+    if (e.target.closest?.('[data-action="start-comment"]')) openNoteInput();
+  });
+  noteModal.addEventListener('click', (e) => {
+    const action = e.target.closest?.('[data-action]')?.dataset.action;
+    if (action === 'save-note') saveComment();
+    else if (action === 'cancel-note') closeNote();
+  });
+
+  function maybeShowFromSelection() {
+    if (noteModalOpen()) return; // don't disturb an in-progress note
+    if (popover.contains(documentImpl.activeElement)) return;
+    const sel = windowImpl.getSelection?.();
+    const info = rangeApi.getSelectionInfo(sel, { documentImpl });
+    if (!info || !allScopes.some((s) => s.contains(info.anchorEl))) {
+      if (!popover.hidden) hidePopover();
+      return;
+    }
+    pending = info;
+    let rect = { bottom: 0, left: 0 };
+    try { rect = sel.getRangeAt(0).getBoundingClientRect(); } catch { /* default */ }
+    showCommentButton(rect);
+  }
+
+  function onMouseUp(e) {
+    if (popover.contains(e.target) || noteModal.contains(e.target)) return;
+    maybeShowFromSelection();
+  }
+
+  // Touch text selection (mobile) finalizes via the native selection handles and
+  // often fires no mouseup, so we also react to selectionchange — debounced so it
+  // runs once the selection settles, not on every drag tick.
+  let selectionTimer = null;
+  function onSelectionChange() {
+    if (windowImpl.clearTimeout) windowImpl.clearTimeout(selectionTimer);
+    if (windowImpl.setTimeout) selectionTimer = windowImpl.setTimeout(maybeShowFromSelection, selectionDelayMs);
+    else maybeShowFromSelection();
+  }
+
+  function onKeyDown(e) {
+    if (e.key !== 'Escape') return;
+    if (noteModalOpen()) closeNote();
+    else if (!popover.hidden) hidePopover();
+  }
+
+  function init() {
+    if (windowImpl.MutationObserver) {
+      observer = new windowImpl.MutationObserver(() => {
+        if (windowImpl.requestAnimationFrame) windowImpl.requestAnimationFrame(reapply);
+        else reapply();
+      });
+    }
+    documentImpl.addEventListener('mouseup', onMouseUp);
+    documentImpl.addEventListener('selectionchange', onSelectionChange);
+    documentImpl.addEventListener('keydown', onKeyDown);
+    refresh();
+  }
+
+  function destroy() {
+    observer?.disconnect();
+    if (windowImpl.clearTimeout) windowImpl.clearTimeout(selectionTimer);
+    documentImpl.removeEventListener('mouseup', onMouseUp);
+    documentImpl.removeEventListener('selectionchange', onSelectionChange);
+    documentImpl.removeEventListener('keydown', onKeyDown);
+    popover.remove();
+    noteModal.remove();
+  }
+
+  return { init, setAnnotations, reapply, refresh, render, destroy, get annotations() { return annotations; } };
+}

--- a/web/src/session/annotations/annotation-layer.test.js
+++ b/web/src/session/annotations/annotation-layer.test.js
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { createAnnotationLayer } from './annotation-layer.js';
+
+const escapeHtml = (s) => String(s).replace(/[&<>"']/g, (c) => (
+  { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+));
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+function fakeApi(initial = []) {
+  let store = [...initial];
+  let seq = 0;
+  return {
+    list: vi.fn(async () => store.slice()),
+    create: vi.fn(async (a) => {
+      const saved = { ...a, id: `real-${++seq}`, source: 'local', createdAt: Date.now() };
+      store.push(saved);
+      return saved;
+    }),
+    remove: vi.fn(async (id) => { store = store.filter((x) => x.id !== id); return true; }),
+    _store: () => store
+  };
+}
+
+function setup({ api, selectionDelayMs = 250 } = {}) {
+  const dom = new JSDOM(
+    '<div id="messages"><div id="entry-e1">hello world</div></div>'
+    + '<div id="annotation-list-host"></div>'
+    + '<textarea id="pi-chat-message"></textarea>'
+    + '<span id="annotation-tab-count" hidden>0</span>'
+  );
+  const { document: doc, window: win } = dom.window;
+  const layer = createAnnotationLayer({
+    sessionId: 's1',
+    api: api || fakeApi(),
+    messagesEl: doc.getElementById('messages'),
+    listHost: doc.getElementById('annotation-list-host'),
+    composerEl: doc.getElementById('pi-chat-message'),
+    countEl: doc.getElementById('annotation-tab-count'),
+    escapeHtml,
+    selectionDelayMs,
+    documentImpl: doc,
+    windowImpl: win
+  });
+  return { doc, win, layer };
+}
+
+function selectWorld(doc, win) {
+  const t = doc.getElementById('entry-e1').firstChild;
+  const range = doc.createRange();
+  range.setStart(t, 6);
+  range.setEnd(t, 11);
+  const sel = win.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+describe('annotation layer', () => {
+  it('renders empty state and a count of zero', () => {
+    const { doc, layer } = setup();
+    layer.setAnnotations([]);
+    expect(doc.querySelector('.annotation-empty')).not.toBeNull();
+    expect(doc.getElementById('annotation-tab-count').hidden).toBe(true);
+  });
+
+  it('renders notes, count, and highlights from a snapshot', () => {
+    const { doc, layer } = setup();
+    layer.setAnnotations([
+      { id: 'a1', anchorId: 'entry-e1', startOffset: 0, endOffset: 5, text: 'note', original: 'hello' }
+    ]);
+    expect(doc.querySelectorAll('.annotation-item')).toHaveLength(1);
+    expect(doc.querySelector('.annotation-note').textContent).toBe('note');
+    expect(doc.getElementById('annotation-tab-count').textContent).toBe('1');
+    expect(doc.querySelector('mark.pi-annotation[data-annotation-id="a1"]').textContent).toBe('hello');
+  });
+
+  it('creates a comment from a selection through the popover', async () => {
+    const api = fakeApi();
+    const { doc, win, layer } = setup({ api });
+    layer.init();
+    await tick(); // initial refresh
+
+    selectWorld(doc, win);
+    doc.dispatchEvent(new win.MouseEvent('mouseup'));
+
+    const commentBtn = doc.querySelector('.annotation-popover [data-action="start-comment"]');
+    expect(commentBtn).not.toBeNull();
+    commentBtn.click();
+
+    doc.querySelector('.annotation-note-input').value = 'fix this';
+    doc.querySelector('[data-action="save-note"]').click();
+    await tick();
+    await tick();
+
+    expect(api.create).toHaveBeenCalledWith(expect.objectContaining({
+      anchorId: 'entry-e1', startOffset: 6, endOffset: 11, kind: 'comment', text: 'fix this', original: 'world'
+    }));
+    expect(doc.querySelector('.annotation-note').textContent).toBe('fix this');
+    expect(doc.querySelector('mark.pi-annotation').textContent).toBe('world');
+  });
+
+  it('shows the popover from selectionchange (touch, where mouseup never fires)', async () => {
+    const { doc, win, layer } = setup({ selectionDelayMs: 0 });
+    layer.init();
+    await tick();
+
+    // Note: no mouseup is dispatched here — only selectionchange, like mobile.
+    selectWorld(doc, win);
+    doc.dispatchEvent(new win.Event('selectionchange'));
+    await new Promise((r) => win.setTimeout(r, 10)); // let the debounce fire on win's clock
+
+    expect(doc.querySelector('.annotation-popover [data-action="start-comment"]')).not.toBeNull();
+  });
+
+  it('deletes a note on click', async () => {
+    const api = fakeApi([{ id: 'a1', anchorId: 'entry-e1', startOffset: 0, endOffset: 5, text: 'n', original: 'hello' }]);
+    const { doc, layer } = setup({ api });
+    layer.init();
+    await tick();
+    expect(doc.querySelectorAll('.annotation-item')).toHaveLength(1);
+
+    doc.querySelector('[data-action="delete"]').click();
+    await tick();
+    await tick();
+    expect(api.remove).toHaveBeenCalledWith('a1');
+    expect(doc.querySelector('.annotation-empty')).not.toBeNull();
+  });
+
+  it('fills the composer when sending transcript notes to pi', () => {
+    const { doc, layer } = setup();
+    layer.setAnnotations([
+      { id: 'a1', anchorId: 'entry-e1', startOffset: 0, endOffset: 5, text: 'rename this', original: 'hello' }
+    ]);
+    doc.querySelector('[data-action="send-to-pi"]').click();
+    const composer = doc.getElementById('pi-chat-message');
+    expect(composer.value).toContain('continuation of our current task');
+    expect(composer.value).toContain('In this conversation:');
+    expect(composer.value).toContain('"hello"');
+    expect(composer.value).toContain('rename this');
+  });
+
+  it('includes file path and line numbers for artifact notes', () => {
+    const dom = new JSDOM(
+      '<div id="messages"></div><div id="annotation-list-host"></div><textarea id="pi-chat-message"></textarea>'
+    );
+    const { document: doc, window: win } = dom.window;
+    const content = 'line one\nline two\nline three\nline four\n';
+    const resolveArtifact = (id) => (id === 'art-1'
+      ? { id: 'art-1', filePath: '/Users/setkyar/milktea/the-silver-flute-of-bagan.md', content }
+      : null);
+    const layer = createAnnotationLayer({
+      sessionId: 's1',
+      api: fakeApi(),
+      scopes: [doc.getElementById('messages')],
+      listHost: doc.getElementById('annotation-list-host'),
+      composerEl: doc.getElementById('pi-chat-message'),
+      escapeHtml,
+      resolveArtifact,
+      documentImpl: doc,
+      windowImpl: win
+    });
+    layer.setAnnotations([
+      { id: 'n1', anchorId: 'artifact-art-1', startOffset: 0, endOffset: 4, text: 'add (burmese)', original: 'line' },
+      { id: 'n2', anchorId: 'artifact-art-1', startOffset: 9, endOffset: 28, text: 'spans lines', original: 'two..three' }
+    ]);
+    doc.querySelector('[data-action="send-to-pi"]').click();
+    const v = doc.getElementById('pi-chat-message').value;
+    expect(v).toContain('In /Users/setkyar/milktea/the-silver-flute-of-bagan.md:');
+    expect(v).toContain('Line 1 — "line"');
+    expect(v).toContain('add (burmese)');
+    expect(v).toContain('Lines 2-3 — "two..three"');
+  });
+
+  it('does not let a slow initial load clobber a newer optimistic create', async () => {
+    // api.list resolves only when we release it, simulating a slow initial
+    // refresh that completes after the user has already created an annotation.
+    let releaseList;
+    const slow = new Promise((r) => { releaseList = r; });
+    const store = [];
+    let firstList = true;
+    const api = {
+      list: vi.fn(() => {
+        if (firstList) { firstList = false; return slow; } // stale initial load
+        return Promise.resolve(store.slice());
+      }),
+      create: vi.fn(async (a) => { const s = { ...a, id: 'real-1' }; store.push(s); return s; }),
+      remove: vi.fn()
+    };
+    const { doc, win, layer } = setup({ api });
+    layer.init(); // kicks off the slow refresh
+
+    selectWorld(doc, win);
+    doc.dispatchEvent(new win.MouseEvent('mouseup'));
+    doc.querySelector('[data-action="start-comment"]').click();
+    doc.querySelector('.annotation-note-input').value = 'keep me';
+    doc.querySelector('[data-action="save-note"]').click();
+    await tick();
+
+    // The stale initial list resolves with [] only now — it must be ignored.
+    releaseList([]);
+    await tick();
+    await tick();
+
+    expect(doc.querySelectorAll('.annotation-item')).toHaveLength(1);
+    expect(doc.querySelector('.annotation-note').textContent).toBe('keep me');
+  });
+
+  it('annotates text inside an artifact scope', async () => {
+    const dom = new JSDOM(
+      '<div id="messages"></div>'
+      + '<div id="artifact-panel-host"><pre id="artifact-art-1">package main</pre></div>'
+      + '<div id="annotation-list-host"></div>'
+      + '<span id="annotation-tab-count" hidden>0</span>'
+    );
+    const { document: doc, window: win } = dom.window;
+    const api = fakeApi();
+    const layer = createAnnotationLayer({
+      sessionId: 's1',
+      api,
+      scopes: [doc.getElementById('messages'), doc.getElementById('artifact-panel-host')],
+      listHost: doc.getElementById('annotation-list-host'),
+      countEl: doc.getElementById('annotation-tab-count'),
+      escapeHtml,
+      documentImpl: doc,
+      windowImpl: win
+    });
+    layer.init();
+    await tick();
+
+    const t = doc.getElementById('artifact-art-1').firstChild;
+    const range = doc.createRange();
+    range.setStart(t, 8); // "main"
+    range.setEnd(t, 12);
+    const sel = win.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    doc.dispatchEvent(new win.MouseEvent('mouseup'));
+
+    doc.querySelector('[data-action="start-comment"]').click();
+    doc.querySelector('.annotation-note-input').value = 'rename';
+    doc.querySelector('[data-action="save-note"]').click();
+    await tick();
+    await tick();
+
+    expect(api.create).toHaveBeenCalledWith(expect.objectContaining({ anchorId: 'artifact-art-1', original: 'main' }));
+    expect(doc.querySelector('#artifact-art-1 mark.pi-annotation').textContent).toBe('main');
+  });
+
+  it('is a no-op when required hosts are missing', () => {
+    const layer = createAnnotationLayer({ sessionId: 's1' });
+    expect(() => { layer.init(); layer.setAnnotations([]); layer.reapply(); }).not.toThrow();
+  });
+});

--- a/web/src/session/annotations/annotation-layer.test.js
+++ b/web/src/session/annotations/annotation-layer.test.js
@@ -22,7 +22,7 @@ function fakeApi(initial = []) {
   };
 }
 
-function setup({ api, selectionDelayMs = 250, onCreate = null } = {}) {
+function setup({ api, selectionDelayMs = 250, onCreate = null, onSend = null } = {}) {
   const dom = new JSDOM(
     '<div id="messages"><div id="entry-e1">hello world</div></div>'
     + '<div id="annotation-list-host"></div>'
@@ -39,6 +39,7 @@ function setup({ api, selectionDelayMs = 250, onCreate = null } = {}) {
     countEl: doc.getElementById('annotation-tab-count'),
     escapeHtml,
     onCreate,
+    onSend,
     selectionDelayMs,
     documentImpl: doc,
     windowImpl: win
@@ -153,6 +154,20 @@ describe('annotation layer', () => {
     expect(composer.value).toContain('In this conversation:');
     expect(composer.value).toContain('"hello"');
     expect(composer.value).toContain('rename this');
+  });
+
+  it('fires onSend before focusing the composer on send-to-pi', () => {
+    const calls = [];
+    const onSend = vi.fn(() => calls.push('onSend'));
+    const { doc, layer } = setup({ onSend });
+    const composer = doc.getElementById('pi-chat-message');
+    composer.focus = vi.fn(() => calls.push('focus'));
+    layer.setAnnotations([
+      { id: 'a1', anchorId: 'entry-e1', startOffset: 0, endOffset: 5, text: 'note', original: 'hello' }
+    ]);
+    doc.querySelector('[data-action="send-to-pi"]').click();
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['onSend', 'focus']); // collapse the overlay, then focus
   });
 
   it('includes file path and line numbers for artifact notes', () => {

--- a/web/src/session/annotations/annotation-layer.test.js
+++ b/web/src/session/annotations/annotation-layer.test.js
@@ -22,7 +22,7 @@ function fakeApi(initial = []) {
   };
 }
 
-function setup({ api, selectionDelayMs = 250 } = {}) {
+function setup({ api, selectionDelayMs = 250, onCreate = null } = {}) {
   const dom = new JSDOM(
     '<div id="messages"><div id="entry-e1">hello world</div></div>'
     + '<div id="annotation-list-host"></div>'
@@ -38,6 +38,7 @@ function setup({ api, selectionDelayMs = 250 } = {}) {
     composerEl: doc.getElementById('pi-chat-message'),
     countEl: doc.getElementById('annotation-tab-count'),
     escapeHtml,
+    onCreate,
     selectionDelayMs,
     documentImpl: doc,
     windowImpl: win
@@ -97,6 +98,21 @@ describe('annotation layer', () => {
     }));
     expect(doc.querySelector('.annotation-note').textContent).toBe('fix this');
     expect(doc.querySelector('mark.pi-annotation').textContent).toBe('world');
+  });
+
+  it('fires onCreate when a note is saved (to reveal the panel)', async () => {
+    const onCreate = vi.fn();
+    const { doc, win, layer } = setup({ onCreate });
+    layer.init();
+    await tick();
+
+    selectWorld(doc, win);
+    doc.dispatchEvent(new win.MouseEvent('mouseup'));
+    doc.querySelector('[data-action="start-comment"]').click();
+    doc.querySelector('.annotation-note-input').value = 'look here';
+    doc.querySelector('[data-action="save-note"]').click();
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
   });
 
   it('shows the popover from selectionchange (touch, where mouseup never fires)', async () => {

--- a/web/src/session/annotations/annotation-range.js
+++ b/web/src/session/annotations/annotation-range.js
@@ -1,0 +1,146 @@
+/**
+ * annotation-range.js — DOM range ⇄ character-offset utilities for annotations.
+ *
+ * Annotations anchor to a rendered entry by its element id (`entry-<id>`) plus a
+ * [start, end) character range measured against that element's text content.
+ * Offsets (not live DOM ranges) survive the re-renders the session view does on
+ * navigation/live-reload, so they are the stable anchor.
+ *
+ * Pure and DOM-injectable for jsdom testing.
+ */
+
+const SHOW_TEXT = 0x4; // NodeFilter.SHOW_TEXT, hard-coded to avoid a global dep
+
+/** A transcript entry anchor (`entry-<id>`). */
+export function isEntryAnchor(el) {
+  return !!(el && el.id && el.id.indexOf('entry-') === 0);
+}
+
+/**
+ * Default predicate: an anchor is a transcript entry (`entry-<id>`) or an
+ * artifact source view (`artifact-<id>`). Both expose stable text content whose
+ * character offsets survive re-render.
+ */
+export function isAnnotationAnchor(el) {
+  if (!el || !el.id) return false;
+  return el.id.indexOf('entry-') === 0 || el.id.indexOf('artifact-') === 0;
+}
+
+function elementOf(node) {
+  if (!node) return null;
+  return node.nodeType === 1 ? node : node.parentElement;
+}
+
+/** Walk up from a node to the nearest matching anchor element, else null. */
+export function findAnchor(node, isAnchor = isAnnotationAnchor) {
+  let el = elementOf(node);
+  while (el) {
+    if (isAnchor(el)) return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+function measureOffset(anchorEl, node, nodeOffset, documentImpl) {
+  const range = documentImpl.createRange();
+  range.selectNodeContents(anchorEl);
+  try {
+    range.setEnd(node, nodeOffset);
+  } catch {
+    return 0;
+  }
+  return range.toString().length;
+}
+
+/**
+ * Describe the current text selection relative to its enclosing anchor.
+ * Returns null if there is no usable selection (collapsed, cross-anchor, or
+ * outside any anchor).
+ */
+export function getSelectionInfo(selection, { documentImpl = document, isAnchor = isAnnotationAnchor } = {}) {
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null;
+  const range = selection.getRangeAt(0);
+  const anchorEl = findAnchor(range.startContainer, isAnchor);
+  if (!anchorEl) return null;
+  // Keep it simple: a selection that spans into a different entry is rejected.
+  if (findAnchor(range.endContainer, isAnchor) !== anchorEl) return null;
+
+  const start = measureOffset(anchorEl, range.startContainer, range.startOffset, documentImpl);
+  const end = measureOffset(anchorEl, range.endContainer, range.endOffset, documentImpl);
+  const text = range.toString();
+  if (end <= start || !text.trim()) return null;
+
+  return { anchorEl, anchorId: anchorEl.id, start, end, text };
+}
+
+/**
+ * Wrap the [start, end) character range of an anchor's text in a <mark>.
+ * Returns true if anything was wrapped. Each wrapped run lives inside a single
+ * text node, so surroundContents never crosses element boundaries.
+ */
+export function wrapRange(anchorEl, start, end, { className = 'pi-annotation', dataset = {}, documentImpl = document } = {}) {
+  if (!anchorEl || end <= start) return false;
+  const walker = documentImpl.createTreeWalker(anchorEl, SHOW_TEXT);
+  const targets = [];
+  let pos = 0;
+  let node;
+  while ((node = walker.nextNode())) {
+    const len = node.nodeValue.length;
+    const nodeStart = pos;
+    const nodeEnd = pos + len;
+    pos = nodeEnd;
+    if (nodeEnd <= start || nodeStart >= end) continue;
+    targets.push({
+      node,
+      from: Math.max(start, nodeStart) - nodeStart,
+      to: Math.min(end, nodeEnd) - nodeStart
+    });
+  }
+  // Wrap last→first so splitting a later node can't invalidate an earlier ref.
+  for (let i = targets.length - 1; i >= 0; i -= 1) {
+    const { node: n, from, to } = targets[i];
+    const range = documentImpl.createRange();
+    range.setStart(n, from);
+    range.setEnd(n, to);
+    const mark = documentImpl.createElement('mark');
+    mark.className = className;
+    for (const [k, v] of Object.entries(dataset)) mark.dataset[k] = v;
+    try {
+      range.surroundContents(mark);
+    } catch {
+      /* run crossed a boundary unexpectedly — skip it rather than corrupt DOM */
+    }
+  }
+  return targets.length > 0;
+}
+
+/** Remove every annotation <mark> in a container, restoring plain text. */
+export function unwrapAll(container, { className = 'pi-annotation' } = {}) {
+  if (!container) return;
+  const marks = Array.from(container.querySelectorAll(`mark.${className}`));
+  for (const mark of marks) {
+    const parent = mark.parentNode;
+    if (!parent) continue;
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+    parent.removeChild(mark);
+    parent.normalize();
+  }
+}
+
+/**
+ * Re-render all highlights for a container: clear existing marks, then wrap each
+ * annotation against its anchor. Idempotent — safe to call after every render.
+ */
+export function applyHighlights(container, annotations, { className = 'pi-annotation', documentImpl = document } = {}) {
+  if (!container) return;
+  unwrapAll(container, { className });
+  for (const a of annotations || []) {
+    const anchorEl = documentImpl.getElementById(a.anchorId);
+    if (!anchorEl || !container.contains(anchorEl)) continue;
+    wrapRange(anchorEl, a.startOffset, a.endOffset, {
+      className,
+      dataset: { annotationId: a.id },
+      documentImpl
+    });
+  }
+}

--- a/web/src/session/annotations/annotation-range.test.js
+++ b/web/src/session/annotations/annotation-range.test.js
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import {
+  findAnchor,
+  isAnnotationAnchor,
+  getSelectionInfo,
+  wrapRange,
+  unwrapAll,
+  applyHighlights
+} from './annotation-range.js';
+
+function domWith(html) {
+  const dom = new JSDOM(`<div id="messages">${html}</div>`);
+  return { doc: dom.window.document, win: dom.window };
+}
+
+function selectRange(win, doc, startNode, startOff, endNode, endOff) {
+  const range = doc.createRange();
+  range.setStart(startNode, startOff);
+  range.setEnd(endNode, endOff);
+  const sel = win.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+  return sel;
+}
+
+describe('findAnchor', () => {
+  it('walks up to the nearest entry-* element', () => {
+    const { doc } = domWith('<div id="entry-e1"><span class="x">hi</span></div>');
+    const span = doc.querySelector('.x');
+    expect(findAnchor(span.firstChild).id).toBe('entry-e1');
+  });
+
+  it('returns null outside any anchor', () => {
+    const { doc } = domWith('<div class="no-id">hi</div>');
+    expect(findAnchor(doc.querySelector('.no-id').firstChild)).toBeNull();
+  });
+
+  it('treats both entry-* and artifact-* ids as anchors', () => {
+    const { doc } = domWith('<pre id="artifact-art-c1"><code>x</code></pre>');
+    expect(isAnnotationAnchor(doc.getElementById('artifact-art-c1'))).toBe(true);
+    expect(findAnchor(doc.querySelector('code').firstChild).id).toBe('artifact-art-c1');
+    expect(isAnnotationAnchor(doc.querySelector('.no-id'))).toBe(false);
+  });
+});
+
+describe('getSelectionInfo', () => {
+  it('measures offsets and text against the anchor', () => {
+    const { doc, win } = domWith('<div id="entry-e1">hello world</div>');
+    const textNode = doc.getElementById('entry-e1').firstChild;
+    const sel = selectRange(win, doc, textNode, 6, textNode, 11);
+
+    const info = getSelectionInfo(sel, { documentImpl: doc });
+    expect(info).toMatchObject({ anchorId: 'entry-e1', start: 6, end: 11, text: 'world' });
+  });
+
+  it('returns null for collapsed selections', () => {
+    const { doc, win } = domWith('<div id="entry-e1">hello</div>');
+    const t = doc.getElementById('entry-e1').firstChild;
+    const sel = selectRange(win, doc, t, 2, t, 2);
+    expect(getSelectionInfo(sel, { documentImpl: doc })).toBeNull();
+  });
+
+  it('rejects selections that span two entries', () => {
+    const { doc, win } = domWith('<div id="entry-e1">aaa</div><div id="entry-e2">bbb</div>');
+    const a = doc.getElementById('entry-e1').firstChild;
+    const b = doc.getElementById('entry-e2').firstChild;
+    const sel = selectRange(win, doc, a, 1, b, 2);
+    expect(getSelectionInfo(sel, { documentImpl: doc })).toBeNull();
+  });
+});
+
+describe('wrapRange / unwrapAll', () => {
+  it('wraps a range within a single text node', () => {
+    const { doc } = domWith('<div id="entry-e1">hello world</div>');
+    const anchor = doc.getElementById('entry-e1');
+    expect(wrapRange(anchor, 0, 5, { dataset: { annotationId: 'a1' }, documentImpl: doc })).toBe(true);
+    const mark = anchor.querySelector('mark.pi-annotation');
+    expect(mark.textContent).toBe('hello');
+    expect(mark.dataset.annotationId).toBe('a1');
+    expect(anchor.textContent).toBe('hello world'); // text content unchanged
+  });
+
+  it('wraps a range that lands inside a nested element', () => {
+    const { doc } = domWith('<div id="entry-e1">a <b>bold</b> c</div>');
+    const anchor = doc.getElementById('entry-e1');
+    wrapRange(anchor, 2, 6, { documentImpl: doc });
+    expect(anchor.querySelector('mark.pi-annotation').textContent).toBe('bold');
+  });
+
+  it('unwrapAll restores plain text', () => {
+    const { doc } = domWith('<div id="entry-e1">hello world</div>');
+    const anchor = doc.getElementById('entry-e1');
+    wrapRange(anchor, 0, 5, { documentImpl: doc });
+    unwrapAll(anchor);
+    expect(anchor.querySelector('mark')).toBeNull();
+    expect(anchor.textContent).toBe('hello world');
+  });
+});
+
+describe('applyHighlights', () => {
+  const annotations = [
+    { id: 'a1', anchorId: 'entry-e1', startOffset: 0, endOffset: 5 },
+    { id: 'a2', anchorId: 'entry-e2', startOffset: 1, endOffset: 3 }
+  ];
+
+  it('applies highlights from offsets across anchors', () => {
+    const { doc } = domWith('<div id="entry-e1">hello world</div><div id="entry-e2">abcd</div>');
+    applyHighlights(doc.getElementById('messages'), annotations, { documentImpl: doc });
+    expect(doc.querySelectorAll('mark.pi-annotation')).toHaveLength(2);
+    expect(doc.querySelector('[data-annotation-id="a1"]').textContent).toBe('hello');
+    expect(doc.querySelector('[data-annotation-id="a2"]').textContent).toBe('bc');
+  });
+
+  it('is idempotent — repeated calls do not stack marks', () => {
+    const { doc } = domWith('<div id="entry-e1">hello world</div><div id="entry-e2">abcd</div>');
+    const container = doc.getElementById('messages');
+    applyHighlights(container, annotations, { documentImpl: doc });
+    applyHighlights(container, annotations, { documentImpl: doc });
+    expect(doc.querySelectorAll('mark.pi-annotation')).toHaveLength(2);
+  });
+
+  it('skips annotations whose anchor is absent', () => {
+    const { doc } = domWith('<div id="entry-e1">hello world</div>');
+    applyHighlights(doc.getElementById('messages'), annotations, { documentImpl: doc });
+    expect(doc.querySelectorAll('mark.pi-annotation')).toHaveLength(1);
+  });
+});

--- a/web/src/session/artifacts/artifact-filter.js
+++ b/web/src/session/artifacts/artifact-filter.js
@@ -24,6 +24,9 @@
 const ENABLED_KEY = 'pi-web:v1:artifacts:enabled';
 const INCLUDE_KEY = 'pi-web:v1:artifacts:include';
 
+// localStorage keys that should re-run the filter when changed in another tab.
+export const ARTIFACT_SETTING_KEYS = [ENABLED_KEY, INCLUDE_KEY];
+
 // JS-side fallbacks so the session page can paint synchronously before the
 // server-backed settings (hydrateSettings) resolve. Mirrors settingDefaults in
 // internal/server/settings.go.

--- a/web/src/session/artifacts/artifact-filter.js
+++ b/web/src/session/artifacts/artifact-filter.js
@@ -1,0 +1,106 @@
+/**
+ * artifact-filter.js — pure, DOM-free filtering of artifact descriptors by the
+ * user's Artifacts settings.
+ *
+ * The registry (artifact-registry.js) always detects *everything*; this module
+ * narrows that list down to what the user wants to see:
+ *
+ *   - `enabled === false` → show nothing (session.js also hides the whole tab).
+ *   - empty `include` list → show everything (all files + chat snippets).
+ *   - non-empty `include` list → keep file artifacts whose path matches a
+ *     pattern, and DROP chat snippets (they have no path to match against).
+ *
+ * Patterns are simple globs, not gitignore syntax:
+ *   - a pattern with no `/` matches the artifact's basename (`*.md`, `*.html`)
+ *   - a pattern containing `/` matches the full path (`artifacts/**`, `docs/*.md`)
+ *   - `*`  → any run of non-slash characters
+ *   - `**` → any characters (including slashes)
+ *   - a bare extension token (`.md`) is normalized to `*.md`
+ *
+ * Kept DOM-free and side-effect-free for isolated unit testing, mirroring
+ * artifact-registry.js.
+ */
+
+const ENABLED_KEY = 'pi-web:v1:artifacts:enabled';
+const INCLUDE_KEY = 'pi-web:v1:artifacts:include';
+
+// JS-side fallbacks so the session page can paint synchronously before the
+// server-backed settings (hydrateSettings) resolve. Mirrors settingDefaults in
+// internal/server/settings.go.
+const DEFAULT_ENABLED = true;
+const DEFAULT_INCLUDE = '*.md, *.html';
+
+/** Split a raw include string into normalized glob patterns. */
+export function parsePatterns(str) {
+  if (typeof str !== 'string') return [];
+  return str
+    .split(/[\s,]+/)
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .map((t) => (t.startsWith('.') && !t.includes('/') ? `*${t}` : t));
+}
+
+function basename(filePath) {
+  return filePath.split(/[\\/]/).pop() || filePath;
+}
+
+/** Compile one glob pattern to a RegExp anchored over the whole string. */
+function globToRegExp(pattern) {
+  let re = '';
+  for (let i = 0; i < pattern.length; i += 1) {
+    const ch = pattern[i];
+    if (ch === '*') {
+      if (pattern[i + 1] === '*') { re += '.*'; i += 1; } // ** → any chars
+      else re += '[^/]*';                                  // *  → non-slash run
+    } else {
+      re += ch.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/** True if filePath matches any pattern (basename-scoped unless pattern has `/`). */
+export function matchesPath(filePath, patterns) {
+  if (typeof filePath !== 'string' || !filePath) return false;
+  const base = basename(filePath);
+  for (const pattern of patterns) {
+    const target = pattern.includes('/') ? filePath : base;
+    if (globToRegExp(pattern).test(target)) return true;
+  }
+  return false;
+}
+
+/**
+ * Filter detected artifacts by the user's settings.
+ * @returns {{visible: Array, hiddenCount: number}}
+ */
+export function filterArtifacts(artifacts, { enabled = true, include = '' } = {}) {
+  const list = Array.isArray(artifacts) ? artifacts : [];
+  if (enabled === false) return { visible: [], hiddenCount: 0 };
+
+  const patterns = parsePatterns(include);
+  if (patterns.length === 0) return { visible: list, hiddenCount: 0 };
+
+  const visible = list.filter((a) => a && a.filePath && matchesPath(a.filePath, patterns));
+  return { visible, hiddenCount: list.length - visible.length };
+}
+
+/**
+ * Read the two artifact settings from storage with JS fallback defaults, so the
+ * session page can filter synchronously on first paint.
+ */
+export function readArtifactSettings(storage) {
+  let enabled = DEFAULT_ENABLED;
+  let include = DEFAULT_INCLUDE;
+  try {
+    const e = storage?.getItem(ENABLED_KEY);
+    if (e != null) enabled = String(e) === 'true';
+    const inc = storage?.getItem(INCLUDE_KEY);
+    if (inc != null) include = String(inc);
+  } catch {
+    // ignore storage availability errors; fall back to defaults
+  }
+  return { enabled, include };
+}
+
+export const __test__ = { globToRegExp, basename, DEFAULT_ENABLED, DEFAULT_INCLUDE };

--- a/web/src/session/artifacts/artifact-filter.test.js
+++ b/web/src/session/artifacts/artifact-filter.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePatterns,
+  matchesPath,
+  filterArtifacts,
+  readArtifactSettings,
+} from './artifact-filter.js';
+
+const file = (filePath) => ({ id: filePath, filePath, content: 'x' });
+const snippet = (id) => ({ id, filePath: null, content: 'x', source: 'fenced' });
+
+describe('parsePatterns', () => {
+  it('splits on commas and whitespace, dropping blanks', () => {
+    expect(parsePatterns('*.md, *.html')).toEqual(['*.md', '*.html']);
+    expect(parsePatterns('  *.md \n *.html  ')).toEqual(['*.md', '*.html']);
+  });
+
+  it('normalizes bare extension tokens to *.ext', () => {
+    expect(parsePatterns('.md, .html')).toEqual(['*.md', '*.html']);
+  });
+
+  it('leaves path tokens with a dot prefix alone', () => {
+    expect(parsePatterns('./docs/*.md')).toEqual(['./docs/*.md']);
+  });
+
+  it('returns [] for empty or non-string input', () => {
+    expect(parsePatterns('')).toEqual([]);
+    expect(parsePatterns('   ')).toEqual([]);
+    expect(parsePatterns(null)).toEqual([]);
+  });
+});
+
+describe('matchesPath', () => {
+  const md = parsePatterns('*.md');
+  it('matches a basename glob regardless of directory', () => {
+    expect(matchesPath('report.md', md)).toBe(true);
+    expect(matchesPath('deep/nested/report.md', md)).toBe(true);
+    expect(matchesPath('report.txt', md)).toBe(false);
+  });
+
+  it('matches a full-path glob when the pattern has a slash', () => {
+    const p = parsePatterns('artifacts/**');
+    expect(matchesPath('artifacts/a.go', p)).toBe(true);
+    expect(matchesPath('artifacts/deep/a.go', p)).toBe(true);
+    expect(matchesPath('src/a.go', p)).toBe(false);
+  });
+
+  it('single * does not cross slashes; ** does', () => {
+    expect(matchesPath('docs/deep/a.md', parsePatterns('docs/*.md'))).toBe(false);
+    expect(matchesPath('docs/a.md', parsePatterns('docs/*.md'))).toBe(true);
+    expect(matchesPath('docs/deep/a.md', parsePatterns('docs/**'))).toBe(true);
+  });
+
+  it('escapes regex metacharacters in the pattern', () => {
+    expect(matchesPath('a.md', parsePatterns('a.md'))).toBe(true);
+    expect(matchesPath('axmd', parsePatterns('a.md'))).toBe(false);
+  });
+
+  it('returns false for empty/non-string path', () => {
+    expect(matchesPath('', md)).toBe(false);
+    expect(matchesPath(null, md)).toBe(false);
+  });
+});
+
+describe('filterArtifacts', () => {
+  it('returns nothing when disabled', () => {
+    const r = filterArtifacts([file('a.md'), snippet('s')], { enabled: false, include: '*.md' });
+    expect(r.visible).toEqual([]);
+    expect(r.hiddenCount).toBe(0);
+  });
+
+  it('returns everything when include is empty', () => {
+    const arts = [file('a.go'), snippet('s')];
+    const r = filterArtifacts(arts, { enabled: true, include: '' });
+    expect(r.visible).toEqual(arts);
+    expect(r.hiddenCount).toBe(0);
+  });
+
+  it('keeps only matching files and drops snippets when include is non-empty', () => {
+    const arts = [file('a.md'), file('b.go'), snippet('s1'), file('docs/c.html')];
+    const r = filterArtifacts(arts, { enabled: true, include: '*.md, *.html' });
+    expect(r.visible.map((a) => a.id)).toEqual(['a.md', 'docs/c.html']);
+    expect(r.hiddenCount).toBe(2); // b.go + snippet
+  });
+
+  it('handles a non-array input gracefully', () => {
+    expect(filterArtifacts(null, { enabled: true, include: '' })).toEqual({ visible: [], hiddenCount: 0 });
+  });
+});
+
+describe('readArtifactSettings', () => {
+  function fakeStorage(map) {
+    return { getItem: (k) => (k in map ? map[k] : null) };
+  }
+
+  it('falls back to defaults when storage is empty', () => {
+    expect(readArtifactSettings(fakeStorage({}))).toEqual({ enabled: true, include: '*.md, *.html' });
+  });
+
+  it('reads stored values', () => {
+    const s = fakeStorage({
+      'pi-web:v1:artifacts:enabled': 'false',
+      'pi-web:v1:artifacts:include': 'artifacts/**',
+    });
+    expect(readArtifactSettings(s)).toEqual({ enabled: false, include: 'artifacts/**' });
+  });
+
+  it('treats only the literal string "true" as enabled', () => {
+    const s = fakeStorage({ 'pi-web:v1:artifacts:enabled': 'nope' });
+    expect(readArtifactSettings(s).enabled).toBe(false);
+  });
+
+  it('survives a throwing storage', () => {
+    const s = { getItem() { throw new Error('blocked'); } };
+    expect(readArtifactSettings(s)).toEqual({ enabled: true, include: '*.md, *.html' });
+  });
+});

--- a/web/src/session/artifacts/artifact-panel.js
+++ b/web/src/session/artifacts/artifact-panel.js
@@ -26,6 +26,8 @@ export function createArtifactPanel({
 
   let artifacts = [];
   let selectedId = '';
+  // How many detected artifacts the active filter is hiding (for the empty state).
+  let hiddenCount = 0;
   // Preview is opt-in (click-to-run): we never auto-execute artifact content on
   // load. Resets to false whenever the selected artifact changes.
   let previewing = false;
@@ -69,6 +71,11 @@ export function createArtifactPanel({
 
   function listHtml() {
     if (artifacts.length === 0) {
+      if (hiddenCount > 0) {
+        const noun = hiddenCount === 1 ? 'artifact' : 'artifacts';
+        return `<div class="artifact-empty">${hiddenCount} ${noun} hidden by your filter — `
+          + `adjust in <a href="/settings">Settings</a>.</div>`;
+      }
       return '<div class="artifact-empty">No artifacts in this session yet.</div>';
     }
     let html = '<div class="artifact-list" role="tablist">';
@@ -210,8 +217,9 @@ export function createArtifactPanel({
     }
   });
 
-  function setArtifacts(next) {
+  function setArtifacts(next, { hiddenCount: hidden = 0 } = {}) {
     artifacts = Array.isArray(next) ? next : [];
+    hiddenCount = Number.isFinite(hidden) && hidden > 0 ? hidden : 0;
     if (!artifacts.some(a => a.id === selectedId)) {
       selectedId = artifacts.length > 0 ? artifacts[0].id : '';
       previewing = false;

--- a/web/src/session/artifacts/artifact-panel.js
+++ b/web/src/session/artifacts/artifact-panel.js
@@ -1,0 +1,237 @@
+/**
+ * artifact-panel.js — renders the artifact list + selected-artifact source view.
+ *
+ * Mounts into a host element (the right-sidebar "Artifacts" tab). Shows a list
+ * of detected artifacts and, for the selected one, its syntax-highlighted
+ * source with copy + download actions. Preview-kind artifacts (HTML/SVG) render
+ * their source here too; the sandboxed live preview is a separate follow-up.
+ *
+ * Dependency-injected (documentImpl/windowImpl/...) for jsdom testability,
+ * mirroring the shape of right-sidebar.js and session-entry-renderer.js.
+ */
+
+export function createArtifactPanel({
+  host,
+  escapeHtml,
+  highlight = null, // (code, lang) => highlightedHtml | null
+  renderMarkdown = null, // (markdownText) => sanitized HTML string
+  documentImpl = document,
+  windowImpl = window,
+  navigatorImpl = navigator,
+  URLImpl = URL,
+  BlobImpl = Blob
+} = {}) {
+  if (!host) throw new Error('createArtifactPanel: host element is required');
+  if (typeof escapeHtml !== 'function') throw new Error('createArtifactPanel: escapeHtml is required');
+
+  let artifacts = [];
+  let selectedId = '';
+  // Preview is opt-in (click-to-run): we never auto-execute artifact content on
+  // load. Resets to false whenever the selected artifact changes.
+  let previewing = false;
+
+  function selected() {
+    return artifacts.find(a => a.id === selectedId) || null;
+  }
+
+  // Render preview-kind content in an isolated iframe. sandbox="allow-scripts"
+  // WITHOUT allow-same-origin gives the frame a unique opaque origin: it cannot
+  // touch the parent DOM, cookies, localStorage, or the PI_WEB_TOKEN. The CSP
+  // meta blocks all network access so previewed code can't exfiltrate. srcdoc is
+  // set as a property (not concatenated into parent HTML) so there is no path for
+  // the content to execute in the parent document.
+  function buildPreviewFrame(artifact) {
+    const csp = "default-src 'none'; img-src data:; style-src 'unsafe-inline'; font-src data:; script-src 'unsafe-inline'";
+    const doc = `<!doctype html><html><head><meta charset="utf-8">`
+      + `<meta http-equiv="Content-Security-Policy" content="${csp}">`
+      + `</head><body>${artifact.content}</body></html>`;
+    const frame = documentImpl.createElement('iframe');
+    frame.className = 'artifact-preview';
+    frame.setAttribute('sandbox', 'allow-scripts');
+    frame.setAttribute('referrerpolicy', 'no-referrer');
+    frame.setAttribute('title', `Preview: ${artifact.title}`);
+    frame.srcdoc = doc;
+    return frame;
+  }
+
+  // The source <pre> carries id="artifact-<id>" so it can be an annotation
+  // anchor (offsets are measured against its text content).
+  function renderCode(content, lang, artifactId) {
+    let inner = null;
+    if (highlight) {
+      try { inner = highlight(content, lang); } catch { inner = null; }
+    }
+    const dataLang = lang ? ` data-lang="${escapeHtml(lang)}"` : '';
+    const pending = inner === null ? ` data-highlight-pending${dataLang}` : '';
+    const idAttr = artifactId ? ` id="artifact-${escapeHtml(artifactId)}"` : '';
+    return `<pre class="artifact-source"${idAttr}><code class="hljs"${pending}>${inner !== null ? inner : escapeHtml(content)}</code></pre>`;
+  }
+
+  function listHtml() {
+    if (artifacts.length === 0) {
+      return '<div class="artifact-empty">No artifacts in this session yet.</div>';
+    }
+    let html = '<div class="artifact-list" role="tablist">';
+    for (const a of artifacts) {
+      const active = a.id === selectedId ? ' active' : '';
+      const badge = a.kind === 'preview' ? '<span class="artifact-badge">preview</span>' : '';
+      html += `<button type="button" class="artifact-list-item${active}" role="tab" aria-selected="${a.id === selectedId}" data-artifact-id="${escapeHtml(a.id)}">`;
+      html += `<span class="artifact-item-title">${escapeHtml(a.title)}</span>`;
+      if (a.lang) html += `<span class="artifact-item-lang">${escapeHtml(a.lang)}</span>`;
+      html += badge;
+      html += '</button>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  function viewHtml() {
+    const a = selected();
+    if (!a) return '<div class="artifact-view"></div>';
+    const isPreview = a.kind === 'preview';
+    // 'markdown' renders inline (sanitized) so the label is a gentle "Preview";
+    // executable html/svg keep the click-to-run "Run preview".
+    const previewLabel = previewing ? 'Show source' : (a.previewType === 'markdown' ? 'Preview' : 'Run preview');
+    const previewToggle = isPreview
+      ? `<button type="button" class="artifact-action${previewing ? ' active' : ''}" data-action="toggle-preview">${previewLabel}</button>`
+      : '';
+    // When previewing, leave the body empty here; iframe/markdown is mounted via
+    // DOM in render() (iframe srcdoc as a property; markdown as sanitized HTML).
+    const body = (isPreview && previewing)
+      ? '<div class="artifact-view-body"></div>'
+      : `<div class="artifact-view-body">${renderCode(a.content, a.lang, a.id)}</div>`;
+    return `<div class="artifact-view">
+      <div class="artifact-view-header">
+        <span class="artifact-view-title">${escapeHtml(a.title)}</span>
+        <div class="artifact-view-actions">
+          ${previewToggle}
+          <button type="button" class="artifact-action" data-action="copy" title="Copy source">Copy</button>
+          <button type="button" class="artifact-action" data-action="download" title="Download">Download</button>
+        </div>
+      </div>
+      ${body}
+    </div>`;
+  }
+
+  function render() {
+    host.innerHTML = `<div class="artifact-panel">${listHtml()}${viewHtml()}</div>`;
+    const a = selected();
+    if (a && a.kind === 'preview' && previewing) {
+      const body = host.querySelector('.artifact-view-body');
+      if (body) {
+        if (a.previewType === 'markdown') {
+          const md = renderMarkdown ? renderMarkdown(a.content) : escapeHtml(a.content);
+          body.innerHTML = `<div class="artifact-markdown markdown-content">${md}</div>`;
+        } else {
+          body.appendChild(buildPreviewFrame(a));
+        }
+      }
+    }
+    applyHighlightFallback();
+  }
+
+  // If hljs wasn't ready at render time, the <code> carries data-highlight-pending;
+  // try once more now (the session's lazy highlighter may have loaded since).
+  function applyHighlightFallback() {
+    if (!highlight) return;
+    host.querySelectorAll('code[data-highlight-pending]').forEach((el) => {
+      const lang = el.dataset.lang;
+      const code = el.textContent;
+      let inner = null;
+      try { inner = highlight(code, lang); } catch { inner = null; }
+      if (inner !== null) {
+        el.innerHTML = inner;
+        el.removeAttribute('data-highlight-pending');
+        el.removeAttribute('data-lang');
+      }
+    });
+  }
+
+  async function copyToClipboard(textValue, button) {
+    let ok = false;
+    try {
+      if (navigatorImpl.clipboard && navigatorImpl.clipboard.writeText) {
+        await navigatorImpl.clipboard.writeText(textValue);
+        ok = true;
+      }
+    } catch { /* fall through to execCommand */ }
+    if (!ok) {
+      try {
+        const ta = documentImpl.createElement('textarea');
+        ta.value = textValue;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        documentImpl.body.appendChild(ta);
+        ta.select();
+        ok = documentImpl.execCommand('copy');
+        documentImpl.body.removeChild(ta);
+      } catch { /* give up silently */ }
+    }
+    if (ok && button) {
+      const original = button.textContent;
+      button.textContent = 'Copied';
+      button.classList.add('copied');
+      windowImpl.setTimeout(() => {
+        button.textContent = original;
+        button.classList.remove('copied');
+      }, 1500);
+    }
+    return ok;
+  }
+
+  function download(a) {
+    const blob = new BlobImpl([a.content], { type: 'text/plain' });
+    const url = URLImpl.createObjectURL(blob);
+    const anchor = documentImpl.createElement('a');
+    anchor.href = url;
+    anchor.download = a.filePath ? a.title : `${a.id}.txt`;
+    documentImpl.body.appendChild(anchor);
+    anchor.click();
+    documentImpl.body.removeChild(anchor);
+    URLImpl.revokeObjectURL(url);
+  }
+
+  host.addEventListener('click', (e) => {
+    const item = e.target.closest?.('.artifact-list-item');
+    if (item && host.contains(item)) {
+      selectArtifact(item.dataset.artifactId);
+      return;
+    }
+    const action = e.target.closest?.('.artifact-action');
+    if (action && host.contains(action)) {
+      const a = selected();
+      if (!a) return;
+      if (action.dataset.action === 'copy') copyToClipboard(a.content, action);
+      else if (action.dataset.action === 'download') download(a);
+      else if (action.dataset.action === 'toggle-preview') {
+        previewing = !previewing;
+        render();
+      }
+    }
+  });
+
+  function setArtifacts(next) {
+    artifacts = Array.isArray(next) ? next : [];
+    if (!artifacts.some(a => a.id === selectedId)) {
+      selectedId = artifacts.length > 0 ? artifacts[0].id : '';
+      previewing = false;
+    }
+    render();
+  }
+
+  function selectArtifact(id) {
+    if (!artifacts.some(a => a.id === id)) return;
+    if (id !== selectedId) previewing = false;
+    selectedId = id;
+    render();
+  }
+
+  return {
+    setArtifacts,
+    selectArtifact,
+    render,
+    getSelectedId: () => selectedId,
+    getArtifact: (id) => artifacts.find(a => a.id === id) || null,
+    getCount: () => artifacts.length
+  };
+}

--- a/web/src/session/artifacts/artifact-panel.test.js
+++ b/web/src/session/artifacts/artifact-panel.test.js
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { createArtifactPanel } from './artifact-panel.js';
+
+const escapeHtml = (s) => String(s).replace(/[&<>"']/g, (c) => (
+  { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+));
+
+function setup({ highlight = null, clipboard } = {}) {
+  const dom = new JSDOM('<div id="host"></div>');
+  const { document: doc, window: win } = dom.window;
+  const navigatorImpl = clipboard ? { clipboard } : {};
+  const created = [];
+  const URLImpl = {
+    createObjectURL: vi.fn(() => 'blob:x'),
+    revokeObjectURL: vi.fn()
+  };
+  class BlobImpl {
+    constructor(parts) { this.parts = parts; created.push(parts); }
+  }
+  const panel = createArtifactPanel({
+    host: doc.getElementById('host'),
+    escapeHtml,
+    highlight,
+    documentImpl: doc,
+    windowImpl: win,
+    navigatorImpl,
+    URLImpl,
+    BlobImpl
+  });
+  return { dom, doc, win, panel, URLImpl, created };
+}
+
+const arts = [
+  { id: 'a1', kind: 'code', title: 'util.go', lang: 'go', content: 'package main', filePath: 'src/util.go' },
+  { id: 'a2', kind: 'preview', previewType: 'html', title: 'page.html', lang: 'html', content: '<h1>hi</h1>', filePath: 'page.html' }
+];
+
+describe('artifact panel', () => {
+  it('renders an empty state with no artifacts', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts([]);
+    expect(doc.querySelector('.artifact-empty')).not.toBeNull();
+    expect(panel.getCount()).toBe(0);
+  });
+
+  it('lists artifacts and auto-selects the first', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts(arts);
+    expect(doc.querySelectorAll('.artifact-list-item')).toHaveLength(2);
+    expect(panel.getSelectedId()).toBe('a1');
+    expect(doc.querySelector('.artifact-list-item.active').dataset.artifactId).toBe('a1');
+    expect(doc.querySelector('.artifact-view-title').textContent).toBe('util.go');
+    expect(doc.querySelector('.artifact-source').textContent).toContain('package main');
+  });
+
+  it('shows a preview badge for preview-kind artifacts', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts(arts);
+    const second = doc.querySelector('[data-artifact-id="a2"]');
+    expect(second.querySelector('.artifact-badge')).not.toBeNull();
+  });
+
+  it('selects a different artifact on click', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts(arts);
+    doc.querySelector('[data-artifact-id="a2"]').click();
+    expect(panel.getSelectedId()).toBe('a2');
+    expect(doc.querySelector('.artifact-view-title').textContent).toBe('page.html');
+  });
+
+  it('uses highlight output when available, else falls back to escaped text', () => {
+    const highlight = vi.fn(() => '<span class="tok">x</span>');
+    const { doc, panel } = setup({ highlight });
+    panel.setArtifacts(arts);
+    expect(highlight).toHaveBeenCalled();
+    expect(doc.querySelector('.artifact-source code').innerHTML).toContain('tok');
+
+    const plain = setup({ highlight: null });
+    plain.panel.setArtifacts([{ id: 'x', kind: 'code', title: 't', lang: '', content: '<b>raw</b>' }]);
+    expect(plain.doc.querySelector('.artifact-source code').innerHTML).toContain('&lt;b&gt;');
+    expect(plain.doc.querySelector('code[data-highlight-pending]')).not.toBeNull();
+  });
+
+  it('copies source to clipboard and gives feedback', async () => {
+    const writeText = vi.fn().mockResolvedValue();
+    const { doc, panel } = setup({ clipboard: { writeText } });
+    panel.setArtifacts(arts);
+    const copyBtn = doc.querySelector('[data-action="copy"]');
+    copyBtn.click();
+    await Promise.resolve();
+    expect(writeText).toHaveBeenCalledWith('package main');
+  });
+
+  it('downloads the selected artifact using its filename', () => {
+    const { doc, panel, URLImpl, created } = setup();
+    panel.setArtifacts(arts);
+    const clickSpy = vi.fn();
+    const realCreate = doc.createElement.bind(doc);
+    vi.spyOn(doc, 'createElement').mockImplementation((tag) => {
+      const el = realCreate(tag);
+      if (tag === 'a') el.click = clickSpy;
+      return el;
+    });
+    doc.querySelector('[data-action="download"]').click();
+    expect(created[0]).toEqual(['package main']);
+    expect(clickSpy).toHaveBeenCalled();
+    expect(URLImpl.revokeObjectURL).toHaveBeenCalledWith('blob:x');
+  });
+
+  it('keeps the selection when setArtifacts is called with the same id', () => {
+    const { panel } = setup();
+    panel.setArtifacts(arts);
+    panel.selectArtifact('a2');
+    panel.setArtifacts(arts);
+    expect(panel.getSelectedId()).toBe('a2');
+  });
+
+  it('shows no preview toggle for code-kind artifacts', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts(arts); // a1 (code) selected by default
+    expect(doc.querySelector('[data-action="toggle-preview"]')).toBeNull();
+  });
+
+  it('runs a preview-kind artifact in a locked-down sandboxed iframe', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts(arts);
+    panel.selectArtifact('a2'); // page.html, kind: preview
+
+    const toggle = doc.querySelector('[data-action="toggle-preview"]');
+    expect(toggle.textContent).toBe('Run preview');
+    expect(doc.querySelector('.artifact-preview')).toBeNull(); // click-to-run: nothing yet
+
+    toggle.click();
+
+    const frame = doc.querySelector('iframe.artifact-preview');
+    expect(frame).not.toBeNull();
+    expect(frame.getAttribute('sandbox')).toBe('allow-scripts');
+    expect(frame.getAttribute('sandbox')).not.toContain('allow-same-origin');
+    expect(frame.srcdoc).toContain('<h1>hi</h1>');
+    expect(frame.srcdoc).toContain('Content-Security-Policy');
+    expect(frame.srcdoc).toContain("default-src 'none'");
+    expect(doc.querySelector('[data-action="toggle-preview"]').textContent).toBe('Show source');
+    expect(doc.querySelector('.artifact-source')).toBeNull();
+  });
+
+  it('renders markdown previews inline via renderMarkdown (not an iframe)', () => {
+    const renderMarkdown = vi.fn((md) => `<h1>${md.replace('# ', '')}</h1>`);
+    const dom = new JSDOM('<div id="host"></div>');
+    const doc = dom.window.document;
+    const panel = createArtifactPanel({
+      host: doc.getElementById('host'),
+      escapeHtml,
+      renderMarkdown,
+      documentImpl: doc,
+      windowImpl: dom.window
+    });
+    panel.setArtifacts([{ id: 'm1', kind: 'preview', previewType: 'markdown', title: 'README.md', lang: 'markdown', content: '# Hello' }]);
+
+    const toggle = doc.querySelector('[data-action="toggle-preview"]');
+    expect(toggle.textContent).toBe('Preview'); // gentler label for non-executable md
+    toggle.click();
+
+    expect(renderMarkdown).toHaveBeenCalledWith('# Hello');
+    expect(doc.querySelector('iframe.artifact-preview')).toBeNull();
+    expect(doc.querySelector('.artifact-markdown h1').textContent).toBe('Hello');
+  });
+
+  it('gives the source view an artifact-<id> anchor for annotations', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts(arts);
+    expect(doc.querySelector('pre.artifact-source#artifact-a1')).not.toBeNull();
+  });
+
+  it('toggles back from preview to source', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts(arts);
+    panel.selectArtifact('a2');
+    doc.querySelector('[data-action="toggle-preview"]').click();
+    doc.querySelector('[data-action="toggle-preview"]').click();
+    expect(doc.querySelector('.artifact-preview')).toBeNull();
+    expect(doc.querySelector('.artifact-source').textContent).toContain('<h1>hi</h1>');
+  });
+
+  it('resets to source view when a different artifact is selected', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts(arts);
+    panel.selectArtifact('a2');
+    doc.querySelector('[data-action="toggle-preview"]').click();
+    expect(doc.querySelector('.artifact-preview')).not.toBeNull();
+
+    panel.selectArtifact('a1');
+    panel.selectArtifact('a2');
+    expect(doc.querySelector('.artifact-preview')).toBeNull();
+    expect(doc.querySelector('[data-action="toggle-preview"]').textContent).toBe('Run preview');
+  });
+
+  it('throws without a host or escapeHtml', () => {
+    expect(() => createArtifactPanel({ escapeHtml })).toThrow(/host/);
+    const dom = new JSDOM('<div id="h"></div>');
+    expect(() => createArtifactPanel({ host: dom.window.document.getElementById('h') })).toThrow(/escapeHtml/);
+  });
+});

--- a/web/src/session/artifacts/artifact-panel.test.js
+++ b/web/src/session/artifacts/artifact-panel.test.js
@@ -44,6 +44,20 @@ describe('artifact panel', () => {
     expect(panel.getCount()).toBe(0);
   });
 
+  it('shows a filter hint in the empty state when artifacts are hidden', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts([], { hiddenCount: 3 });
+    const empty = doc.querySelector('.artifact-empty');
+    expect(empty.textContent).toContain('3 artifacts hidden by your filter');
+    expect(empty.querySelector('a[href="/settings"]')).not.toBeNull();
+  });
+
+  it('singularizes the filter hint for a single hidden artifact', () => {
+    const { doc, panel } = setup();
+    panel.setArtifacts([], { hiddenCount: 1 });
+    expect(doc.querySelector('.artifact-empty').textContent).toContain('1 artifact hidden');
+  });
+
   it('lists artifacts and auto-selects the first', () => {
     const { doc, panel } = setup();
     panel.setArtifacts(arts);

--- a/web/src/session/artifacts/artifact-registry.js
+++ b/web/src/session/artifacts/artifact-registry.js
@@ -1,0 +1,332 @@
+/**
+ * artifact-registry.js — pure detection of "artifacts" from session entries.
+ *
+ * An artifact is substantial, self-contained content worth surfacing in a
+ * dedicated panel. File artifacts are keyed by path and reflect the file's
+ * latest known state, reconstructed from the *structured* tool calls:
+ *   - `write`  → sets full content (replaces any prior state at that path)
+ *   - `edit`   → applies its {oldText→newText} edits to the current content
+ *   - `bash`   → only simple, recognized `mv` / `git mv` / `rm` (success-checked)
+ *               rename or remove the artifact; anything fancier is left alone
+ *
+ * This means write/edit are always accurate, and the common rename/delete cases
+ * are handled — but file changes made through arbitrary shell (sed, redirects,
+ * scripts) can't be tracked from the transcript and may go stale. That tradeoff
+ * is surfaced to users via the Artifacts help (?) panel.
+ *
+ * Sizeable fenced code blocks in assistant text are also surfaced as snippets.
+ * This module is DOM-free and side-effect-free for isolated unit testing.
+ *
+ * Previewable artifacts carry a `previewType` describing how the panel should
+ * render them: 'html'/'svg' run in a sandboxed iframe, 'markdown' renders via
+ * the app's markdown parser. Non-previewable artifacts have previewType ''.
+ */
+
+const EXT_TO_LANG = {
+  ts: 'typescript', tsx: 'typescript', js: 'javascript', jsx: 'javascript',
+  py: 'python', rb: 'ruby', rs: 'rust', go: 'go', java: 'java',
+  c: 'c', cpp: 'cpp', h: 'c', hpp: 'cpp', cs: 'csharp',
+  php: 'php', sh: 'bash', bash: 'bash', zsh: 'bash',
+  sql: 'sql', html: 'html', htm: 'html', css: 'css', scss: 'scss',
+  json: 'json', yaml: 'yaml', yml: 'yaml', xml: 'xml',
+  md: 'markdown', svg: 'svg', dockerfile: 'dockerfile'
+};
+
+function extOf(filePath) {
+  const base = filePath.split(/[\\/]/).pop() || '';
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0) return '';
+  return base.slice(dot + 1).toLowerCase();
+}
+
+function basename(filePath) {
+  return filePath.split(/[\\/]/).pop() || filePath;
+}
+
+function langFromPath(filePath) {
+  return EXT_TO_LANG[extOf(filePath)] || '';
+}
+
+/** How a previewable artifact should render, or '' for non-previewable. */
+function previewTypeFor(lang) {
+  switch (lang) {
+    case 'html':
+    case 'xml':
+      return 'html';
+    case 'svg':
+      return 'svg';
+    case 'markdown':
+    case 'md':
+      return 'markdown';
+    default:
+      return '';
+  }
+}
+
+/** Coerce a tool-call path argument to a non-empty string, else null. */
+function strPath(value) {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function makeFileArtifact(id, path, content, entry) {
+  const lang = langFromPath(path);
+  const previewType = previewTypeFor(lang);
+  return {
+    id,
+    kind: previewType ? 'preview' : 'code',
+    previewType,
+    title: basename(path),
+    lang,
+    content,
+    filePath: path,
+    entryId: entry.id,
+    anchorId: `entry-${entry.id}`,
+    source: 'write'
+  };
+}
+
+/** Apply pi `edit` edits ([{oldText,newText}]) to content (first-match each). */
+function applyEdits(content, edits) {
+  if (!Array.isArray(edits)) return content;
+  let out = content;
+  for (const e of edits) {
+    if (!e) continue;
+    const oldText = typeof e.oldText === 'string' ? e.oldText : e.old_string;
+    const newText = typeof e.newText === 'string' ? e.newText
+      : (typeof e.new_string === 'string' ? e.new_string : '');
+    if (typeof oldText !== 'string' || oldText === '') continue;
+    const i = out.indexOf(oldText);
+    if (i === -1) continue; // mismatch (e.g. file changed via untracked means) — skip
+    out = out.slice(0, i) + (newText || '') + out.slice(i + oldText.length);
+  }
+  return out;
+}
+
+// Shell features we refuse to interpret: their presence means the command may do
+// more than a plain mv/rm, so we leave artifacts untouched rather than guess.
+const UNSAFE_SHELL = /[|&;<>$`*?(){}\n]/;
+
+/** Split a simple command into tokens honoring '…' and "…". null if unbalanced. */
+function tokenizeShell(s) {
+  const tokens = [];
+  let cur = '';
+  let quote = '';
+  let started = false;
+  for (let i = 0; i < s.length; i += 1) {
+    const ch = s[i];
+    if (quote) {
+      if (ch === quote) quote = '';
+      else cur += ch;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+    } else if (ch === ' ' || ch === '\t') {
+      if (started) { tokens.push(cur); cur = ''; started = false; }
+    } else {
+      cur += ch;
+      started = true;
+    }
+  }
+  if (quote) return null;
+  if (started) tokens.push(cur);
+  return tokens;
+}
+
+/**
+ * Recognize ONLY plain `mv`/`git mv`/`rm` and return the file ops they imply.
+ * Returns [] for anything with shell features, redirection, or ambiguous forms.
+ */
+export function parseFileOps(command) {
+  if (typeof command !== 'string') return [];
+  const trimmed = command.trim();
+  if (!trimmed || UNSAFE_SHELL.test(trimmed)) return [];
+  const tokens = tokenizeShell(trimmed);
+  if (!tokens || tokens.length < 2) return [];
+
+  let verb = tokens[0];
+  let rest = tokens.slice(1);
+  if (verb === 'git' && rest[0] === 'mv') { verb = 'mv'; rest = rest.slice(1); }
+  if (verb !== 'mv' && verb !== 'rm') return [];
+
+  const args = rest.filter((t) => !t.startsWith('-'));
+  if (verb === 'rm') {
+    return args.map((p) => ({ op: 'rm', path: p }));
+  }
+  if (args.length < 2) return [];
+  const dst = args[args.length - 1];
+  const srcs = args.slice(0, -1);
+  if (dst.endsWith('/')) {
+    return srcs.map((s) => ({ op: 'mv', from: s, to: dst + basename(s) }));
+  }
+  if (srcs.length === 1) return [{ op: 'mv', from: srcs[0], to: dst }];
+  return []; // multiple sources without a directory dst — ambiguous, skip
+}
+
+function applyBashOps(command, byPath) {
+  for (const op of parseFileOps(command)) {
+    if (op.op === 'rm') {
+      const art = byPath.get(op.path);
+      if (art) { art._removed = true; byPath.delete(op.path); }
+    } else if (op.op === 'mv' && op.from !== op.to) {
+      const art = byPath.get(op.from);
+      if (!art) continue;
+      byPath.delete(op.from);
+      art.filePath = op.to;
+      art.title = basename(op.to);
+      art.lang = langFromPath(op.to);
+      art.previewType = previewTypeFor(art.lang);
+      art.kind = art.previewType ? 'preview' : 'code';
+      byPath.set(op.to, art);
+    }
+  }
+}
+
+function indexToolResults(entries) {
+  const map = new Map();
+  for (const entry of entries) {
+    if (entry && entry.type === 'message' && entry.message && entry.message.role === 'toolResult') {
+      map.set(entry.message.toolCallId, entry.message);
+    }
+  }
+  return map;
+}
+
+/** A tool call counts as "applied" only once its result lands without error. */
+function toolSucceeded(callId, results) {
+  const r = results.get(callId);
+  return !!r && r.isError !== true;
+}
+
+function applyFileToolCall(call, entry, order, byPath, results) {
+  const args = call.arguments || {};
+  if (call.name === 'write') {
+    const path = strPath(args.file_path ?? args.path);
+    const content = typeof args.content === 'string' ? args.content : null;
+    if (path === null || content === null) return;
+    const existing = byPath.get(path);
+    if (existing) {
+      existing.content = content;
+      existing.entryId = entry.id;
+      existing.anchorId = `entry-${entry.id}`;
+    } else {
+      const art = makeFileArtifact(`art-${call.id ?? `${entry.id}-write`}`, path, content, entry);
+      order.push(art);
+      byPath.set(path, art);
+    }
+  } else if (call.name === 'edit') {
+    const path = strPath(args.file_path ?? args.path);
+    if (path === null) return;
+    const art = byPath.get(path);
+    if (!art) return; // no in-session baseline content — can't reconstruct, skip
+    art.content = applyEdits(art.content, args.edits);
+    art.entryId = entry.id;
+    art.anchorId = `entry-${entry.id}`;
+  } else if (call.name === 'bash') {
+    if (toolSucceeded(call.id, results)) applyBashOps(args.command, byPath);
+  }
+}
+
+/**
+ * Yield fenced code blocks from markdown text. Recognizes ``` and ~~~ fences of
+ * length >= 3; a closing fence is a line of the same char with no info string.
+ */
+function* fencedBlocks(text) {
+  const lines = text.split('\n');
+  let open = false;
+  let fenceChar = '';
+  let info = '';
+  let buf = [];
+
+  for (const line of lines) {
+    const m = line.match(/^(\s*)(`{3,}|~{3,})(.*)$/);
+    if (!open && m) {
+      open = true;
+      fenceChar = m[2][0];
+      info = m[3].trim();
+      buf = [];
+    } else if (open && m && m[2][0] === fenceChar && m[3].trim() === '') {
+      yield { lang: (info.split(/\s+/)[0] || '').toLowerCase(), content: buf.join('\n') };
+      open = false;
+      info = '';
+    } else if (open) {
+      buf.push(line);
+    }
+  }
+}
+
+function* artifactsFromText(text, entry, blockIndex, minCodeBlockLines) {
+  let fenceIndex = 0;
+  for (const { lang, content } of fencedBlocks(text)) {
+    const idx = fenceIndex++;
+    if (!content.trim()) continue;
+    const previewType = previewTypeFor(lang);
+    const previewable = previewType !== '';
+    const lineCount = content.split('\n').length;
+    if (!previewable && lineCount < minCodeBlockLines) continue;
+
+    yield {
+      id: `art-${entry.id}-${blockIndex}-${idx}`,
+      kind: previewable ? 'preview' : 'code',
+      previewType,
+      title: lang ? `${lang} snippet` : 'snippet',
+      lang,
+      content,
+      filePath: null,
+      entryId: entry.id,
+      anchorId: `entry-${entry.id}`,
+      source: 'fenced'
+    };
+  }
+}
+
+/**
+ * Walk session entries and collect artifact descriptors. File artifacts are
+ * path-keyed and reflect their latest state (write/edit/rename/remove); fenced
+ * snippets are emitted per occurrence. Order is first-appearance.
+ *
+ * @param {Array} entries  session entries (data-model order)
+ * @param {object} [opts]
+ * @param {number} [opts.minCodeBlockLines=6]  minimum lines for a non-previewable
+ *        fenced block to qualify as a snippet artifact
+ * @returns {Array<{id,kind,previewType,title,lang,content,filePath,entryId,anchorId,source}>}
+ */
+export function collectArtifacts(entries, { minCodeBlockLines = 6 } = {}) {
+  if (!Array.isArray(entries)) return [];
+  const order = [];          // file + snippet artifacts in first-seen order
+  const byPath = new Map();   // current path -> file artifact
+  const results = indexToolResults(entries);
+
+  for (const entry of entries) {
+    if (!entry || entry.type !== 'message') continue;
+    const msg = entry.message;
+    if (!msg) continue;
+
+    // A bash command the user ran directly in the composer can also rename/remove.
+    if (msg.role === 'bashExecution') {
+      if (!msg.cancelled && msg.exitCode === 0) applyBashOps(msg.command, byPath);
+      continue;
+    }
+
+    if (msg.role !== 'assistant' || !Array.isArray(msg.content)) continue;
+
+    let blockIndex = 0;
+    for (const block of msg.content) {
+      const idx = blockIndex++;
+      if (!block) continue;
+      if (block.type === 'toolCall') {
+        applyFileToolCall(block, entry, order, byPath, results);
+      } else if (block.type === 'text' && typeof block.text === 'string') {
+        for (const a of artifactsFromText(block.text, entry, idx, minCodeBlockLines)) {
+          order.push(a);
+        }
+      }
+    }
+  }
+
+  return order.filter((a) => !a._removed);
+}
+
+export const __test__ = {
+  fencedBlocks, langFromPath, previewTypeFor, basename, extOf,
+  parseFileOps, applyEdits, tokenizeShell
+};

--- a/web/src/session/artifacts/artifact-registry.test.js
+++ b/web/src/session/artifacts/artifact-registry.test.js
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+import { collectArtifacts, __test__ } from './artifact-registry.js';
+
+function assistant(id, content) {
+  return { id, type: 'message', message: { role: 'assistant', content } };
+}
+function writeCall(callId, file_path, content) {
+  return { type: 'toolCall', id: callId, name: 'write', arguments: { file_path, content } };
+}
+function editCall(callId, path, edits) {
+  return { type: 'toolCall', id: callId, name: 'edit', arguments: { path, edits } };
+}
+function bashCall(callId, command) {
+  return { type: 'toolCall', id: callId, name: 'bash', arguments: { command } };
+}
+function toolResult(callId, isError = false) {
+  return { id: `r-${callId}`, type: 'message', message: { role: 'toolResult', toolCallId: callId, isError, content: [] } };
+}
+function text(t) {
+  return { type: 'text', text: t };
+}
+
+describe('collectArtifacts — write tool calls', () => {
+  it('captures a written file as a code artifact', () => {
+    const entries = [assistant('e1', [writeCall('c1', 'src/util.go', 'package main\n')])];
+    const [a] = collectArtifacts(entries);
+    expect(a).toMatchObject({
+      id: 'art-c1', kind: 'code', title: 'util.go', lang: 'go',
+      content: 'package main\n', filePath: 'src/util.go',
+      entryId: 'e1', anchorId: 'entry-e1', source: 'write'
+    });
+  });
+
+  it('marks .html and .svg writes as preview kind', () => {
+    const entries = [
+      assistant('e1', [writeCall('c1', 'page.html', '<h1>hi</h1>')]),
+      assistant('e2', [writeCall('c2', 'icon.svg', '<svg></svg>')])
+    ];
+    const arts = collectArtifacts(entries);
+    expect(arts.map(a => a.kind)).toEqual(['preview', 'preview']);
+    expect(arts.map(a => a.previewType)).toEqual(['html', 'svg']);
+  });
+
+  it('marks markdown writes as a markdown-preview artifact', () => {
+    const [a] = collectArtifacts([assistant('e1', [writeCall('c1', 'README.md', '# Title\n')])]);
+    expect(a).toMatchObject({ kind: 'preview', previewType: 'markdown', lang: 'markdown' });
+  });
+
+  it('treats short markdown fenced blocks as previewable too', () => {
+    const [a] = collectArtifacts([assistant('e1', [text('```md\n# Hi\n```')])]);
+    expect(a).toMatchObject({ kind: 'preview', previewType: 'markdown' });
+  });
+
+  it('accepts path arg alias and ignores writes with non-string content', () => {
+    const ok = collectArtifacts([assistant('e1', [{ type: 'toolCall', id: 'c1', name: 'write', arguments: { path: 'a.js', content: 'x' } }])]);
+    expect(ok).toHaveLength(1);
+    expect(ok[0].title).toBe('a.js');
+
+    const bad = collectArtifacts([assistant('e2', [{ type: 'toolCall', id: 'c2', name: 'write', arguments: { file_path: 'a.js', content: { not: 'a string' } } }])]);
+    expect(bad).toHaveLength(0);
+  });
+
+  it('ignores non-write tool calls', () => {
+    const entries = [assistant('e1', [{ type: 'toolCall', id: 'c1', name: 'bash', arguments: { command: 'ls' } }])];
+    expect(collectArtifacts(entries)).toHaveLength(0);
+  });
+});
+
+describe('collectArtifacts — fenced code blocks', () => {
+  it('captures previewable fenced blocks regardless of length', () => {
+    const entries = [assistant('e1', [text('Here:\n\n```html\n<p>hi</p>\n```')])];
+    const [a] = collectArtifacts(entries);
+    expect(a).toMatchObject({ kind: 'preview', lang: 'html', source: 'fenced', anchorId: 'entry-e1' });
+    expect(a.content).toBe('<p>hi</p>');
+  });
+
+  it('captures long code blocks but skips short non-previewable ones', () => {
+    const short = '```js\na();\nb();\n```';
+    const long = '```js\n' + Array.from({ length: 8 }, (_, i) => `line${i};`).join('\n') + '\n```';
+    const arts = collectArtifacts([assistant('e1', [text(`${short}\n\n${long}`)])]);
+    expect(arts).toHaveLength(1);
+    expect(arts[0].lang).toBe('js');
+    expect(arts[0].content.split('\n')).toHaveLength(8);
+  });
+
+  it('respects a custom minCodeBlockLines threshold', () => {
+    const block = '```js\na;\nb;\n```';
+    expect(collectArtifacts([assistant('e1', [text(block)])], { minCodeBlockLines: 2 })).toHaveLength(1);
+    expect(collectArtifacts([assistant('e1', [text(block)])], { minCodeBlockLines: 3 })).toHaveLength(0);
+  });
+
+  it('handles ~~~ fences and tildes do not close backtick fences', () => {
+    const blocks = __test__.fencedBlocks('~~~svg\n<svg/>\n~~~');
+    expect([...blocks]).toEqual([{ lang: 'svg', content: '<svg/>' }]);
+  });
+
+  it('gives each artifact a stable distinct id and keeps document order', () => {
+    const entries = [
+      assistant('e1', [writeCall('c1', 'a.go', 'package a'), text('```html\n<i>x</i>\n```')])
+    ];
+    const arts = collectArtifacts(entries);
+    expect(arts.map(a => a.id)).toEqual(['art-c1', 'art-e1-1-0']);
+    expect(new Set(arts.map(a => a.id)).size).toBe(2);
+  });
+});
+
+describe('collectArtifacts — path-keyed file state', () => {
+  it('collapses repeated writes to the same path into one artifact (latest wins)', () => {
+    const arts = collectArtifacts([
+      assistant('e1', [writeCall('c1', 'a.md', 'v1')]),
+      assistant('e2', [writeCall('c2', 'a.md', 'v2')])
+    ]);
+    expect(arts).toHaveLength(1);
+    expect(arts[0]).toMatchObject({ id: 'art-c1', title: 'a.md', content: 'v2' });
+  });
+
+  it('folds edits into the current content', () => {
+    const arts = collectArtifacts([
+      assistant('e1', [writeCall('c1', 'hi.txt', 'hello world')]),
+      assistant('e2', [editCall('c2', 'hi.txt', [{ oldText: 'world', newText: 'there' }])])
+    ]);
+    expect(arts).toHaveLength(1);
+    expect(arts[0].content).toBe('hello there');
+  });
+
+  it('ignores edits to a file never written in-session', () => {
+    const arts = collectArtifacts([
+      assistant('e1', [editCall('c1', 'unknown.txt', [{ oldText: 'a', newText: 'b' }])])
+    ]);
+    expect(arts).toHaveLength(0);
+  });
+
+  it('renames an artifact on a successful mv (path, title, lang all update)', () => {
+    const arts = collectArtifacts([
+      assistant('e1', [writeCall('c1', 'daytrip.md', '# Trip')]),
+      assistant('e2', [bashCall('c2', 'mv daytrip.md day-trip.md')]),
+      toolResult('c2')
+    ]);
+    expect(arts).toHaveLength(1);
+    expect(arts[0]).toMatchObject({ id: 'art-c1', title: 'day-trip.md', filePath: 'day-trip.md', content: '# Trip' });
+  });
+
+  it('handles git mv and mv into a directory', () => {
+    const gitMv = collectArtifacts([
+      assistant('e1', [writeCall('c1', 'a.go', 'x')]),
+      assistant('e2', [bashCall('c2', 'git mv a.go b.go')]),
+      toolResult('c2')
+    ]);
+    expect(gitMv[0].title).toBe('b.go');
+
+    const intoDir = collectArtifacts([
+      assistant('e1', [writeCall('c1', 'a.go', 'x')]),
+      assistant('e2', [bashCall('c2', 'mv a.go src/')]),
+      toolResult('c2')
+    ]);
+    expect(intoDir[0].filePath).toBe('src/a.go');
+  });
+
+  it('removes an artifact on a successful rm', () => {
+    const arts = collectArtifacts([
+      assistant('e1', [writeCall('c1', 'tmp.txt', 'junk')]),
+      assistant('e2', [bashCall('c2', 'rm tmp.txt')]),
+      toolResult('c2')
+    ]);
+    expect(arts).toHaveLength(0);
+  });
+
+  it('does NOT act on a failed mv', () => {
+    const arts = collectArtifacts([
+      assistant('e1', [writeCall('c1', 'a.md', 'x')]),
+      assistant('e2', [bashCall('c2', 'mv a.md b.md')]),
+      toolResult('c2', true) // isError
+    ]);
+    expect(arts[0].title).toBe('a.md'); // unchanged
+  });
+
+  it('leaves artifacts alone for shell it will not interpret', () => {
+    const arts = collectArtifacts([
+      assistant('e1', [writeCall('c1', 'a.md', 'x')]),
+      assistant('e2', [bashCall('c2', 'mv a.md b.md && echo done')]),
+      toolResult('c2')
+    ]);
+    expect(arts[0].title).toBe('a.md'); // unsafe (&&) → not parsed
+  });
+
+  it('tracks renames the user runs directly in the composer (bashExecution)', () => {
+    const arts = collectArtifacts([
+      assistant('e1', [writeCall('c1', 'a.md', 'x')]),
+      { id: 'e2', type: 'message', message: { role: 'bashExecution', command: 'mv a.md b.md', exitCode: 0 } }
+    ]);
+    expect(arts[0].title).toBe('b.md');
+  });
+});
+
+describe('parseFileOps', () => {
+  const { parseFileOps } = __test__;
+  it('recognizes plain mv / git mv / rm', () => {
+    expect(parseFileOps('mv a b')).toEqual([{ op: 'mv', from: 'a', to: 'b' }]);
+    expect(parseFileOps('git mv a b')).toEqual([{ op: 'mv', from: 'a', to: 'b' }]);
+    expect(parseFileOps('rm a')).toEqual([{ op: 'rm', path: 'a' }]);
+    expect(parseFileOps('rm -f a b')).toEqual([{ op: 'rm', path: 'a' }, { op: 'rm', path: 'b' }]);
+  });
+  it('honors quotes', () => {
+    expect(parseFileOps('mv "a b.md" c.md')).toEqual([{ op: 'mv', from: 'a b.md', to: 'c.md' }]);
+  });
+  it('bails on shell features and unrelated commands', () => {
+    expect(parseFileOps('mv a b | tee log')).toEqual([]);
+    expect(parseFileOps('sed -i s/x/y/ a')).toEqual([]);
+    expect(parseFileOps('ls -la')).toEqual([]);
+    expect(parseFileOps('mv a b c')).toEqual([]); // ambiguous multi-src, non-dir dst
+  });
+});
+
+describe('collectArtifacts — robustness', () => {
+  it('returns [] for non-array input', () => {
+    expect(collectArtifacts(null)).toEqual([]);
+    expect(collectArtifacts(undefined)).toEqual([]);
+  });
+
+  it('ignores user messages and non-message entries', () => {
+    const entries = [
+      { id: 'u1', type: 'message', message: { role: 'user', content: 'write app.html' } },
+      { id: 'm1', type: 'model_change', provider: 'anthropic', modelId: 'x' }
+    ];
+    expect(collectArtifacts(entries)).toEqual([]);
+  });
+});

--- a/web/src/session/live/live-events.js
+++ b/web/src/session/live/live-events.js
@@ -70,6 +70,7 @@ export function wireSessionEvents({
   eventSource,
   onReload,
   onChatPreview,
+  onAnnotations = null,
   onError = () => {},
   windowImpl = typeof window !== 'undefined' ? window : null,
   CustomEventImpl = typeof CustomEvent !== 'undefined' ? CustomEvent : null
@@ -90,6 +91,16 @@ export function wireSessionEvents({
       onError(error);
     }
   });
+  if (onAnnotations) {
+    eventSource.addEventListener('annotations', (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        onAnnotations(Array.isArray(data.annotations) ? data.annotations : []);
+      } catch (error) {
+        onError(error);
+      }
+    });
+  }
   eventSource.onerror = onError;
   return eventSource;
 }

--- a/web/src/session/live/live-reload-runner.js
+++ b/web/src/session/live/live-reload-runner.js
@@ -19,7 +19,8 @@ export function runLiveReload({
   resumeButton,
   newSessionButton,
   cwd = '',
-  onSessionDataReload = () => {}
+  onSessionDataReload = () => {},
+  onAnnotations = null
 } = {}) {
   const document = documentImpl;
   const window = windowImpl;
@@ -298,6 +299,7 @@ export function runLiveReload({
         eventSource: es,
         onReload: triggerReload,
         onChatPreview: renderChatPreview,
+        onAnnotations: onAnnotations,
         onError: function() {
           // EventSource fires onerror both for transient blips (browser
           // will auto-retry) and terminal closures (readyState===CLOSED,

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -15,7 +15,7 @@ import * as searchFiltersApi from './ui/search-filters.js';
 import { setupSessionUi } from './ui/session-ui-runner.js';
 import { collectArtifacts } from './artifacts/artifact-registry.js';
 import { createArtifactPanel } from './artifacts/artifact-panel.js';
-import { filterArtifacts, readArtifactSettings } from './artifacts/artifact-filter.js';
+import { filterArtifacts, readArtifactSettings, ARTIFACT_SETTING_KEYS } from './artifacts/artifact-filter.js';
 import { createAnnotationApi } from './annotations/annotation-api.js';
 import { createAnnotationLayer } from './annotations/annotation-layer.js';
 import * as chatComposerRunner from './chat/chat-composer-runner.js';
@@ -276,6 +276,14 @@ export function runSessionApp({ target = window } = {}) {
     import('highlight.js').then(({ default: loaded }) => {
       artifactHljs = loaded;
       artifactPanel.render();
+    });
+
+    // Reflect artifact-setting changes made on the /settings page (in another
+    // tab) without a reload. The `storage` event fires only in other documents,
+    // so this won't double-fire for changes originating in this same tab. A null
+    // key means storage was cleared — refresh to re-read defaults.
+    target.addEventListener('storage', (e) => {
+      if (e.key === null || ARTIFACT_SETTING_KEYS.includes(e.key)) refreshArtifacts();
     });
 
     // Artifacts help (?) modal — shown only on the Artifacts tab via CSS.

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -15,6 +15,7 @@ import * as searchFiltersApi from './ui/search-filters.js';
 import { setupSessionUi } from './ui/session-ui-runner.js';
 import { collectArtifacts } from './artifacts/artifact-registry.js';
 import { createArtifactPanel } from './artifacts/artifact-panel.js';
+import { filterArtifacts, readArtifactSettings } from './artifacts/artifact-filter.js';
 import { createAnnotationApi } from './annotations/annotation-api.js';
 import { createAnnotationLayer } from './annotations/annotation-layer.js';
 import * as chatComposerRunner from './chat/chat-composer-runner.js';
@@ -102,14 +103,27 @@ export function runSessionApp({ target = window } = {}) {
 
   let artifactPanel = null;
   let annotationLayer = null;
+  // Hide the Artifacts tab entirely when the feature is disabled; if it was the
+  // active tab, fall back to Scratchpad so the user isn't left on a blank pane.
+  function applyArtifactsEnabled(enabled) {
+    const tab = documentImpl.getElementById('right-tab-artifacts');
+    if (!tab) return;
+    tab.hidden = !enabled;
+    if (!enabled && tab.classList.contains('active')) {
+      documentImpl.getElementById('right-tab-scratchpad')?.click();
+    }
+  }
   function refreshArtifacts() {
     if (!artifactPanel) return;
-    const artifacts = collectArtifacts(dataModel.entries);
-    artifactPanel.setArtifacts(artifacts);
+    const all = collectArtifacts(dataModel.entries);
+    const settings = readArtifactSettings(target.localStorage);
+    applyArtifactsEnabled(settings.enabled);
+    const { visible, hiddenCount } = filterArtifacts(all, settings);
+    artifactPanel.setArtifacts(visible, { hiddenCount });
     const countEl = documentImpl.getElementById('artifact-tab-count');
     if (countEl) {
-      countEl.textContent = String(artifacts.length);
-      countEl.hidden = artifacts.length === 0;
+      countEl.textContent = String(visible.length);
+      countEl.hidden = visible.length === 0;
     }
   }
 

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -404,6 +404,10 @@ export function runSessionApp({ target = window } = {}) {
         ui.activateRightTab('artifacts');
         artifactPanel?.selectArtifact(artifactId);
       },
+      onCreate: () => {
+        ui.openRightSidebar();
+        ui.activateRightTab('notes');
+      },
       resolveArtifact: (artifactId) => artifactPanel?.getArtifact(artifactId) || null,
       documentImpl,
       windowImpl: target

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -13,6 +13,10 @@ import * as toggleStateApi from './ui/toggle-state.js';
 import * as sidebarApi from './ui/sidebar.js';
 import * as searchFiltersApi from './ui/search-filters.js';
 import { setupSessionUi } from './ui/session-ui-runner.js';
+import { collectArtifacts } from './artifacts/artifact-registry.js';
+import { createArtifactPanel } from './artifacts/artifact-panel.js';
+import { createAnnotationApi } from './annotations/annotation-api.js';
+import { createAnnotationLayer } from './annotations/annotation-layer.js';
 import * as chatComposerRunner from './chat/chat-composer-runner.js';
 import * as doneNotifier from './chat/done-notifier.js';
 import * as chatApi from './chat/chat-api.js';
@@ -96,6 +100,19 @@ export function runSessionApp({ target = window } = {}) {
     })
   };
 
+  let artifactPanel = null;
+  let annotationLayer = null;
+  function refreshArtifacts() {
+    if (!artifactPanel) return;
+    const artifacts = collectArtifacts(dataModel.entries);
+    artifactPanel.setArtifacts(artifacts);
+    const countEl = documentImpl.getElementById('artifact-tab-count');
+    if (countEl) {
+      countEl.textContent = String(artifacts.length);
+      countEl.hidden = artifacts.length === 0;
+    }
+  }
+
   function replaceMapContents(targetMap, nextMap) {
     targetMap.clear();
     nextMap.forEach((value, key) => targetMap.set(key, value));
@@ -140,6 +157,8 @@ export function runSessionApp({ target = window } = {}) {
       syncTreeRendererState();
       treeRenderer.forceTreeRerender();
     }
+
+    refreshArtifacts();
   }
 
   const sessionTree = {
@@ -214,6 +233,51 @@ export function runSessionApp({ target = window } = {}) {
     navigateTo: (...args) => navigateTo(...args),
     projectPath: dataModel.header?.cwd || ''
   });
+
+  // Artifacts panel (right-sidebar "Artifacts" tab). Live-only: the host element
+  // is rendered only when IsLive, so this is a no-op on export snapshots.
+  const artifactHost = documentImpl.getElementById('artifact-panel-host');
+  if (artifactHost) {
+    let artifactHljs = null;
+    const artifactHighlight = (code, lang) => {
+      if (!artifactHljs) return null;
+      try {
+        return lang && artifactHljs.getLanguage(lang)
+          ? artifactHljs.highlight(code, { language: lang }).value
+          : artifactHljs.highlightAuto(code).value;
+      } catch { return null; }
+    };
+    artifactPanel = createArtifactPanel({
+      host: artifactHost,
+      escapeHtml: sessionFormat.escapeHtml,
+      highlight: artifactHighlight,
+      renderMarkdown: (text) => safeMarkedParse(text, { marked }),
+      documentImpl,
+      windowImpl: target,
+      navigatorImpl: target.navigator,
+      URLImpl: target.URL,
+      BlobImpl: target.Blob
+    });
+    refreshArtifacts();
+    import('highlight.js').then(({ default: loaded }) => {
+      artifactHljs = loaded;
+      artifactPanel.render();
+    });
+
+    // Artifacts help (?) modal — shown only on the Artifacts tab via CSS.
+    const helpBtn = documentImpl.getElementById('artifact-help-btn');
+    const helpModal = documentImpl.getElementById('artifact-help-modal');
+    if (helpBtn && helpModal) {
+      const hideHelp = () => { helpModal.hidden = true; };
+      helpBtn.addEventListener('click', () => { helpModal.hidden = false; });
+      helpModal.addEventListener('click', (e) => {
+        if (e.target.closest('[data-action="close-artifact-help"]')) hideHelp();
+      });
+      target.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !helpModal.hidden) hideHelp();
+      });
+    }
+  }
 
   const navigateTo = (targetId, scrollMode = 'target', scrollToEntryId = null) => navigatorInstance.navigateTo(targetId, scrollMode, scrollToEntryId);
   const renderEntryToNode = (entry) => navigatorInstance.renderEntryToNode(entry);
@@ -300,6 +364,32 @@ export function runSessionApp({ target = window } = {}) {
   // entries below the stub and the conversation appears duplicated.
   navigateTo(currentLeafId, dataModel.urlTargetId ? 'target' : 'bottom', dataModel.urlTargetId || null);
 
+  // Annotation layer (right-sidebar "Notes" tab). Live-only: the host element is
+  // rendered only when IsLive. Anchors to entries by `entry-<id>` + offsets.
+  const annotationListHost = documentImpl.getElementById('annotation-list-host');
+  const messagesEl = documentImpl.getElementById('messages');
+  if (annotationListHost && messagesEl && sessionId) {
+    const annotationArtifactHost = documentImpl.getElementById('artifact-panel-host');
+    annotationLayer = createAnnotationLayer({
+      sessionId,
+      api: createAnnotationApi({ sessionId, fetchImpl: target.fetch.bind(target) }),
+      scopes: [messagesEl, annotationArtifactHost].filter(Boolean),
+      listHost: annotationListHost,
+      composerEl: documentImpl.getElementById('pi-chat-message'),
+      countEl: documentImpl.getElementById('annotation-tab-count'),
+      escapeHtml: sessionFormat.escapeHtml,
+      onSelectArtifact: (artifactId) => {
+        ui.activateRightTab('artifacts');
+        artifactPanel?.selectArtifact(artifactId);
+      },
+      resolveArtifact: (artifactId) => artifactPanel?.getArtifact(artifactId) || null,
+      documentImpl,
+      windowImpl: target
+    });
+    annotationLayer.init();
+    target.addEventListener('pi-session-reload', () => annotationLayer.reapply());
+  }
+
   doneNotifier.setupDoneNotifyToggle({ documentImpl, windowImpl: target });
   target.addEventListener('pi-worker-done', () => {
     doneNotifier.notifyDone({ documentImpl, windowImpl: target });
@@ -327,7 +417,8 @@ export function runSessionApp({ target = window } = {}) {
     resumeButton,
     newSessionButton,
     cwd: dataModel.header?.cwd || '',
-    onSessionDataReload: (data) => syncDataModelEntries(data.entries)
+    onSessionDataReload: (data) => syncDataModelEntries(data.entries),
+    onAnnotations: (list) => annotationLayer?.setAnnotations(list)
   });
 
   setupKeyboardNav({ windowImpl: target, documentImpl });

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -408,6 +408,11 @@ export function runSessionApp({ target = window } = {}) {
         ui.openRightSidebar();
         ui.activateRightTab('notes');
       },
+      onSend: () => {
+        // On mobile the sidebar is a full-screen overlay; collapse it so the
+        // composer it just filled is visible and ready to type into.
+        if (ui.isMobileLayout()) ui.collapseRightSidebar();
+      },
       resolveArtifact: (artifactId) => artifactPanel?.getArtifact(artifactId) || null,
       documentImpl,
       windowImpl: target

--- a/web/src/session/ui/right-sidebar-tabs.test.js
+++ b/web/src/session/ui/right-sidebar-tabs.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { setupRightSidebarTabs } from './right-sidebar.js';
+
+function makeDom() {
+  const dom = new JSDOM(`
+    <aside id="right-sidebar">
+      <div class="right-sidebar-tabs">
+        <button class="right-sidebar-tab active" data-pane="scratchpad" aria-selected="true">Scratchpad</button>
+        <button class="right-sidebar-tab" data-pane="artifacts" aria-selected="false">Artifacts</button>
+      </div>
+      <div class="right-sidebar-content">
+        <div id="right-pane-scratchpad" class="right-sidebar-pane active"></div>
+        <div id="right-pane-artifacts" class="right-sidebar-pane" hidden></div>
+      </div>
+    </aside>
+  `);
+  return dom.window.document;
+}
+
+function memoryStorage() {
+  const map = new Map();
+  return { getItem: (k) => (map.has(k) ? map.get(k) : null), setItem: (k, v) => map.set(k, String(v)) };
+}
+
+describe('setupRightSidebarTabs', () => {
+  it('switches panes and aria state on tab click', () => {
+    const doc = makeDom();
+    setupRightSidebarTabs({ documentImpl: doc, storage: memoryStorage() });
+
+    doc.querySelector('[data-pane="artifacts"]').click();
+
+    expect(doc.querySelector('[data-pane="artifacts"]').classList.contains('active')).toBe(true);
+    expect(doc.querySelector('[data-pane="artifacts"]').getAttribute('aria-selected')).toBe('true');
+    expect(doc.querySelector('[data-pane="scratchpad"]').getAttribute('aria-selected')).toBe('false');
+    expect(doc.getElementById('right-pane-artifacts').hasAttribute('hidden')).toBe(false);
+    expect(doc.getElementById('right-pane-scratchpad').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('persists the active tab and restores it on the next setup', () => {
+    const storage = memoryStorage();
+    const doc1 = makeDom();
+    setupRightSidebarTabs({ documentImpl: doc1, storage });
+    doc1.querySelector('[data-pane="artifacts"]').click();
+    expect(storage.getItem('pi-web:v1:right-sidebar-tab')).toBe('artifacts');
+
+    const doc2 = makeDom();
+    setupRightSidebarTabs({ documentImpl: doc2, storage });
+    expect(doc2.getElementById('right-pane-artifacts').hasAttribute('hidden')).toBe(false);
+    expect(doc2.querySelector('[data-pane="artifacts"]').classList.contains('active')).toBe(true);
+  });
+
+  it('returns a no-op activate when tabs are absent', () => {
+    const dom = new JSDOM('<div></div>');
+    const { activate } = setupRightSidebarTabs({ documentImpl: dom.window.document, storage: memoryStorage() });
+    expect(() => activate('artifacts')).not.toThrow();
+  });
+
+  it('marks the active tab on the sidebar for tab-scoped chrome (help button)', () => {
+    const doc = makeDom();
+    setupRightSidebarTabs({ documentImpl: doc, storage: memoryStorage() });
+    expect(doc.getElementById('right-sidebar').dataset.activeTab).toBe('scratchpad');
+    doc.querySelector('[data-pane="artifacts"]').click();
+    expect(doc.getElementById('right-sidebar').dataset.activeTab).toBe('artifacts');
+  });
+
+  it('ignores activation for an unknown pane name', () => {
+    const doc = makeDom();
+    const { activate } = setupRightSidebarTabs({ documentImpl: doc, storage: memoryStorage() });
+    activate('nonexistent');
+    expect(doc.querySelector('[data-pane="scratchpad"]').classList.contains('active')).toBe(true);
+  });
+});

--- a/web/src/session/ui/right-sidebar.js
+++ b/web/src/session/ui/right-sidebar.js
@@ -140,6 +140,12 @@ export function setupRightSidebar({
     }
   }
 
+  // Hide the sidebar (and exit expand mode) regardless of current state.
+  function collapseSidebar() {
+    setExpanded(false);
+    setCollapsed(true);
+  }
+
   toggleBtn?.addEventListener('click', toggleSidebar);
 
   closeBtn?.addEventListener('click', () => {
@@ -282,5 +288,5 @@ export function setupRightSidebar({
 
   if (textarea) lastSaved = textarea.value;
 
-  return { toggleSidebar, openSidebar };
+  return { toggleSidebar, openSidebar, collapseSidebar };
 }

--- a/web/src/session/ui/right-sidebar.js
+++ b/web/src/session/ui/right-sidebar.js
@@ -11,7 +11,49 @@
 
 const RIGHT_SIDEBAR_COLLAPSED_KEY = 'pi-web:v1:right-sidebar-collapsed';
 const RIGHT_SIDEBAR_WIDTH_KEY = 'pi-web:v1:right-sidebar-width';
+const RIGHT_SIDEBAR_TAB_KEY = 'pi-web:v1:right-sidebar-tab';
 const MIN_CONTENT_WIDTH = 320;
+
+/**
+ * Wire the Scratchpad / Artifacts tab switcher in the right-sidebar header.
+ * Pure DOM toggling; the artifact panel's data is owned by session.js.
+ * Returns { activate } so callers can switch tabs programmatically.
+ */
+export function setupRightSidebarTabs({ documentImpl = document, storage = globalThis.localStorage } = {}) {
+  const tabs = Array.from(documentImpl.querySelectorAll('.right-sidebar-tab'));
+  const panes = Array.from(documentImpl.querySelectorAll('.right-sidebar-pane'));
+  const sidebar = documentImpl.getElementById('right-sidebar');
+  if (tabs.length === 0 || panes.length === 0) return { activate: () => {} };
+
+  function activate(pane) {
+    if (!tabs.some(tab => tab.dataset.pane === pane)) return;
+    for (const tab of tabs) {
+      const isActive = tab.dataset.pane === pane;
+      tab.classList.toggle('active', isActive);
+      tab.setAttribute('aria-selected', String(isActive));
+    }
+    for (const p of panes) {
+      const isActive = p.id === `right-pane-${pane}`;
+      p.classList.toggle('active', isActive);
+      if (isActive) p.removeAttribute('hidden');
+      else p.setAttribute('hidden', '');
+    }
+    // Drives tab-scoped chrome via CSS (e.g. the Artifacts-only help button).
+    if (sidebar) sidebar.dataset.activeTab = pane;
+    try { storage?.setItem(RIGHT_SIDEBAR_TAB_KEY, pane); } catch {}
+  }
+
+  for (const tab of tabs) {
+    tab.addEventListener('click', () => activate(tab.dataset.pane));
+  }
+
+  let initial = '';
+  try { initial = storage?.getItem(RIGHT_SIDEBAR_TAB_KEY) || ''; } catch {}
+  if (initial && initial !== 'scratchpad') activate(initial);
+  if (sidebar && !sidebar.dataset.activeTab) sidebar.dataset.activeTab = 'scratchpad';
+
+  return { activate };
+}
 
 export function setupRightSidebar({
   documentImpl = document,

--- a/web/src/session/ui/right-sidebar.js
+++ b/web/src/session/ui/right-sidebar.js
@@ -132,6 +132,14 @@ export function setupRightSidebar({
     }
   }
 
+  // Reveal the sidebar without toggling it shut when already open.
+  function openSidebar() {
+    if (isCollapsed()) {
+      setCollapsed(false);
+      loadScratchpad();
+    }
+  }
+
   toggleBtn?.addEventListener('click', toggleSidebar);
 
   closeBtn?.addEventListener('click', () => {
@@ -274,5 +282,5 @@ export function setupRightSidebar({
 
   if (textarea) lastSaved = textarea.value;
 
-  return { toggleSidebar };
+  return { toggleSidebar, openSidebar };
 }

--- a/web/src/session/ui/session-ui-runner.js
+++ b/web/src/session/ui/session-ui-runner.js
@@ -70,6 +70,7 @@ export function setupSessionUi({
     attachHeaderHandlers,
     toggleController,
     toggleRightSidebar: rightSidebar?.toggleSidebar ?? (() => {}),
+    openRightSidebar: rightSidebar?.openSidebar ?? (() => {}),
     activateRightTab: rightSidebarTabs?.activate ?? (() => {}),
   };
 }

--- a/web/src/session/ui/session-ui-runner.js
+++ b/web/src/session/ui/session-ui-runner.js
@@ -1,4 +1,4 @@
-import { setupRightSidebar } from './right-sidebar.js';
+import { setupRightSidebar, setupRightSidebarTabs } from './right-sidebar.js';
 
 export function setupSessionUi({
   documentImpl = document,
@@ -44,6 +44,7 @@ export function setupSessionUi({
   }
 
   const rightSidebar = setupRightSidebar({ documentImpl, windowImpl, storage, projectPath });
+  const rightSidebarTabs = setupRightSidebarTabs({ documentImpl, storage });
 
   const toggleController = toggleStateApi.createToggleController({ documentImpl, storage });
   windowImpl.sessionToggleState = toggleController;
@@ -69,5 +70,6 @@ export function setupSessionUi({
     attachHeaderHandlers,
     toggleController,
     toggleRightSidebar: rightSidebar?.toggleSidebar ?? (() => {}),
+    activateRightTab: rightSidebarTabs?.activate ?? (() => {}),
   };
 }

--- a/web/src/session/ui/session-ui-runner.js
+++ b/web/src/session/ui/session-ui-runner.js
@@ -71,6 +71,7 @@ export function setupSessionUi({
     toggleController,
     toggleRightSidebar: rightSidebar?.toggleSidebar ?? (() => {}),
     openRightSidebar: rightSidebar?.openSidebar ?? (() => {}),
+    collapseRightSidebar: rightSidebar?.collapseSidebar ?? (() => {}),
     activateRightTab: rightSidebarTabs?.activate ?? (() => {}),
   };
 }

--- a/web/src/shared/settings-store.js
+++ b/web/src/shared/settings-store.js
@@ -33,6 +33,8 @@ export const SERVER_SETTING_KEYS = [
   'pi-web:v1:auto-title:enabled',
   'pi-web:v1:auto-title:mode',
   'pi-web:v1:auto-title:model',
+  'pi-web:v1:artifacts:enabled',
+  'pi-web:v1:artifacts:include',
 ];
 
 // Network sync is disabled until a page entrypoint configures it. This keeps


### PR DESCRIPTION
## Summary

Adds an in-browser review surface to the session viewer via the right sidebar (Scratchpad / Artifacts / Annotations tabs). The motivation: a long agent session produces files and decisions buried in a linear transcript — this makes the outputs easy to find, preview, and review, and lets you push structured feedback straight back to the agent.

- **Artifacts panel** — a path-keyed, edit-aware registry reconstructs each file's latest state from the *structured* tool calls (`write`/`edit`, plus a conservative `mv`/`git mv`/`rm` recognizer; arbitrary shell is intentionally left alone). Source view with copy/download, sandboxed HTML/SVG preview and inline Markdown preview, and a help (?) modal that explains the bash-staleness limitation in plain language.
- **Artifacts settings & filter** — two server-backed settings (`artifacts:enabled`, `artifacts:include`, default `*.md, *.html`) let users hide the Artifacts tab entirely or scope it to specific paths. Filtering is a pure frontend pass over the unchanged registry (`artifact-filter.js`): matching file artifacts are kept; loose chat snippets are dropped whenever a filter is active; the empty state links to Settings when artifacts are hidden. Disabling hides the tab and falls back to Scratchpad.
- **Annotations** — offset-anchored highlights on transcript messages *and* artifact source, persisted in SQLite (`/api/annotations`, GET/POST/DELETE) and synced across tabs via an `annotations` SSE snapshot. Mobile-friendly selection → note-modal flow (`selectionchange` trigger for touch). "Send notes to pi" groups notes by file with line numbers and fills the composer with a directive framing.
- **Backend/infra** — new `annotations` table + handlers; SQLite pool capped to one connection (`SetMaxOpenConns(1)`) so concurrent writers queue instead of hitting "database is locked".
- **Docs** — new `artifacts.md` / `annotations.md` sequence-flow deep-dives (artifacts.md now covers the filtering model); architecture docs and AGENTS.md updated for the new endpoint, SSE event, and frontend modules.

## Related issue

Closes #

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `style` — formatting / UI styling, no behavior change
- [ ] `test` — adding or updating tests
- [ ] `chore` — build, tooling, or maintenance

## Live vs. Export

- [x] Considered both the live app and the export snapshot
- [x] Kept `internal/ui/live_templates/` in sync with `web/src/session/` changes
- [x] No live-only chrome (Vite scripts, active composer, SSE/API) leaked into export — the artifacts/annotations hosts render only when `IsLive`, so the layers are no-ops in exported Gist snapshots

## Testing

- [x] `make check` passes (test + build + vet)
- [x] Frontend tests (`vitest`) cover the change — registry/panel/filter, annotation range/api/layer, tab controller (445 tests)
- [x] Go tests (`go test ./...`) cover the change — `annotations_test.go` (create/list/upsert/delete/validation/scoping)
- [x] UI changes verified in a browser — Playwright E2E (`artifacts.spec.ts` incl. include-filter / empty-state / disabled-tab cases, `annotations.spec.ts`) across desktop, mobile, and iPad projects