### PR TITLE
session: render extension widgets in the right-sidebar via setWidget RPC events

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -21,6 +21,7 @@ import (
 	"pi-web/internal/sessions"
 	"pi-web/internal/ui"
 	"pi-web/internal/updater"
+	"pi-web/internal/widgets"
 	"pi-web/internal/workers"
 	"pi-web/web"
 )
@@ -68,11 +69,28 @@ func Main(version string) {
 	versionChecker := updater.New(version)
 
 	var srv *server.Server
+	widgetStore := widgets.NewStore()
 	manager := workers.NewManager(func(sessionID, sessionPath string) (workers.ChatWorker, error) {
-		return rpc.NewPiWorkerWithStream(sessionPath, func(preview rpc.StreamPreview) {
-			if srv != nil {
-				srv.BroadcastChatPreview(sessionID, preview)
-			}
+		return rpc.NewPiWorker(sessionPath, rpc.NewPiWorkerOptions{
+			StreamSink: func(preview rpc.StreamPreview) {
+				if srv != nil {
+					srv.BroadcastChatPreview(sessionID, preview)
+				}
+			},
+			WidgetSink: func(ev rpc.WidgetEvent) {
+				// Mirror setWidget into the per-session store + broadcast over
+				// SSE so connected browser sidebars update immediately.
+				if ev.Removed {
+					if widgetStore.Remove(sessionID, ev.Key) && srv != nil {
+						srv.BroadcastWidgetUpdate(sessionID, widgets.Widget{Key: ev.Key, Placement: ev.Placement}, true)
+					}
+					return
+				}
+				w := widgetStore.Set(sessionID, ev.Key, ev.Lines, ev.Placement)
+				if srv != nil {
+					srv.BroadcastWidgetUpdate(sessionID, w, false)
+				}
+			},
 		})
 	})
 	srv = server.New(server.Deps{
@@ -91,6 +109,7 @@ func Main(version string) {
 		Updater:    versionChecker,
 		RunInstall: runInstall,
 		RunRestart: runRestart,
+		Widgets:    widgetStore,
 	})
 
 	ui.SetThemeProvider(srv.ThemeSetting)

--- a/internal/rpc/stream.go
+++ b/internal/rpc/stream.go
@@ -7,6 +7,17 @@ type StreamPreview struct {
 
 type StreamEventSink func(StreamPreview)
 
+// WidgetEvent is forwarded to a WidgetSink whenever the pi worker emits a
+// setWidget extension_ui_request. Lines=nil indicates removal.
+type WidgetEvent struct {
+	Key       string
+	Lines     []string
+	Placement string
+	Removed   bool
+}
+
+type WidgetSink func(WidgetEvent)
+
 type assistantMessageEvent struct {
 	Type    string `json:"type"`
 	Delta   string `json:"delta"`

--- a/internal/rpc/worker.go
+++ b/internal/rpc/worker.go
@@ -36,6 +36,7 @@ type piRPCWorker struct {
 	lastStreamActivity   atomic.Int64 // unix nanos; stream/turn events keep worker visually running
 	streamSink           StreamEventSink
 	streamPreview        *streamPreviewAccumulator
+	widgetSink           WidgetSink
 }
 
 // idleReportable is implemented by workers that can report when they were last
@@ -58,7 +59,26 @@ func (w *piRPCWorker) IdleSince(now time.Time) time.Duration {
 	return now.Sub(time.Unix(0, last))
 }
 
+// NewPiWorkerWithStream spawns a `pi --mode rpc` subprocess for the given
+// session and wires up event sinks. Pass nil for any sink you don't need.
+//
+// streamSink: receives assistant-message text-delta previews for live UI.
+// widgetSink: receives extension setWidget events (added 2026-06-04 to
+// surface extension widgets — todos, goals, monitors, etc. — in the browser
+// alongside the existing TUI rendering).
 func NewPiWorkerWithStream(sessionPath string, streamSink StreamEventSink) (workers.ChatWorker, error) {
+	return NewPiWorker(sessionPath, NewPiWorkerOptions{StreamSink: streamSink})
+}
+
+// NewPiWorkerOptions bundles optional sinks/config for NewPiWorker. New fields
+// can be added without breaking existing callers.
+type NewPiWorkerOptions struct {
+	StreamSink StreamEventSink
+	WidgetSink WidgetSink
+}
+
+// NewPiWorker spawns a pi RPC worker with the given options.
+func NewPiWorker(sessionPath string, opts NewPiWorkerOptions) (workers.ChatWorker, error) {
 	if _, err := exec.LookPath("pi"); err != nil {
 		return nil, fmt.Errorf("pi executable not found: %w", err)
 	}
@@ -80,8 +100,9 @@ func NewPiWorkerWithStream(sessionPath string, streamSink StreamEventSink) (work
 		status:        workers.WorkerStatus{State: workers.WorkerStateIdle},
 		pending:       make(map[string]chan response),
 		stderrBuf:     &stderrBuf,
-		streamSink:    streamSink,
+		streamSink:    opts.StreamSink,
 		streamPreview: &streamPreviewAccumulator{},
+		widgetSink:    opts.WidgetSink,
 	}
 	if err := cmd.Start(); err != nil {
 		return nil, err
@@ -437,6 +458,31 @@ func (w *piRPCWorker) handleRPCLine(line string) {
 			w.currentThinkingLevel = level
 			w.mu.Unlock()
 		}
+	}
+	if raw["type"] == "extension_ui_request" && raw["method"] == "setWidget" && w.widgetSink != nil {
+		// Pi's RPC mode dispatches setWidget as fire-and-forget (no response
+		// expected — see dist/modes/rpc/rpc-mode.js). We just route the payload
+		// to the sink; the widgets store handles broadcasting to the browser.
+		key, _ := raw["widgetKey"].(string)
+		if key == "" {
+			return
+		}
+		placement, _ := raw["widgetPlacement"].(string)
+		// widgetLines is `string[] | undefined`. Undefined → JSON null → removal.
+		var lines []string
+		removed := true
+		if v, ok := raw["widgetLines"]; ok && v != nil {
+			if arr, ok := v.([]any); ok {
+				lines = make([]string, 0, len(arr))
+				for _, item := range arr {
+					if s, ok := item.(string); ok {
+						lines = append(lines, s)
+					}
+				}
+				removed = false
+			}
+		}
+		w.widgetSink(WidgetEvent{Key: key, Lines: lines, Placement: placement, Removed: removed})
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -9,11 +9,13 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"pi-web/internal/agentdir"
 	"pi-web/internal/sessions"
+	"pi-web/internal/widgets"
 )
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
@@ -62,6 +64,20 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 				scratchpad = content
 			}
 		}
+	}
+	// Page-load widget bootstrap: ensure an RPC worker exists for this session
+	// so its extensions run session_start and emit setWidget events. Without
+	// this, /api/widgets would be empty until the user actually starts a chat.
+	// EnsureWorker is idempotent — it reuses an existing worker if one is
+	// already running, otherwise spawns one via the factory (which wires the
+	// WidgetSink in app.go). Background-context so we don't block the page
+	// render on worker startup. The 10-min idle reaper handles cleanup.
+	if s.chatSender != nil && s.widgets != nil {
+		go func(sessionID, sessionPath string) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = s.chatSender.EnsureWorker(ctx, sessionID, sessionPath)
+		}(resolved.Session.ID, resolved.Path)
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	io.WriteString(w, s.renderLiveSession(resolved.Session, scratchpad))
@@ -188,6 +204,56 @@ func (s *Server) handleApiSessions(w http.ResponseWriter, r *http.Request) {
 	sessions.SortSummariesByActivity(summaries)
 
 	writeJSON(w, 0, map[string]any{"sessions": summaries})
+}
+
+// handleApiWidgets returns the current extension-widget snapshot for a session.
+//
+// GET /api/widgets?session=<id> → {"widgets": [{key, lines, placement, updated_at}, ...]}
+//
+// The widgets are populated by the RPC worker's setWidget event consumer in
+// internal/app/app.go (a worker's stdout emits extension_ui_request events,
+// the WidgetSink routes them into the per-session store). When no worker has
+// ever run for the session, the snapshot is empty — the page-load worker
+// bootstrap in handleSession addresses that case.
+//
+// Live updates are pushed via SSE `widget-update` events on the same per-
+// session channel as chat-preview etc.; see BroadcastWidgetUpdate.
+func (s *Server) handleApiWidgets(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.URL.Query().Get("session")
+	if sessionID == "" {
+		writeJSONError(w, http.StatusBadRequest, "session is required")
+		return
+	}
+	if s.widgets == nil {
+		writeJSON(w, 0, map[string]any{"widgets": []any{}})
+		return
+	}
+	state := s.widgets.Get(sessionID)
+	out := make([]widgets.Widget, 0, len(state))
+	for _, wgt := range state {
+		out = append(out, wgt)
+	}
+	// Deterministic ordering: aboveEditor first, then belowEditor, then
+	// alphabetical by key inside each placement bucket. Keeps the UI stable.
+	sort.Slice(out, func(i, j int) bool {
+		pi, pj := placementRank(out[i].Placement), placementRank(out[j].Placement)
+		if pi != pj {
+			return pi < pj
+		}
+		return out[i].Key < out[j].Key
+	})
+	writeJSON(w, 0, map[string]any{"widgets": out})
+}
+
+func placementRank(p string) int {
+	switch p {
+	case "aboveEditor":
+		return 0
+	case "belowEditor":
+		return 1
+	default:
+		return 2
+	}
 }
 
 func (s *Server) handleApiSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"pi-web/internal/rpc"
 	"pi-web/internal/sessions"
 	"pi-web/internal/updater"
+	"pi-web/internal/widgets"
 
 	_ "modernc.org/sqlite"
 )
@@ -56,6 +57,11 @@ type Deps struct {
 	// RunRestart restarts the pi-web service (detached) so the new binary
 	// takes over. Optional; when nil /api/restart responds 503.
 	RunRestart func() error
+	// Widgets is the per-session extension widget store. Populated by the
+	// RPC worker's setWidget event handler in internal/app/app.go and read
+	// by /api/widgets + broadcast via SSE on changes. Optional; nil disables
+	// the widget endpoint + SSE event but doesn't break anything else.
+	Widgets *widgets.Store
 }
 
 // Server holds runtime state — connected SSE clients and last-seen modtimes
@@ -88,6 +94,7 @@ type Server struct {
 	runInstall          func(ctx context.Context) error
 	runRestart          func() error
 	updateMu            sync.Mutex // serializes install/restart operations
+	widgets             *widgets.Store
 
 	// Auto-title bookkeeping (see auto_title.go). Guards against re-titling
 	// loops and clobbering user-set names.
@@ -172,6 +179,7 @@ func New(deps Deps) *Server {
 		updater:             deps.Updater,
 		runInstall:          deps.RunInstall,
 		runRestart:          deps.RunRestart,
+		widgets:             deps.Widgets,
 	}
 	if pm, err := NewPushManager(agentDir); err != nil {
 		fmt.Fprintf(os.Stderr, "push notifications unavailable: %v\n", err)
@@ -210,6 +218,7 @@ func (s *Server) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/settings", s.auth.Wrap(s.handleSettingsPage))
 	mux.HandleFunc("/api/session", s.auth.Wrap(s.handleApiSession))
 	mux.HandleFunc("/api/sessions", s.auth.Wrap(s.handleApiSessions))
+	mux.HandleFunc("/api/widgets", s.auth.Wrap(s.handleApiWidgets))
 	mux.HandleFunc("/api/chat", s.auth.Wrap(s.handleChat))
 	mux.HandleFunc("/api/chat/cancel", s.auth.Wrap(s.handleCancelChat))
 	mux.HandleFunc("/api/set-model", s.auth.Wrap(s.handleSetModel))
@@ -314,6 +323,27 @@ func (s *Server) removeClient(target *sseClient) {
 	s.clients = filtered
 	s.clientsMu.Unlock()
 	close(target.ch)
+}
+
+// BroadcastWidgetUpdate emits a `widget-update` SSE event on the per-session
+// channel when an extension setWidget call landed. Mirrors BroadcastChatPreview;
+// the embedding app wires it to the worker factory's WidgetSink so widget
+// events flow to connected browsers immediately. Removed=true tells the
+// frontend to tear down that widget's section.
+func (s *Server) BroadcastWidgetUpdate(sessionID string, w widgets.Widget, removed bool) {
+	if sessionID == "" || sessionID == globalSessID {
+		return
+	}
+	payload := map[string]any{
+		"session_id": sessionID,
+		"widget":     w,
+		"removed":    removed,
+	}
+	msg, err := formatSSEJSONEvent("widget-update", payload)
+	if err != nil {
+		return
+	}
+	s.broadcast(sessionID, msg)
 }
 
 func (s *Server) BroadcastChatPreview(sessionID string, preview rpc.StreamPreview) {

--- a/internal/server/widgets_test.go
+++ b/internal/server/widgets_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"pi-web/internal/widgets"
+)
+
+func TestHandleApiWidgets_MissingSession(t *testing.T) {
+	s := &Server{widgets: widgets.NewStore()}
+	req := httptest.NewRequest(http.MethodGet, "/api/widgets", nil)
+	w := httptest.NewRecorder()
+	s.handleApiWidgets(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing session param, got %d", w.Code)
+	}
+}
+
+func TestHandleApiWidgets_NilStore(t *testing.T) {
+	// When the store wasn't wired (tests, --no-extensions builds), the endpoint
+	// should return an empty list rather than 500.
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/widgets?session=s", nil)
+	w := httptest.NewRecorder()
+	s.handleApiWidgets(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with nil store, got %d", w.Code)
+	}
+	var resp struct {
+		Widgets []any `json:"widgets"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Widgets) != 0 {
+		t.Errorf("expected empty widgets list, got %v", resp.Widgets)
+	}
+}
+
+func TestHandleApiWidgets_SortedByPlacementThenKey(t *testing.T) {
+	store := widgets.NewStore()
+	store.Set("s1", "todos", []string{"3 pending"}, "belowEditor")
+	store.Set("s1", "goals", []string{"goal A"}, "aboveEditor")
+	store.Set("s1", "monitors", []string{"2 monitors"}, "belowEditor")
+	store.Set("s1", "memory", []string{"122 facts"}, "aboveEditor")
+
+	s := &Server{widgets: store}
+	req := httptest.NewRequest(http.MethodGet, "/api/widgets?session=s1", nil)
+	w := httptest.NewRecorder()
+	s.handleApiWidgets(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Widgets []widgets.Widget `json:"widgets"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Widgets) != 4 {
+		t.Fatalf("expected 4 widgets, got %d", len(resp.Widgets))
+	}
+	// aboveEditor before belowEditor; alpha within each placement.
+	wantKeys := []string{"goals", "memory", "monitors", "todos"}
+	for i, want := range wantKeys {
+		if resp.Widgets[i].Key != want {
+			t.Errorf("widgets[%d].Key = %q, want %q (full = %v)", i, resp.Widgets[i].Key, want, keysOf(resp.Widgets))
+			break
+		}
+	}
+}
+
+func TestHandleApiWidgets_ScopedBySession(t *testing.T) {
+	store := widgets.NewStore()
+	store.Set("a", "x", []string{"alpha"}, "belowEditor")
+	store.Set("b", "x", []string{"beta"}, "belowEditor")
+	s := &Server{widgets: store}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/widgets?session=a", nil)
+	rec := httptest.NewRecorder()
+	s.handleApiWidgets(rec, req)
+	var resp struct {
+		Widgets []widgets.Widget `json:"widgets"`
+	}
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if len(resp.Widgets) != 1 || resp.Widgets[0].Lines[0] != "alpha" {
+		t.Errorf("session=a leaked another session's widgets: %v", resp.Widgets)
+	}
+}
+
+func keysOf(ws []widgets.Widget) []string {
+	out := make([]string, 0, len(ws))
+	for _, w := range ws {
+		out = append(out, w.Key)
+	}
+	return out
+}

--- a/internal/ui/live_templates/session.html
+++ b/internal/ui/live_templates/session.html
@@ -95,14 +95,17 @@
     <div id="right-sidebar-resizer" class="right-sidebar-resizer" role="separator" aria-orientation="vertical" aria-label="Resize scratchpad sidebar"></div>
     <aside id="right-sidebar" class="right-sidebar">
       <div class="right-sidebar-header">
-        <h3>Scratchpad</h3>
+        <div class="right-sidebar-tabs" role="tablist" aria-label="Right sidebar tabs">
+          <button id="right-sidebar-tab-scratchpad" class="right-sidebar-tab is-active" role="tab" aria-selected="true" aria-controls="right-sidebar-pane-scratchpad" data-pane="scratchpad">Scratchpad</button>
+          <button id="right-sidebar-tab-widgets" class="right-sidebar-tab" role="tab" aria-selected="false" aria-controls="right-sidebar-pane-widgets" data-pane="widgets">Widgets</button>
+        </div>
         <div class="right-sidebar-actions">
-          <button id="expand-right-sidebar" class="right-sidebar-btn" title="Expand scratchpad">
+          <button id="expand-right-sidebar" class="right-sidebar-btn" title="Expand sidebar">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"/>
             </svg>
           </button>
-          <button id="close-right-sidebar" class="right-sidebar-btn" title="Hide scratchpad (⌘⇧N)">
+          <button id="close-right-sidebar" class="right-sidebar-btn" title="Hide sidebar (⌘⇧N)">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <line x1="18" y1="6" x2="6" y2="18"></line>
               <line x1="6" y1="6" x2="18" y2="18"></line>
@@ -110,8 +113,11 @@
           </button>
         </div>
       </div>
-      <div class="right-sidebar-content">
+      <div id="right-sidebar-pane-scratchpad" class="right-sidebar-content right-sidebar-pane is-active" role="tabpanel" aria-labelledby="right-sidebar-tab-scratchpad">
         <textarea id="scratchpad-textarea" class="scratchpad-textarea" placeholder="Write project-level notes, scratchpad, tasks...">{{.Scratchpad}}</textarea>
+      </div>
+      <div id="right-sidebar-pane-widgets" class="right-sidebar-content right-sidebar-pane" role="tabpanel" aria-labelledby="right-sidebar-tab-widgets" hidden>
+        <div id="widgets-panel" class="widgets-panel"></div>
       </div>
       <div class="right-sidebar-footer">
         <span id="scratchpad-status" class="scratchpad-status">Saved</span>

--- a/internal/ui/live_templates/styles/session.css
+++ b/internal/ui/live_templates/styles/session.css
@@ -4707,3 +4707,87 @@
     }
     .cat-settings-skip:hover { filter: brightness(1.08); }
 
+
+    /* Right-sidebar tab control (Scratchpad | Widgets). The header already
+       had .right-sidebar-header + .right-sidebar-actions; tabs replace the
+       previous <h3>Scratchpad</h3>. */
+    .right-sidebar-tabs {
+      display: flex;
+      gap: 4px;
+      flex: 1 1 auto;
+    }
+    .right-sidebar-tab {
+      flex: 0 0 auto;
+      padding: 4px 10px;
+      font: inherit;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--muted, #aaa);
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: 3px;
+      cursor: pointer;
+    }
+    .right-sidebar-tab:hover {
+      color: var(--text, #fff);
+      background: rgba(255, 255, 255, 0.04);
+    }
+    .right-sidebar-tab.is-active {
+      color: var(--text, #fff);
+      background: rgba(255, 255, 255, 0.06);
+      border-color: var(--dim, rgba(255, 255, 255, 0.12));
+    }
+    .right-sidebar-pane { display: none; }
+    .right-sidebar-pane.is-active { display: flex; flex-direction: column; }
+
+    /* Widgets pane content. Each widget is a section with a header (key) +
+       a <pre>-styled body (lines). Sections stack vertically; the panel
+       scrolls when content overflows. */
+    .widgets-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      padding: 10px;
+      overflow-y: auto;
+      height: 100%;
+    }
+    .widget {
+      border: 1px solid var(--dim, rgba(255, 255, 255, 0.12));
+      border-radius: 4px;
+      background: rgba(255, 255, 255, 0.02);
+      overflow: hidden;
+    }
+    .widget-header {
+      padding: 6px 10px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--muted, #aaa);
+      background: rgba(255, 255, 255, 0.03);
+      border-bottom: 1px solid var(--dim, rgba(255, 255, 255, 0.10));
+    }
+    .widget-lines {
+      margin: 0;
+      padding: 8px 10px;
+      font-family: var(--font-sans);
+      font-size: 12px;
+      line-height: 1.5;
+      color: var(--text, #ddd);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .widget-empty {
+      padding: 8px 10px;
+      font-size: 12px;
+      color: var(--muted, #888);
+      font-style: italic;
+    }
+    .widgets-empty {
+      padding: 16px 12px;
+      color: var(--muted, #888);
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .widgets-empty p { margin: 0 0 8px; }
+    .widgets-empty-hint { font-size: 12px; opacity: 0.8; }

--- a/internal/widgets/store.go
+++ b/internal/widgets/store.go
@@ -1,0 +1,123 @@
+// Package widgets stores extension-widget state emitted by pi --mode rpc
+// workers and exposes it for the HTTP layer + SSE stream.
+//
+// Each running pi extension can call ctx.ui.setWidget(key, lines, {placement})
+// to surface a small text block in the host UI. In RPC mode the extension
+// emits this as `extension_ui_request` with method="setWidget" on the worker's
+// stdout. The RPC worker's stream consumer routes those events here; the
+// store keeps the latest payload per session+key and notifies subscribers
+// so the HTTP/SSE layers can push updates to the browser.
+package widgets
+
+import (
+	"sync"
+	"time"
+)
+
+// Widget is a single named extension widget for a session.
+type Widget struct {
+	Key       string    `json:"key"`
+	Lines     []string  `json:"lines"`
+	Placement string    `json:"placement"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Update is the message broadcast to subscribers when a widget changes.
+// Removed=true means the widget should be torn down (extension passed lines=nil).
+type Update struct {
+	SessionID string `json:"session_id"`
+	Widget    Widget `json:"widget"`
+	Removed   bool   `json:"removed"`
+}
+
+// Store holds per-session widget state. Safe for concurrent use.
+//
+// The HTTP layer reads via Get; the RPC worker writes via Set/Remove. Real-time
+// browser updates are handled by the server's existing SSE plumbing — when the
+// app wires the worker factory it routes setWidget events both to the store
+// (so /api/widgets returns the latest) AND to Server.BroadcastWidgetUpdate
+// (so connected SSE clients see the change immediately). Mirrors the
+// BroadcastChatPreview shape; no per-store subscriber machinery needed.
+type Store struct {
+	mu      sync.RWMutex
+	state   map[string]map[string]Widget // sessionID → key → Widget
+	nowFunc func() time.Time
+}
+
+// NewStore returns an empty widget store.
+func NewStore() *Store {
+	return &Store{
+		state:   make(map[string]map[string]Widget),
+		nowFunc: time.Now,
+	}
+}
+
+// Set inserts or replaces a widget for a session. Placement defaults to
+// "belowEditor" if empty (matches pi-coding-agent's setWidget default).
+// Returns the resulting Widget — the caller forwards this to the SSE
+// broadcaster so connected browsers see the update.
+func (s *Store) Set(sessionID, key string, lines []string, placement string) Widget {
+	if placement == "" {
+		placement = "belowEditor"
+	}
+	w := Widget{
+		Key:       key,
+		Lines:     append([]string(nil), lines...),
+		Placement: placement,
+		UpdatedAt: s.nowFunc(),
+	}
+	s.mu.Lock()
+	if _, ok := s.state[sessionID]; !ok {
+		s.state[sessionID] = make(map[string]Widget)
+	}
+	s.state[sessionID][key] = w
+	s.mu.Unlock()
+	return w
+}
+
+// Remove drops a single widget. Returns true if it existed.
+func (s *Store) Remove(sessionID, key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	bySession, ok := s.state[sessionID]
+	if !ok {
+		return false
+	}
+	if _, existed := bySession[key]; !existed {
+		return false
+	}
+	delete(bySession, key)
+	if len(bySession) == 0 {
+		delete(s.state, sessionID)
+	}
+	return true
+}
+
+// Get returns a snapshot of all widgets for a session (key → Widget).
+// Lines slices are copies so callers may mutate without locking.
+func (s *Store) Get(sessionID string) map[string]Widget {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	bySession, ok := s.state[sessionID]
+	if !ok {
+		return nil
+	}
+	out := make(map[string]Widget, len(bySession))
+	for k, w := range bySession {
+		out[k] = Widget{
+			Key:       w.Key,
+			Lines:     append([]string(nil), w.Lines...),
+			Placement: w.Placement,
+			UpdatedAt: w.UpdatedAt,
+		}
+	}
+	return out
+}
+
+// ClearSession drops all widgets for a session. Called when a worker for the
+// session terminates so stale state doesn't leak into the next worker's view.
+func (s *Store) ClearSession(sessionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.state, sessionID)
+}

--- a/internal/widgets/store_test.go
+++ b/internal/widgets/store_test.go
@@ -1,0 +1,112 @@
+package widgets
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestStore_SetAndGet(t *testing.T) {
+	s := NewStore()
+	w := s.Set("sess-1", "todos", []string{"3 pending", "1 done"}, "belowEditor")
+	if w.Key != "todos" {
+		t.Errorf("Key = %q, want todos", w.Key)
+	}
+	if w.Placement != "belowEditor" {
+		t.Errorf("Placement = %q, want belowEditor", w.Placement)
+	}
+
+	state := s.Get("sess-1")
+	if len(state) != 1 {
+		t.Fatalf("len(state) = %d, want 1", len(state))
+	}
+	if state["todos"].Lines[0] != "3 pending" {
+		t.Errorf("unexpected lines: %v", state["todos"].Lines)
+	}
+}
+
+func TestStore_DefaultPlacement(t *testing.T) {
+	s := NewStore()
+	w := s.Set("sess-1", "x", []string{"a"}, "")
+	if w.Placement != "belowEditor" {
+		t.Errorf("default placement = %q, want belowEditor", w.Placement)
+	}
+}
+
+func TestStore_Replace(t *testing.T) {
+	s := NewStore()
+	s.Set("sess-1", "todos", []string{"3 pending"}, "belowEditor")
+	s.Set("sess-1", "todos", []string{"2 pending", "1 done"}, "belowEditor")
+	state := s.Get("sess-1")
+	if len(state["todos"].Lines) != 2 {
+		t.Errorf("expected 2 lines after replace, got %d", len(state["todos"].Lines))
+	}
+	if state["todos"].Lines[0] != "2 pending" {
+		t.Errorf("replace did not update lines: %v", state["todos"].Lines)
+	}
+}
+
+func TestStore_Remove(t *testing.T) {
+	s := NewStore()
+	s.Set("sess-1", "todos", []string{"a"}, "belowEditor")
+	if !s.Remove("sess-1", "todos") {
+		t.Error("Remove returned false for existing key")
+	}
+	if s.Remove("sess-1", "todos") {
+		t.Error("Remove returned true for already-removed key")
+	}
+	if state := s.Get("sess-1"); state != nil {
+		t.Errorf("expected nil snapshot after last remove, got %v", state)
+	}
+}
+
+func TestStore_GetReturnsCopies(t *testing.T) {
+	s := NewStore()
+	s.Set("sess-1", "k", []string{"a", "b"}, "belowEditor")
+	state := s.Get("sess-1")
+	// Mutate the copy; the store should retain its own snapshot.
+	state["k"].Lines[0] = "mutated"
+	fresh := s.Get("sess-1")
+	if fresh["k"].Lines[0] != "a" {
+		t.Errorf("store returned a shared slice — caller mutation leaked: %v", fresh["k"].Lines)
+	}
+}
+
+func TestStore_PerSessionIsolation(t *testing.T) {
+	s := NewStore()
+	s.Set("sess-a", "k", []string{"a"}, "belowEditor")
+	s.Set("sess-b", "k", []string{"b"}, "aboveEditor")
+	a := s.Get("sess-a")
+	b := s.Get("sess-b")
+	if a["k"].Lines[0] != "a" || b["k"].Lines[0] != "b" {
+		t.Errorf("sessions leaked: a=%v b=%v", a, b)
+	}
+	if a["k"].Placement != "belowEditor" || b["k"].Placement != "aboveEditor" {
+		t.Errorf("placement leaked: a=%s b=%s", a["k"].Placement, b["k"].Placement)
+	}
+}
+
+func TestStore_ClearSession(t *testing.T) {
+	s := NewStore()
+	s.Set("sess-a", "x", []string{"a"}, "belowEditor")
+	s.Set("sess-a", "y", []string{"b"}, "belowEditor")
+	s.Set("sess-b", "x", []string{"c"}, "belowEditor")
+	s.ClearSession("sess-a")
+	if s.Get("sess-a") != nil {
+		t.Error("ClearSession did not drop sess-a")
+	}
+	if s.Get("sess-b") == nil {
+		t.Error("ClearSession also dropped sess-b")
+	}
+}
+
+func TestStore_ConcurrentSetGetIsSafe(t *testing.T) {
+	s := NewStore()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func(i int) { defer wg.Done(); s.Set("sess", "k", []string{"v"}, "belowEditor"); _ = i }(i)
+		go func() { defer wg.Done(); _ = s.Get("sess") }()
+	}
+	wg.Wait()
+	// Survived the race detector — that's the assertion.
+}

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -13,6 +13,7 @@ import * as toggleStateApi from './ui/toggle-state.js';
 import * as sidebarApi from './ui/sidebar.js';
 import * as searchFiltersApi from './ui/search-filters.js';
 import { setupSessionUi } from './ui/session-ui-runner.js';
+import { setupRightSidebarTabs, setupWidgetsPanel } from './ui/widgets-panel.js';
 import * as chatComposerRunner from './chat/chat-composer-runner.js';
 import * as doneNotifier from './chat/done-notifier.js';
 import * as chatApi from './chat/chat-api.js';
@@ -477,6 +478,19 @@ export function runSessionApp({ target = window } = {}) {
     windowImpl: target,
     cwd: dataModel.header?.cwd || '',
     parentId: getSessionSearchParams({ documentImpl, windowImpl: target }).get('id') || '',
+  });
+
+  // Right-sidebar tabs (Scratchpad | Widgets) + widgets panel data layer.
+  // Widgets are populated by the server's RPC worker (handleSession spawns one
+  // on page load to bootstrap them). /api/widgets returns the current
+  // snapshot; SSE `widget-update` events keep the panel live.
+  setupRightSidebarTabs({ documentImpl });
+  setupWidgetsPanel({
+    sessionId,
+    documentImpl,
+    windowImpl: target,
+    fetchImpl: target.fetch ? target.fetch.bind(target) : undefined,
+    EventSourceImpl: target.EventSource,
   });
 
   // Handle Visual Viewport changes to prevent mobile browsers from shifting

--- a/web/src/session/ui/widgets-panel.js
+++ b/web/src/session/ui/widgets-panel.js
@@ -1,0 +1,167 @@
+/**
+ * widgets-panel — surface extension setWidget data in the right-sidebar.
+ *
+ * Pi extensions call `ctx.ui.setWidget(key, lines, { placement })` to surface
+ * status strips (todos, goals, monitors, memory counts, etc.) below or above
+ * the editor in the TUI. In pi --mode rpc those events become
+ * `extension_ui_request` JSON lines; the server's RPC worker routes them into
+ * the per-session widget store and re-broadcasts on the SSE channel as
+ * `widget-update` events. This module fetches the snapshot from
+ * `/api/widgets?session=X`, renders it, and patches DOM in-place on SSE
+ * updates.
+ *
+ * Two-tab right-sidebar: scratchpad vs widgets. Active pane persists in
+ * localStorage so the user's last choice is sticky across navigation.
+ */
+
+const PANE_STORAGE_KEY = 'pi-web:v1:right-sidebar-pane';
+
+export function setupRightSidebarTabs({
+  documentImpl = document,
+  storage = (typeof localStorage !== 'undefined' ? localStorage : null),
+} = {}) {
+  const tabs = documentImpl.querySelectorAll('.right-sidebar-tab');
+  const panes = documentImpl.querySelectorAll('.right-sidebar-pane');
+  if (tabs.length === 0 || panes.length === 0) return null;
+
+  function activate(pane) {
+    tabs.forEach((t) => {
+      const isActive = t.dataset.pane === pane;
+      t.classList.toggle('is-active', isActive);
+      t.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    });
+    panes.forEach((p) => {
+      const isActive = p.id === `right-sidebar-pane-${pane}`;
+      p.classList.toggle('is-active', isActive);
+      if (isActive) p.removeAttribute('hidden');
+      else p.setAttribute('hidden', '');
+    });
+    // Scratchpad-only footer (Saved indicator) hides on widgets tab.
+    const footer = documentImpl.querySelector('.right-sidebar-footer');
+    if (footer) footer.style.display = pane === 'scratchpad' ? '' : 'none';
+    try { storage?.setItem(PANE_STORAGE_KEY, pane); } catch { /* ignore */ }
+  }
+
+  tabs.forEach((t) => {
+    t.addEventListener('click', () => activate(t.dataset.pane));
+  });
+
+  let initial = 'scratchpad';
+  try { initial = storage?.getItem(PANE_STORAGE_KEY) || 'scratchpad'; } catch { /* ignore */ }
+  activate(initial);
+  return { activate };
+}
+
+function escapeHtml(s) {
+  if (s == null) return '';
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  })[c]);
+}
+
+function renderWidgetSection(widget) {
+  const lines = Array.isArray(widget.lines) ? widget.lines : [];
+  const body = lines.length
+    ? `<pre class="widget-lines">${lines.map(escapeHtml).join('\n')}</pre>`
+    : '<div class="widget-empty">(empty)</div>';
+  return `<section class="widget" data-key="${escapeHtml(widget.key)}" data-placement="${escapeHtml(widget.placement || '')}">
+    <header class="widget-header">${escapeHtml(widget.key)}</header>
+    ${body}
+  </section>`;
+}
+
+function renderAll(panel, widgets) {
+  if (!widgets || widgets.length === 0) {
+    panel.innerHTML = `<div class="widgets-empty">
+      <p>No widgets yet.</p>
+      <p class="widgets-empty-hint">Widgets populate when this session has had at least one turn. Pi-web spawns a worker on page load to bootstrap them; check back in a few seconds.</p>
+    </div>`;
+    return;
+  }
+  panel.innerHTML = widgets.map(renderWidgetSection).join('');
+}
+
+function cssEscape(s) {
+  // CSS.escape isn't always present in test environments; fall back to a
+  // safe minimal escape good enough for selector-attribute matching of
+  // ASCII widget keys.
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(s);
+  }
+  return String(s).replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
+}
+
+function patchSection(panel, widget, removed) {
+  const doc = panel.ownerDocument;
+  const existing = panel.querySelector(`section.widget[data-key="${cssEscape(widget.key)}"]`);
+  if (removed) {
+    if (existing) existing.remove();
+    if (panel.children.length === 0) renderAll(panel, []);
+    return;
+  }
+  const html = renderWidgetSection(widget);
+  if (existing) {
+    const wrapper = doc.createElement('div');
+    wrapper.innerHTML = html.trim();
+    existing.replaceWith(wrapper.firstChild);
+  } else {
+    // Empty-state placeholder? Replace it.
+    if (panel.querySelector('.widgets-empty')) panel.innerHTML = '';
+    panel.insertAdjacentHTML('beforeend', html);
+  }
+}
+
+export function setupWidgetsPanel({
+  sessionId,
+  documentImpl = document,
+  windowImpl = window,
+  fetchImpl,
+  EventSourceImpl,
+} = {}) {
+  if (!sessionId) return null;
+  const panel = documentImpl.getElementById('widgets-panel');
+  if (!panel) return null;
+  const fetcher = fetchImpl || (windowImpl?.fetch ? windowImpl.fetch.bind(windowImpl) : null);
+  if (!fetcher) return null;
+  const ES = EventSourceImpl || windowImpl?.EventSource;
+
+  async function refresh() {
+    try {
+      const res = await fetcher(`/api/widgets?session=${encodeURIComponent(sessionId)}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      renderAll(panel, Array.isArray(data?.widgets) ? data.widgets : []);
+    } catch (err) {
+      panel.innerHTML = `<div class="widgets-empty">Failed to load widgets: ${escapeHtml(err.message)}</div>`;
+    }
+  }
+
+  refresh();
+
+  // SSE subscription — the session SSE topic already carries widget-update
+  // events alongside chat-preview etc.
+  let es = null;
+  if (ES) {
+    try {
+      es = new ES(`/events?session=${encodeURIComponent(sessionId)}`);
+      es.addEventListener('widget-update', (e) => {
+        try {
+          const payload = JSON.parse(e.data);
+          if (!payload?.widget?.key) return;
+          patchSection(panel, payload.widget, !!payload.removed);
+        } catch { /* drop malformed */ }
+      });
+    } catch { /* SSE unavailable — falls back to manual refresh on tab activation */ }
+  }
+
+  // Re-fetch when the user switches into the widgets tab — covers the case
+  // where worker spawn was slow on page load and the initial fetch was empty.
+  documentImpl.querySelectorAll('.right-sidebar-tab[data-pane="widgets"]').forEach((t) => {
+    t.addEventListener('click', () => { refresh(); });
+  });
+
+  return {
+    refresh,
+    close: () => { if (es) try { es.close(); } catch { /* ignore */ } },
+  };
+}

--- a/web/src/session/ui/widgets-panel.test.js
+++ b/web/src/session/ui/widgets-panel.test.js
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { setupRightSidebarTabs, setupWidgetsPanel } from './widgets-panel.js';
+
+function dom() {
+  return new JSDOM(`<body>
+    <aside id="right-sidebar">
+      <div class="right-sidebar-header">
+        <div class="right-sidebar-tabs">
+          <button class="right-sidebar-tab is-active" data-pane="scratchpad" aria-selected="true">Scratchpad</button>
+          <button class="right-sidebar-tab" data-pane="widgets" aria-selected="false">Widgets</button>
+        </div>
+      </div>
+      <div id="right-sidebar-pane-scratchpad" class="right-sidebar-content right-sidebar-pane is-active"></div>
+      <div id="right-sidebar-pane-widgets" class="right-sidebar-content right-sidebar-pane" hidden>
+        <div id="widgets-panel" class="widgets-panel"></div>
+      </div>
+      <div class="right-sidebar-footer"><span id="scratchpad-status">Saved</span></div>
+    </aside>
+  </body>`);
+}
+
+function makeStorage() {
+  const store = new Map();
+  return {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => { store.set(k, v); },
+  };
+}
+
+describe('setupRightSidebarTabs', () => {
+  it('activates the widgets tab on click', () => {
+    const jsdom = dom();
+    const doc = jsdom.window.document;
+    setupRightSidebarTabs({ documentImpl: doc, storage: makeStorage() });
+
+    const widgetsTab = doc.querySelector('.right-sidebar-tab[data-pane="widgets"]');
+    widgetsTab.click();
+
+    expect(widgetsTab.classList.contains('is-active')).toBe(true);
+    expect(widgetsTab.getAttribute('aria-selected')).toBe('true');
+    expect(doc.getElementById('right-sidebar-pane-widgets').hasAttribute('hidden')).toBe(false);
+    expect(doc.getElementById('right-sidebar-pane-scratchpad').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('hides scratchpad-status footer on widgets tab', () => {
+    const jsdom = dom();
+    const doc = jsdom.window.document;
+    setupRightSidebarTabs({ documentImpl: doc, storage: makeStorage() });
+    doc.querySelector('.right-sidebar-tab[data-pane="widgets"]').click();
+    expect(doc.querySelector('.right-sidebar-footer').style.display).toBe('none');
+  });
+
+  it('persists the active pane to storage', () => {
+    const jsdom = dom();
+    const doc = jsdom.window.document;
+    const storage = makeStorage();
+    setupRightSidebarTabs({ documentImpl: doc, storage });
+    doc.querySelector('.right-sidebar-tab[data-pane="widgets"]').click();
+    expect(storage.getItem('pi-web:v1:right-sidebar-pane')).toBe('widgets');
+  });
+
+  it('restores the active pane from storage on init', () => {
+    const jsdom = dom();
+    const doc = jsdom.window.document;
+    const storage = makeStorage();
+    storage.setItem('pi-web:v1:right-sidebar-pane', 'widgets');
+    setupRightSidebarTabs({ documentImpl: doc, storage });
+    expect(doc.getElementById('right-sidebar-pane-widgets').hasAttribute('hidden')).toBe(false);
+  });
+});
+
+describe('setupWidgetsPanel', () => {
+  it('renders an empty-state when no widgets', async () => {
+    const jsdom = dom();
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ widgets: [] }) }));
+    setupWidgetsPanel({
+      sessionId: 's1',
+      documentImpl: jsdom.window.document,
+      windowImpl: jsdom.window,
+      fetchImpl: fetchMock,
+      EventSourceImpl: null,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchMock).toHaveBeenCalledWith('/api/widgets?session=s1');
+    expect(jsdom.window.document.getElementById('widgets-panel').textContent).toMatch(/No widgets yet/);
+  });
+
+  it('renders widget sections from snapshot', async () => {
+    const jsdom = dom();
+    const widgets = [
+      { key: 'todos', lines: ['3 pending', '1 done'], placement: 'belowEditor' },
+      { key: 'goals', lines: ['Migrate to PG'], placement: 'aboveEditor' },
+    ];
+    setupWidgetsPanel({
+      sessionId: 's1',
+      documentImpl: jsdom.window.document,
+      windowImpl: jsdom.window,
+      fetchImpl: async () => ({ ok: true, json: async () => ({ widgets }) }),
+      EventSourceImpl: null,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    const panel = jsdom.window.document.getElementById('widgets-panel');
+    const sections = panel.querySelectorAll('section.widget');
+    expect(sections.length).toBe(2);
+    expect(sections[0].dataset.key).toBe('todos');
+    expect(sections[0].textContent).toContain('3 pending');
+  });
+
+  it('patches a section on widget-update SSE event', async () => {
+    const jsdom = dom();
+    const listeners = new Map();
+    class FakeES {
+      constructor() { listeners.set('instance', this); }
+      addEventListener(type, fn) { listeners.set(type, fn); }
+      close() {}
+    }
+    setupWidgetsPanel({
+      sessionId: 's1',
+      documentImpl: jsdom.window.document,
+      windowImpl: jsdom.window,
+      fetchImpl: async () => ({ ok: true, json: async () => ({ widgets: [] }) }),
+      EventSourceImpl: FakeES,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Simulate the SSE event arrival.
+    const handler = listeners.get('widget-update');
+    handler({ data: JSON.stringify({
+      session_id: 's1',
+      widget: { key: 'todos', lines: ['2 pending'], placement: 'belowEditor' },
+      removed: false,
+    }) });
+
+    const panel = jsdom.window.document.getElementById('widgets-panel');
+    expect(panel.querySelector('section.widget[data-key="todos"]')).not.toBeNull();
+    expect(panel.textContent).toContain('2 pending');
+  });
+
+  it('removes a section on widget-update with removed=true', async () => {
+    const jsdom = dom();
+    const widgets = [{ key: 'todos', lines: ['a'], placement: 'belowEditor' }];
+    let handler;
+    class FakeES {
+      addEventListener(type, fn) { if (type === 'widget-update') handler = fn; }
+      close() {}
+    }
+    setupWidgetsPanel({
+      sessionId: 's1',
+      documentImpl: jsdom.window.document,
+      windowImpl: jsdom.window,
+      fetchImpl: async () => ({ ok: true, json: async () => ({ widgets }) }),
+      EventSourceImpl: FakeES,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    handler({ data: JSON.stringify({
+      session_id: 's1',
+      widget: { key: 'todos' },
+      removed: true,
+    }) });
+
+    const panel = jsdom.window.document.getElementById('widgets-panel');
+    expect(panel.querySelector('section.widget[data-key="todos"]')).toBeNull();
+    expect(panel.textContent).toMatch(/No widgets yet/);
+  });
+});


### PR DESCRIPTION
## Summary

Pi extensions can call `ctx.ui.setWidget(key, lines, { placement })` to surface status strips in the TUI (todos, goals, monitors, memory counts, usage, etc.). In RPC mode — which pi-web spawns for browser chat — those events arrive as `extension_ui_request` JSON lines on the worker's stdout. The existing `worker.handleRPCLine` silently dropped them, so all that rich extension state was invisible in the browser even though the TUI rendered it fine.

This PR plumbs setWidget through the whole stack, with a page-load bootstrap so widgets populate even during passive viewing (no chat needed).

## Real-world demo

Smoke test on my own CanLegal session — `/api/widgets?session=X` after page load returns:

```json
{
  "widgets": [
    {"key": "episodes", "lines": ["📚 1164/1164 here · 4363 episodes global"], "placement": "belowEditor"},
    {"key": "goals", "lines": ["🎯 Complete CanLII extraction pipeline... · 3h29m"], "placement": "belowEditor"},
    {"key": "memory", "lines": ["🧠 33 facts · 12 lessons · 3 failures (1 helpful)"], "placement": "belowEditor"},
    {"key": "usage", "lines": ["💰 $0 · 20.0k↑4.3k↓ · 116.4kc · 10t", "api-deepseek-v4-flash: free", "deepseek-v4-pro: free"], "placement": "belowEditor"}
  ]
}
```

Same content as the TUI strips. Renders as a "Widgets" tab in the existing right-sidebar (alongside Scratchpad).

## Approach

| Change | File |
|---|---|
| Per-session widget store (Set/Remove/Get/ClearSession). Thread-safe; copies on Set/Get so callers can't mutate shared state. | new `internal/widgets/store.go` |
| `WidgetSink` type + `NewPiWorker(opts)` constructor (`NewPiWorkerWithStream` preserved as wrapper for backward compat). `handleRPCLine` routes `type=\"extension_ui_request\" method=\"setWidget\"` payloads to the sink. Pi dispatches these fire-and-forget — no response needed. | `internal/rpc/{worker,stream}.go` |
| `Server.BroadcastWidgetUpdate` emits a `widget-update` SSE event on the existing per-session channel when widgets mutate. Mirrors `BroadcastChatPreview`. | `internal/server/server.go` |
| `GET /api/widgets?session=X` returns the current snapshot sorted `aboveEditor` → `belowEditor`, alphabetical within. No-op when store isn't wired (tests / --no-extensions). | `internal/server/handlers.go` |
| **Page-load widget bootstrap.** `handleSession` calls `EnsureWorker` in the background so extensions run `session_start` + emit their widgets even when the user is just passively viewing (no chat yet). Idempotent via the manager's create-cache. Worker is reused for any subsequent chat; the existing 10-min reaper handles cleanup. | `internal/server/handlers.go` |
| App wiring: creates `widgets.Store`, passes to both `server.Deps` and the worker factory's `WidgetSink`. The sink does `store.Set/Remove` + `srv.BroadcastWidgetUpdate`. | `internal/app/app.go` |

### Frontend

| Change | File |
|---|---|
| Right-sidebar now has tabs (Scratchpad \| Widgets) with proper `role=\"tab\"`/`role=\"tabpanel\"` + aria. Existing scratchpad scaffolding preserved as a pane. | `internal/ui/live_templates/session.html` |
| `setupRightSidebarTabs` (click handlers, persist active pane to localStorage, hide scratchpad-status footer on widgets tab). `setupWidgetsPanel` (fetch /api/widgets, subscribe to `widget-update` SSE, patch DOM in place — replace section by key OR append; remove section + restore empty-state on `removed=true`). Re-fetches on tab activation to cover slow worker spawn. | new `web/src/session/ui/widgets-panel.js` |
| CSS for tabs + widget sections. | `internal/ui/live_templates/styles/session.css` |

## Tests

- **Go** (12 new):
  - `internal/widgets/store_test.go` — set/get, default placement, replace, remove, get-returns-copies (no shared slices), per-session isolation, clear session, concurrent safety.
  - `internal/server/widgets_test.go` — missing-session 400, nil-store empty list, sort order (aboveEditor before belowEditor, alpha within), session scoping.
- **JS** (8 new): `web/src/session/ui/widgets-panel.test.js` — tab activation, footer-hide on widgets tab, localStorage persist + restore, empty-state, initial render, SSE patch, SSE remove.
- `make check` green: 375 JS tests + every Go package.

## Mobile

The right-sidebar already collapses on small screens (existing behavior). The Widgets tab inherits that — accessible via the right-sidebar toggle button. PWA users get widget access on phone.

## Resource note

The page-load bootstrap spawns an RPC worker if one doesn't exist for the visited session. Each worker is ~150MB and idle-reaped after 10min. Users browsing 5 different sessions concurrently → 5 workers, ~750MB. The existing manager's idempotent `EnsureWorker` prevents duplicate spawns. If you want this gated (e.g. only bootstrap when last activity < 24h), happy to add a setting.

## Related

Sibling to #51 (scanner buffer cap) and #52 (pagination). All three are branched cleanly off `main` so they review independently.