### PR TITLE
docs: note to avoid launchd agent for local pi-web dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,10 @@ make e2e        # build binary + run Playwright E2E (not part of test/check)
 
 **Critical:** `go build ./cmd/pi-web` requires `web/dist` to exist first because of `//go:embed`. Always run `make build`, never `go build` alone.
 
+### Local development — do NOT rely on a launchd agent
+
+For development, start pi-web with `make dev` (Vite watcher + Go hot-reload) or run the freshly built `./pi-web` binary directly. Do **not** depend on a macOS LaunchAgent (e.g. `~/Library/LaunchAgents/com.pi-web.plist`) to run it — a `KeepAlive` agent pins port `31415` to the installed `~/.pi/agent/bin/pi-web` binary and will auto-respawn the old build, masking your local changes. If such an agent exists, unload it (`launchctl bootout gui/$(id -u)/com.pi-web`) and remove the plist before developing.
+
 ## Testing
 
 - **Go:** Table-driven tests in `*_test.go` alongside source
@@ -106,4 +110,3 @@ make e2e        # build binary + run Playwright E2E (not part of test/check)
 4. **One worker per session.** Reused for subsequent messages. Crashed = evicted + replaced. Idle workers reaped after 10 min.
 5. **SSE topics:** `globalSessID = "__all__"` for index-wide events; session ID for per-session events.
 6. **Default port:** `31415`. State file: `~/.pi/agent/pi-web/pi-web-state.json`.
-


### PR DESCRIPTION
## Summary

- Adds a **Local Development** section to `AGENTS.md` warning contributors about macOS LaunchAgent interference.
- A `KeepAlive` launchd agent pins port `31415` to the installed binary and auto-respawns it, masking local build changes.
- The note includes the exact `launchctl bootout` command to unload the agent so developers can spot and disable it.

## Related issue

N/A — standalone docs improvement.

## Type of change

- [x] `docs` — documentation only

## Live vs. Export

- [x] Not applicable — this PR doesn't touch session rendering

## Testing

- [ ] `make check` passes (test + build + vet)
- [ ] Frontend tests (`vitest`) cover the change
- [ ] Go tests (`go test ./...`) cover the change
- [ ] UI changes verified in a browser
