### PR TITLE
sessions: paginate large sessions in the HTML render + add /api/session?from=N&count=K

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -203,10 +204,40 @@ func (s *Server) handleApiSession(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	// Optional pagination: ?from=N&count=K returns entries[N:N+K]. Used by the
+	// "Load earlier" affordance in the frontend for huge sessions whose tails
+	// were the only thing embedded in the initial HTML render. Both params
+	// must be present and parse as non-negative ints to enable windowing;
+	// otherwise the full entries slice is returned for backwards compat.
+	entries := resolved.Session.Entries
+	total := len(entries)
+	from := 0
+	q := r.URL.Query()
+	fromStr := q.Get("from")
+	countStr := q.Get("count")
+	if fromStr != "" && countStr != "" {
+		f, errF := strconv.Atoi(fromStr)
+		c, errC := strconv.Atoi(countStr)
+		if errF == nil && errC == nil && f >= 0 && c >= 0 {
+			if f > total {
+				f = total
+			}
+			end := f + c
+			if end > total {
+				end = total
+			}
+			entries = entries[f:end]
+			from = f
+		}
+	}
+
 	writeJSON(w, 0, map[string]any{
 		"header":  resolved.Session.Header,
-		"entries": resolved.Session.Entries,
+		"entries": entries,
 		"name":    resolved.Session.Name,
+		"total":   total,
+		"from":    from,
 	})
 }
 

--- a/internal/server/pagination_test.go
+++ b/internal/server/pagination_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"pi-web/internal/sessions"
+)
+
+// writeSessionWithNMessages scaffolds a session JSONL with `n` message
+// entries (plus the leading session header line — so total entries in the
+// parsed Session is n+1). Used to exercise the pagination thresholds
+// (default 1500 entries → tail-truncate to 1000).
+func writeSessionWithNMessages(t *testing.T, root, project, name string, n int) string {
+	t.Helper()
+	dir := filepath.Join(root, project)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	cwd := filepath.Join(root, "cwd")
+	if err := os.MkdirAll(cwd, 0755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	b.WriteString(`{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":"` + cwd + `"}` + "\n")
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, `{"type":"message","id":"id%06d","parentId":null,"timestamp":"2026-05-06T00:00:%02d.000Z","message":{"role":"user","content":"m%d"}}`+"\n", i, i%60, i)
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestHandleApiSession_PaginationWindowed(t *testing.T) {
+	root := t.TempDir()
+	const messages = 50
+	const totalEntries = messages + 1 // session header is entries[0]
+	writeSessionWithNMessages(t, root, "proj", "s.jsonl", messages)
+	s := &Server{sessionsDir: root, cache: sessions.NewCache()}
+
+	// Window [10, 15) → 5 entries starting at entries[10].
+	// Since entries[0] is the session header, entries[10] is message #9 (id000009).
+	req := httptest.NewRequest(http.MethodGet, "/api/session?id=s.jsonl&from=10&count=5", nil)
+	w := httptest.NewRecorder()
+	s.handleApiSession(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Entries []map[string]any `json:"entries"`
+		Total   int              `json:"total"`
+		From    int              `json:"from"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Total != totalEntries {
+		t.Errorf("total = %d, want %d", resp.Total, totalEntries)
+	}
+	if resp.From != 10 {
+		t.Errorf("from = %d, want 10", resp.From)
+	}
+	if got := len(resp.Entries); got != 5 {
+		t.Errorf("got %d entries, want 5", got)
+	}
+	firstID, _ := resp.Entries[0]["id"].(string)
+	if firstID != "id000009" {
+		t.Errorf("first entry id = %q, want id000009", firstID)
+	}
+}
+
+func TestHandleApiSession_PaginationClampsBeyondEnd(t *testing.T) {
+	root := t.TempDir()
+	const messages = 20
+	const totalEntries = messages + 1
+	writeSessionWithNMessages(t, root, "proj", "s.jsonl", messages)
+	s := &Server{sessionsDir: root, cache: sessions.NewCache()}
+
+	// from=15, count=100 → should clamp to entries[15:21] = 6 entries
+	req := httptest.NewRequest(http.MethodGet, "/api/session?id=s.jsonl&from=15&count=100", nil)
+	w := httptest.NewRecorder()
+	s.handleApiSession(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		Entries []map[string]any `json:"entries"`
+		Total   int              `json:"total"`
+		From    int              `json:"from"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Total != totalEntries {
+		t.Errorf("total = %d, want %d", resp.Total, totalEntries)
+	}
+	if got := len(resp.Entries); got != totalEntries-15 {
+		t.Errorf("clamped entries = %d, want %d", got, totalEntries-15)
+	}
+}
+
+func TestHandleApiSession_NoPaginationByDefault(t *testing.T) {
+	root := t.TempDir()
+	const messages = 30
+	const totalEntries = messages + 1
+	writeSessionWithNMessages(t, root, "proj", "s.jsonl", messages)
+	s := &Server{sessionsDir: root, cache: sessions.NewCache()}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/session?id=s.jsonl", nil)
+	w := httptest.NewRecorder()
+	s.handleApiSession(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		Entries []map[string]any `json:"entries"`
+		Total   int              `json:"total"`
+		From    int              `json:"from"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Total != totalEntries {
+		t.Errorf("total = %d, want %d", resp.Total, totalEntries)
+	}
+	if got := len(resp.Entries); got != totalEntries {
+		t.Errorf("default (no params) returned %d entries, want all %d", got, totalEntries)
+	}
+	if resp.From != 0 {
+		t.Errorf("from = %d, want 0", resp.From)
+	}
+}
+
+func TestHandleApiSession_InvalidParamsReturnFull(t *testing.T) {
+	root := t.TempDir()
+	const messages = 12
+	const totalEntries = messages + 1
+	writeSessionWithNMessages(t, root, "proj", "s.jsonl", messages)
+	s := &Server{sessionsDir: root, cache: sessions.NewCache()}
+
+	// from=abc (invalid) → should ignore pagination and return full set.
+	req := httptest.NewRequest(http.MethodGet, "/api/session?id=s.jsonl&from=abc&count=5", nil)
+	w := httptest.NewRecorder()
+	s.handleApiSession(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		Entries []map[string]any `json:"entries"`
+		Total   int              `json:"total"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Entries) != totalEntries {
+		t.Errorf("invalid params: got %d entries, want %d", len(resp.Entries), totalEntries)
+	}
+}

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -4707,3 +4707,39 @@
     }
     .cat-settings-skip:hover { filter: brightness(1.08); }
 
+
+    /* Load-earlier banner — surfaces when the server tail-truncated the
+       initial entries payload for a huge session. */
+    .load-earlier-banner {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      padding: 10px 14px;
+      margin: 8px 0 12px;
+      background: var(--container-bg, rgba(255, 255, 255, 0.04));
+      border: 1px solid var(--dim, rgba(255, 255, 255, 0.12));
+      border-radius: 6px;
+      font-size: 13px;
+      color: var(--muted, #aaa);
+    }
+    .load-earlier-label { flex: 1 1 auto; }
+    .load-earlier-button {
+      flex: 0 0 auto;
+      padding: 6px 14px;
+      font: inherit;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--bg, #111);
+      background: var(--accent, #88c0d0);
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .load-earlier-button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .load-earlier-button:not(:disabled):hover { filter: brightness(1.08); }
+    .load-earlier-status {
+      flex: 0 0 auto;
+      font-size: 12px;
+      color: var(--text-soft, var(--muted));
+    }

--- a/internal/ui/pagination_test.go
+++ b/internal/ui/pagination_test.go
@@ -1,0 +1,105 @@
+package ui
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"pi-web/internal/sessions"
+)
+
+func sessionWithNEntries(n int) sessions.Session {
+	entries := make([]map[string]any, n)
+	for i := 0; i < n; i++ {
+		entries[i] = map[string]any{
+			"type":      "message",
+			"id":        fmt.Sprintf("id%06d", i),
+			"timestamp": "2026-05-06T00:00:00.000Z",
+			"message":   map[string]any{"role": "user", "content": "m"},
+		}
+	}
+	return sessions.Session{
+		SessionSummary: sessions.SessionSummary{ID: "test.jsonl", Filename: "test.jsonl", ChatAvailable: true},
+		Header:         map[string]any{"cwd": "/tmp", "name": "Test"},
+		Entries:        entries,
+	}
+}
+
+func decodeEmbed(t *testing.T, dataBase64 string) map[string]any {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(dataBase64)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+	return payload
+}
+
+func TestPrepareSessionPageData_SmallSessionNotTruncated(t *testing.T) {
+	sess := sessionWithNEntries(LargeSessionThreshold - 1)
+	dataBase64, _, _ := prepareSessionPageData(sess, "")
+
+	payload := decodeEmbed(t, dataBase64)
+	entries, _ := payload["entries"].([]any)
+	if len(entries) != LargeSessionThreshold-1 {
+		t.Errorf("expected all %d entries embedded, got %d", LargeSessionThreshold-1, len(entries))
+	}
+	if truncated, _ := payload["truncated"].(bool); truncated {
+		t.Errorf("truncated should be false for small session")
+	}
+	if from, _ := payload["from"].(float64); from != 0 {
+		t.Errorf("from = %v, want 0", from)
+	}
+	if total, _ := payload["total"].(float64); int(total) != LargeSessionThreshold-1 {
+		t.Errorf("total = %v, want %d", total, LargeSessionThreshold-1)
+	}
+}
+
+func TestPrepareSessionPageData_LargeSessionTailEmbedded(t *testing.T) {
+	const n = LargeSessionThreshold + 500
+	sess := sessionWithNEntries(n)
+	dataBase64, _, _ := prepareSessionPageData(sess, "")
+
+	payload := decodeEmbed(t, dataBase64)
+	entries, _ := payload["entries"].([]any)
+	if len(entries) != LargeSessionTailEntries {
+		t.Errorf("expected %d entries (tail) embedded, got %d", LargeSessionTailEntries, len(entries))
+	}
+	if truncated, _ := payload["truncated"].(bool); !truncated {
+		t.Errorf("truncated should be true for large session")
+	}
+	wantFrom := n - LargeSessionTailEntries
+	if from, _ := payload["from"].(float64); int(from) != wantFrom {
+		t.Errorf("from = %v, want %d", from, wantFrom)
+	}
+	if total, _ := payload["total"].(float64); int(total) != n {
+		t.Errorf("total = %v, want %d", total, n)
+	}
+	// First embedded entry should be at index wantFrom in the original slice.
+	if first, ok := entries[0].(map[string]any); ok {
+		wantID := fmt.Sprintf("id%06d", wantFrom)
+		if got, _ := first["id"].(string); got != wantID {
+			t.Errorf("first embedded id = %q, want %q", got, wantID)
+		}
+	}
+}
+
+func TestPrepareSessionPageData_LeafIDStillTailWhenTruncated(t *testing.T) {
+	const n = LargeSessionThreshold + 100
+	sess := sessionWithNEntries(n)
+	dataBase64, _, _ := prepareSessionPageData(sess, "")
+
+	payload := decodeEmbed(t, dataBase64)
+	leafID, _ := payload["leafId"].(string)
+	// LeafID is computed from the FULL session entries (not just the embedded
+	// tail), so it should still point at the last entry of the original slice.
+	want := fmt.Sprintf("id%06d", n-1)
+	if !strings.Contains(leafID, want) {
+		t.Errorf("leafId = %q, want it to contain %q (last entry of full session)", leafID, want)
+	}
+}

--- a/internal/ui/session_page.go
+++ b/internal/ui/session_page.go
@@ -34,8 +34,23 @@ var chatComposerTmplStr string
 
 var chatComposerTmpl = template.Must(template.New("chat_composer").Parse(chatComposerTmplStr))
 
+// LargeSessionTailEntries controls how many trailing entries get embedded
+// in the initial HTML render for huge sessions. The frontend exposes a
+// "Load earlier" affordance that fetches preceding windows via
+// /api/session?id=...&from=N&count=K. Keep these tunable as exports so
+// tests + future config plumbing can override.
+const (
+	LargeSessionThreshold  = 1500
+	LargeSessionTailEntries = 1000
+)
+
 // prepareSessionPageData computes the shared payload (base64-encoded session
 // data, themed CSS, and body attributes) used by both live and export renders.
+//
+// For sessions with more than LargeSessionThreshold entries we embed only the
+// tail (LargeSessionTailEntries) and add { truncated, total, from } fields so
+// the frontend can render a "Load earlier" banner and lazily fetch preceding
+// windows. Small sessions get the full payload as before — zero behavior change.
 func prepareSessionPageData(session sessions.Session, cssTemplate string) (dataBase64, css, bodyAttrs string) {
 	leafID := ""
 	for i := len(session.Entries) - 1; i >= 0; i-- {
@@ -45,14 +60,27 @@ func prepareSessionPageData(session sessions.Session, cssTemplate string) (dataB
 		}
 	}
 
+	total := len(session.Entries)
+	entries := session.Entries
+	from := 0
+	truncated := false
+	if total > LargeSessionThreshold {
+		from = total - LargeSessionTailEntries
+		entries = session.Entries[from:]
+		truncated = true
+	}
+
 	sessionData := map[string]any{
 		"header":        session.Header,
-		"entries":       session.Entries,
+		"entries":       entries,
 		"name":          session.Name,
 		"leafId":        leafID,
 		"systemPrompt":  nil,
 		"tools":         nil,
 		"renderedTools": nil,
+		"total":         total,
+		"from":          from,
+		"truncated":     truncated,
 	}
 
 	dataJSON, _ := json.Marshal(sessionData)

--- a/web/src/session/data/session-data.js
+++ b/web/src/session/data/session-data.js
@@ -58,6 +58,15 @@ export function createSessionDataModel(payload, params = new URLSearchParams()) 
   const urlLeafId = params.get('leafId');
   const urlTargetId = params.get('targetId');
 
+  // Pagination metadata for huge sessions. When the server embeds only a
+  // tail window, `total` is the full entry count, `from` is the index in the
+  // full session where the embedded slice starts, and `truncated` is true
+  // when from > 0. Small sessions don't include these fields — defaults
+  // make the model behave as before.
+  const total = Number.isInteger(payload?.total) ? payload.total : entries.length;
+  const from = Number.isInteger(payload?.from) ? payload.from : 0;
+  const truncated = Boolean(payload?.truncated) || from > 0 || entries.length < total;
+
   return {
     payload,
     params,
@@ -70,6 +79,9 @@ export function createSessionDataModel(payload, params = new URLSearchParams()) 
     systemPrompt: payload?.systemPrompt ?? null,
     tools: payload?.tools ?? null,
     renderedTools: payload?.renderedTools ?? null,
+    total,
+    from,
+    truncated,
     ...buildSessionLookups(entries)
   };
 }

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -13,6 +13,7 @@ import * as toggleStateApi from './ui/toggle-state.js';
 import * as sidebarApi from './ui/sidebar.js';
 import * as searchFiltersApi from './ui/search-filters.js';
 import { setupSessionUi } from './ui/session-ui-runner.js';
+import { setupLoadEarlierBanner } from './ui/load-earlier.js';
 import * as chatComposerRunner from './chat/chat-composer-runner.js';
 import * as doneNotifier from './chat/done-notifier.js';
 import * as chatApi from './chat/chat-api.js';
@@ -477,6 +478,18 @@ export function runSessionApp({ target = window } = {}) {
     windowImpl: target,
     cwd: dataModel.header?.cwd || '',
     parentId: getSessionSearchParams({ documentImpl, windowImpl: target }).get('id') || '',
+  });
+
+  // For huge sessions the server embeds only the tail entries in the initial
+  // HTML render. Wire a "Load earlier" banner that fetches preceding windows
+  // via /api/session?id=...&from=N&count=K and merges them into the model.
+  // No-ops on small sessions (dataModel.truncated is false).
+  setupLoadEarlierBanner({
+    dataModel,
+    sessionId,
+    syncDataModelEntries,
+    documentImpl,
+    fetchImpl: target.fetch.bind(target),
   });
 
   // Handle Visual Viewport changes to prevent mobile browsers from shifting

--- a/web/src/session/ui/load-earlier.js
+++ b/web/src/session/ui/load-earlier.js
@@ -1,0 +1,113 @@
+/**
+ * load-earlier — "Load earlier messages" affordance for huge sessions.
+ *
+ * When the server embeds only the tail of a huge session in the initial HTML
+ * payload (see `internal/ui/session_page.go:prepareSessionPageData` —
+ * truncated/total/from fields), this module injects a banner above the
+ * #messages container with a button that fetches preceding windows from
+ * `/api/session?id=...&from=N&count=K` and merges them into the data model.
+ *
+ * The merge primitive (`syncDataModelEntries`) is owned by session.js;
+ * we receive it as a dependency. We also receive the current dataModel by
+ * reference so its `entries` / `total` / `from` stay live across loads.
+ *
+ * Design notes:
+ * - Loads in WINDOW_SIZE chunks (default 500) to keep each round-trip
+ *   responsive and the DOM-rebuild incremental.
+ * - Disables the button + shows a spinner while a fetch is in-flight, so
+ *   repeated clicks can't queue up overlapping requests.
+ * - On error, surfaces the message in the banner and re-enables the button
+ *   so the user can retry.
+ * - When all entries are loaded (from === 0), removes the banner from the DOM.
+ */
+
+const WINDOW_SIZE = 500;
+
+export function setupLoadEarlierBanner({
+  dataModel,
+  sessionId,
+  syncDataModelEntries,
+  documentImpl = document,
+  fetchImpl = (typeof window !== 'undefined' ? window.fetch.bind(window) : null),
+  windowSize = WINDOW_SIZE,
+} = {}) {
+  if (!dataModel || !dataModel.truncated || dataModel.from <= 0) return null;
+  if (typeof syncDataModelEntries !== 'function') return null;
+  if (typeof fetchImpl !== 'function') return null;
+
+  const messagesEl = documentImpl.getElementById('messages');
+  if (!messagesEl) return null;
+
+  const banner = documentImpl.createElement('div');
+  banner.id = 'load-earlier-banner';
+  banner.className = 'load-earlier-banner';
+  banner.setAttribute('role', 'region');
+  banner.setAttribute('aria-label', 'Earlier messages');
+
+  const label = documentImpl.createElement('span');
+  label.className = 'load-earlier-label';
+
+  const button = documentImpl.createElement('button');
+  button.type = 'button';
+  button.className = 'load-earlier-button';
+
+  const status = documentImpl.createElement('span');
+  status.className = 'load-earlier-status';
+
+  banner.appendChild(label);
+  banner.appendChild(button);
+  banner.appendChild(status);
+  messagesEl.parentNode.insertBefore(banner, messagesEl);
+
+  function updateLabel() {
+    const shown = dataModel.entries.length;
+    const total = dataModel.total;
+    label.textContent = `Showing latest ${shown.toLocaleString()} of ${total.toLocaleString()} messages.`;
+    const remaining = dataModel.from;
+    const next = Math.min(windowSize, remaining);
+    button.textContent = remaining > 0 ? `Load ${next.toLocaleString()} earlier` : 'All earlier loaded';
+    button.disabled = remaining <= 0;
+  }
+
+  async function loadEarlier() {
+    if (button.disabled) return;
+    const requestFrom = Math.max(0, dataModel.from - windowSize);
+    const requestCount = dataModel.from - requestFrom;
+    button.disabled = true;
+    status.textContent = 'Loading…';
+    try {
+      const url = `/api/session?id=${encodeURIComponent(sessionId)}&from=${requestFrom}&count=${requestCount}`;
+      const res = await fetchImpl(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const payload = await res.json();
+      const earlier = Array.isArray(payload?.entries) ? payload.entries : [];
+      if (earlier.length === 0) {
+        // Server returned empty — treat as fully loaded.
+        dataModel.from = 0;
+        dataModel.truncated = false;
+        status.textContent = '';
+        updateLabel();
+        if (dataModel.from === 0) banner.remove();
+        return;
+      }
+      const merged = [...earlier, ...dataModel.entries];
+      // syncDataModelEntries handles the full re-build: replaces entries,
+      // rebuilds byId/toolCallMap/labelMap, re-renders the tree.
+      syncDataModelEntries(merged);
+      dataModel.from = requestFrom;
+      dataModel.truncated = requestFrom > 0;
+      status.textContent = '';
+      updateLabel();
+      if (requestFrom === 0) banner.remove();
+    } catch (err) {
+      const message = (err && err.message) ? err.message : String(err);
+      status.textContent = `Failed to load: ${message}`;
+      button.disabled = false;
+    }
+  }
+
+  button.addEventListener('click', loadEarlier);
+  updateLabel();
+
+  return { banner, loadEarlier, refresh: updateLabel };
+}

--- a/web/src/session/ui/load-earlier.test.js
+++ b/web/src/session/ui/load-earlier.test.js
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { setupLoadEarlierBanner } from './load-earlier.js';
+
+function dom() {
+  return new JSDOM(`<body><div id="messages"></div></body>`);
+}
+
+function entry(i) {
+  return { type: 'message', id: `id${String(i).padStart(6, '0')}`, message: { role: 'user', content: `m${i}` } };
+}
+
+describe('setupLoadEarlierBanner', () => {
+  it('returns null when session is not truncated', () => {
+    const jsdom = dom();
+    const dataModel = { truncated: false, from: 0, total: 5, entries: [entry(0)] };
+    const result = setupLoadEarlierBanner({
+      dataModel,
+      sessionId: 's.jsonl',
+      syncDataModelEntries: vi.fn(),
+      documentImpl: jsdom.window.document,
+      fetchImpl: vi.fn(),
+    });
+    expect(result).toBeNull();
+    expect(jsdom.window.document.getElementById('load-earlier-banner')).toBeNull();
+  });
+
+  it('returns null when from is 0 even if truncated flag is set', () => {
+    const jsdom = dom();
+    const dataModel = { truncated: true, from: 0, total: 5, entries: [entry(0)] };
+    const result = setupLoadEarlierBanner({
+      dataModel,
+      sessionId: 's.jsonl',
+      syncDataModelEntries: vi.fn(),
+      documentImpl: jsdom.window.document,
+      fetchImpl: vi.fn(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it('renders banner with current state when truncated', () => {
+    const jsdom = dom();
+    const dataModel = {
+      truncated: true,
+      from: 1500,
+      total: 2500,
+      entries: Array.from({ length: 1000 }, (_, i) => entry(1500 + i)),
+    };
+    const result = setupLoadEarlierBanner({
+      dataModel,
+      sessionId: 's.jsonl',
+      syncDataModelEntries: vi.fn(),
+      documentImpl: jsdom.window.document,
+      fetchImpl: vi.fn(),
+      windowSize: 500,
+    });
+    expect(result).not.toBeNull();
+    const banner = jsdom.window.document.getElementById('load-earlier-banner');
+    expect(banner).not.toBeNull();
+    expect(banner.textContent).toContain('1,000');
+    expect(banner.textContent).toContain('2,500');
+    const button = banner.querySelector('.load-earlier-button');
+    expect(button.textContent).toMatch(/Load 500 earlier/);
+    expect(button.disabled).toBe(false);
+  });
+
+  it('fetches preceding window on click + merges via syncDataModelEntries', async () => {
+    const jsdom = dom();
+    const dataModel = {
+      truncated: true,
+      from: 100,
+      total: 600,
+      entries: Array.from({ length: 500 }, (_, i) => entry(100 + i)),
+    };
+    const olderEntries = Array.from({ length: 50 }, (_, i) => entry(50 + i));
+    const syncMock = vi.fn();
+    const fetchMock = vi.fn(async (url) => ({
+      ok: true,
+      json: async () => ({ entries: olderEntries, total: 600, from: 50 }),
+    }));
+
+    const banner = setupLoadEarlierBanner({
+      dataModel,
+      sessionId: 's.jsonl',
+      syncDataModelEntries: syncMock,
+      documentImpl: jsdom.window.document,
+      fetchImpl: fetchMock,
+      windowSize: 50,
+    });
+
+    await banner.loadEarlier();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('from=50');
+    expect(url).toContain('count=50');
+    expect(syncMock).toHaveBeenCalledOnce();
+    // Should have prepended olderEntries to the existing 500
+    const mergedArg = syncMock.mock.calls[0][0];
+    expect(mergedArg.length).toBe(550);
+    expect(mergedArg[0].id).toBe('id000050');
+    expect(dataModel.from).toBe(50);
+  });
+
+  it('removes the banner when all earlier entries are loaded', async () => {
+    const jsdom = dom();
+    const dataModel = {
+      truncated: true,
+      from: 30,
+      total: 130,
+      entries: Array.from({ length: 100 }, (_, i) => entry(30 + i)),
+    };
+    const earlierAll = Array.from({ length: 30 }, (_, i) => entry(i));
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ entries: earlierAll, total: 130, from: 0 }),
+    }));
+
+    const banner = setupLoadEarlierBanner({
+      dataModel,
+      sessionId: 's.jsonl',
+      syncDataModelEntries: vi.fn(),
+      documentImpl: jsdom.window.document,
+      fetchImpl: fetchMock,
+      windowSize: 100,
+    });
+
+    await banner.loadEarlier();
+
+    expect(dataModel.from).toBe(0);
+    expect(dataModel.truncated).toBe(false);
+    expect(jsdom.window.document.getElementById('load-earlier-banner')).toBeNull();
+  });
+
+  it('surfaces fetch errors + re-enables button', async () => {
+    const jsdom = dom();
+    const dataModel = {
+      truncated: true,
+      from: 100,
+      total: 200,
+      entries: Array.from({ length: 100 }, (_, i) => entry(100 + i)),
+    };
+    const fetchMock = vi.fn(async () => ({ ok: false, status: 500 }));
+
+    const banner = setupLoadEarlierBanner({
+      dataModel,
+      sessionId: 's.jsonl',
+      syncDataModelEntries: vi.fn(),
+      documentImpl: jsdom.window.document,
+      fetchImpl: fetchMock,
+      windowSize: 50,
+    });
+
+    await banner.loadEarlier();
+
+    const status = banner.banner.querySelector('.load-earlier-status');
+    expect(status.textContent).toMatch(/Failed to load/);
+    const button = banner.banner.querySelector('.load-earlier-button');
+    expect(button.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Huge sessions (7000+ messages, 40+ MB on disk) currently render as a **60+ MB HTML page** because the entire `entries` array is base64-embedded inline in `<script id=\"session-data\">`. Browsers either OOM or lock the main thread for minutes, producing a blank-looking page.

I have a CanLegal session with 7699 messages where `/session?id=...` was effectively unusable until I built this. With the patch the page loads in ~1 second.

## Approach

Tail-window strategy. The server embeds only the last N entries in the initial HTML, and the frontend lazily loads preceding windows via a new query API.

| Change | File |
|---|---|
| `prepareSessionPageData` embeds only last `LargeSessionTailEntries` (1000) when total > `LargeSessionThreshold` (1500). Adds `{ total, from, truncated }` to the payload. | `internal/ui/session_page.go` |
| `/api/session?id=X&from=N&count=K` accepts windowed queries; returns `{ entries, total, from }`. Default behavior (no params) unchanged. | `internal/server/handlers.go` |
| Frontend parses `total/from/truncated` into the data model. | `web/src/session/data/session-data.js` |
| New `setupLoadEarlierBanner` injects a banner above `#messages` with a button that fetches preceding windows and merges via existing `syncDataModelEntries`. Self-removes when `from` reaches 0. | `web/src/session/ui/load-earlier.js` |
| CSS for the banner | `internal/ui/live_templates/styles/session.css` |

## Behavior preserved for small sessions

- Sessions with ≤1500 entries: full payload as before. No banner injected.
- `/api/session` without `from`/`count` params: full slice as before (now with `total` field added).
- `dataModel.truncated` defaults to false. Existing 367 frontend tests still pass.

## Tests

- 4 new Go tests in `internal/server/pagination_test.go` (windowed, clamped, no-params default, invalid params)
- 3 new Go tests in `internal/ui/pagination_test.go` (small not truncated, large tail embedded, leafId still tail when truncated)
- 6 new JS tests in `web/src/session/ui/load-earlier.test.js` (no-op when not truncated, renders banner with state, fetches and merges, removes when from=0, surfaces errors and re-enables button, ignores invalid responses)

`make check` is green:

```
ok  	pi-web/internal/server	0.716s
ok  	pi-web/internal/ui	0.049s
...
Test Files  54 passed (54)
Tests       373 passed (373)
```

## Real-world test

The CanLegal session in my repro:

```
Filename: 2026-05-31T23-35-15-850Z_019e8064-...jsonl
MessageCount: 7699
TokenTotal: 361,334,566
On-disk: 41 MB JSONL
```

Before: `/session?id=...` page = 60 MB HTML, browser blank/locked for 2+ minutes.
After: page = ~6 MB HTML (last 1000 entries), loads in ~1s. Banner shows \"Showing latest 1,000 of 8,189 messages. [Load 500 earlier]\". Each click fetches 500 more in ~300ms and merges.

## Tunable constants

`LargeSessionThreshold` (1500) and `LargeSessionTailEntries` (1000) are exported from `internal/ui`. Easy to plumb through user config later if you want.

## Note

I'm running this alongside #51 (the scanner-buffer-cap fix). They're independent — this PR is cleanly branched off `main`, so it should apply standalone.