### PR TITLE
test(sessions): regression test for large per-line scanner buffer

### DIFF
--- a/internal/sessions/session_test.go
+++ b/internal/sessions/session_test.go
@@ -320,6 +320,32 @@ func TestRenameSessionRejectsEmptyName(t *testing.T) {
 	}
 }
 
+func TestParseSummaryHandlesLargeToolResultLine(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "s.jsonl")
+
+	// A single tool-result message line larger than the old 4MB scanner cap.
+	// Before the buffer bump, scanner.Err() returns bufio.ErrTooLong and the
+	// whole session is dropped from the index.
+	big := strings.Repeat("a", 8*1024*1024)
+	content := `{"type":"session","name":"Big Session","timestamp":"2026-05-08T10:00:00Z"}` + "\n" +
+		`{"type":"message","timestamp":"2026-05-08T10:00:01Z","message":{"role":"user","content":"hello"}}` + "\n" +
+		`{"type":"message","timestamp":"2026-05-08T10:00:02Z","message":{"role":"assistant","content":"` + big + `"}}` + "\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := ParseSummary(path, "--proj--", "s.jsonl")
+	if err != nil {
+		t.Fatalf("ParseSummary returned error on large line: %v", err)
+	}
+	if s.Name != "Big Session" {
+		t.Errorf("Name = %q, want %q", s.Name, "Big Session")
+	}
+	if s.MessageCount != 2 {
+		t.Errorf("MessageCount = %d, want 2", s.MessageCount)
+	}
+}
+
 func TestParseSummaryUsesHeaderName(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "s.jsonl")


### PR DESCRIPTION
## Summary

Follow-up to #51. Adds a regression test for the per-line scanner buffer bump so the "session silently dropped from the index" bug can't reappear.

`TestParseSummaryHandlesLargeToolResultLine` writes a session whose third line is an ~8 MB `message` (simulating a large `toolResult`) and asserts `ParseSummary` succeeds with the correct name and message count.

- On the pre-#51 4 MB cap this failed with `bufio.Scanner: token too long`.
- With #51's 256 MB cap it passes.

## Test plan

- [x] `make check` green (vitest + go test + build + vet)
- [x] `go test ./internal/sessions/ -run TestParseSummaryHandlesLargeToolResultLine -count=1` passes