### PR TITLE
fix(session): render earlier messages when loading paginated windows

### DIFF
--- a/e2e/tests/load-earlier.spec.ts
+++ b/e2e/tests/load-earlier.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, collapseScratchpad } from "../lib/test";
+import { uniqueSessionName, writeSession } from "../lib/sessions";
+
+// Build a session large enough to cross the server-side truncation threshold
+// (internal/ui/session_page.go: LargeSessionThreshold = 1500). The initial HTML
+// render then embeds only the tail (LargeSessionTailEntries = 1000) and the
+// frontend shows a "Load earlier" banner that lazily fetches preceding windows
+// via /api/session?id=...&from=N&count=K.
+const MESSAGE_COUNT = 1600; // + 1 header => 1601 entries, > 1500 threshold
+const EARLY_INDEX = 5; // an early message, well outside the embedded tail
+const EARLY_MARKER = "EARLY_MARKER_LOADME";
+
+function buildLargeSession(): unknown[] {
+  const cwd = "/home/user/demo-project";
+  const base = Date.parse("2026-05-06T00:00:00.000Z");
+  const ts = (i: number) => new Date(base + i * 1000).toISOString();
+
+  const entries: unknown[] = [
+    { type: "session", version: 3, id: "019e0000-0000-7000-8000-000000000000", timestamp: ts(0), cwd },
+  ];
+
+  let parentId: string | null = null;
+  for (let i = 0; i < MESSAGE_COUNT; i += 1) {
+    const id = `m${String(i).padStart(6, "0")}`;
+    const role = i % 2 === 0 ? "user" : "assistant";
+    const text = i === EARLY_INDEX ? EARLY_MARKER : `message body ${i}`;
+    entries.push({
+      type: "message",
+      id,
+      parentId,
+      timestamp: ts(i + 1),
+      message: { role, content: [{ type: "text", text }], timestamp: base + (i + 1) * 1000 },
+    });
+    parentId = id;
+  }
+  return entries;
+}
+
+test.describe("load-earlier banner (large session pagination)", () => {
+  test("truncated session loads earlier windows on demand", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    // On narrow viewports the scratchpad overlays content and can intercept
+    // clicks; collapse it before navigating so the banner button is clickable.
+    await collapseScratchpad(page);
+
+    const name = uniqueSessionName(testInfo, "le");
+    const id = writeSession(sessionsDir, name, buildLargeSession());
+
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+
+    const banner = page.locator("#load-earlier-banner");
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(/Showing latest .* of .* messages/);
+
+    // The early message is outside the embedded tail, so it is not rendered yet.
+    await expect(page.locator("#messages")).not.toContainText(EARLY_MARKER);
+
+    // Click through preceding windows until everything is loaded. The banner
+    // removes itself once `from` reaches 0 (load-earlier.js).
+    const button = banner.getByRole("button");
+    for (let i = 0; i < 6 && (await banner.count()) > 0; i += 1) {
+      await expect(button).toBeEnabled();
+      await button.click();
+      // Either the banner is gone, or it re-enabled for the next window.
+      await expect
+        .poll(async () =>
+          (await banner.count()) === 0 || (await button.isEnabled()),
+        )
+        .toBe(true);
+    }
+
+    await expect(page.locator("#load-earlier-banner")).toHaveCount(0);
+
+    // After all earlier windows load, the earliest message must actually be
+    // rendered in the conversation view — not just merged into the data model.
+    await expect(page.locator("#messages")).toContainText(EARLY_MARKER);
+  });
+});

--- a/web/src/session/session.js
+++ b/web/src/session/session.js
@@ -488,6 +488,10 @@ export function runSessionApp({ target = window } = {}) {
     dataModel,
     sessionId,
     syncDataModelEntries,
+    // Re-render the conversation from the current leaf so the prepended earlier
+    // entries actually appear in #messages, keeping the viewport anchored on the
+    // message that was previously at the top (anchorId) to avoid a scroll jump.
+    rerender: (anchorId) => navigateTo(dataModel.leafId, anchorId ? 'target' : 'bottom', anchorId || null),
     documentImpl,
     fetchImpl: target.fetch.bind(target),
   });

--- a/web/src/session/ui/load-earlier.js
+++ b/web/src/session/ui/load-earlier.js
@@ -27,6 +27,7 @@ export function setupLoadEarlierBanner({
   dataModel,
   sessionId,
   syncDataModelEntries,
+  rerender,
   documentImpl = document,
   fetchImpl = (typeof window !== 'undefined' ? window.fetch.bind(window) : null),
   windowSize = WINDOW_SIZE,
@@ -73,6 +74,9 @@ export function setupLoadEarlierBanner({
     if (button.disabled) return;
     const requestFrom = Math.max(0, dataModel.from - windowSize);
     const requestCount = dataModel.from - requestFrom;
+    // The message currently at the top of the conversation. We re-anchor the
+    // viewport on it after prepending older entries so the page doesn't jump.
+    const anchorId = dataModel.entries[0]?.id || null;
     button.disabled = true;
     status.textContent = 'Loading…';
     try {
@@ -91,9 +95,13 @@ export function setupLoadEarlierBanner({
         return;
       }
       const merged = [...earlier, ...dataModel.entries];
-      // syncDataModelEntries handles the full re-build: replaces entries,
-      // rebuilds byId/toolCallMap/labelMap, re-renders the tree.
+      // syncDataModelEntries handles the data-model re-build: replaces entries,
+      // rebuilds byId/toolCallMap/labelMap, re-renders the sidebar tree. It does
+      // NOT re-render the #messages conversation (live-reload appends new
+      // entries at the bottom separately), so we must explicitly re-render the
+      // conversation to surface the freshly prepended earlier messages.
       syncDataModelEntries(merged);
+      if (typeof rerender === 'function') rerender(anchorId);
       dataModel.from = requestFrom;
       dataModel.truncated = requestFrom > 0;
       status.textContent = '';


### PR DESCRIPTION
Follow-up to #52.

#52 added tail-window pagination for large sessions with a "Load earlier" banner, but clicking it never displayed the older messages — they were merged into the data model but the conversation pane (`#messages`) was never re-rendered.

## Root cause
`syncDataModelEntries` only rebuilds the data model + sidebar (`treeRenderer.forceTreeRerender()`). It intentionally doesn't re-render `#messages` — live-reload appends *new* entries at the bottom via `liveRenderer` separately — so prepending *older* entries updated state but never redrew the conversation.

## Fix
Re-render the conversation after each merge via a `rerender` callback wired to `navigateTo(leafId, ...)` (which rebuilds `#messages` from the full ancestor path), anchored on the previously-top message so the viewport doesn't jump.

## Test
Adds a Playwright spec driving a >1500-entry session: it reproduces the original failure (early message never renders) and passes with the fix. The existing JS unit tests missed this because they mock `syncDataModelEntries`.

`make check` green locally.