### PR TITLE
docs+test: refresh architecture docs and cover share package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Before making structural changes, read the relevant doc in `docs/`:
 | Working on artifacts | `docs/sequence-flows/artifacts.md` |
 | Working on annotations | `docs/sequence-flows/annotations.md` |
 | Working on the @mention path autocomplete | `docs/sequence-flows/mention-autocomplete.md` |
+| Working on btw floating scratch-chats | `docs/sequence-flows/btw.md` |
 | Working on export/share | `docs/sequence-flows/share.md` |
 | Working on the worker metrics dashboard | `docs/dev/metrics-dashboard.md` |
 | Writing or debugging E2E / browser tests | `docs/dev/e2e-testing.md` |
@@ -33,11 +34,19 @@ The most important doc for frontend work is **`docs/dev/templates-vs-web.md`**. 
 ### Backend (`internal/`)
 | Package | Purpose |
 |---------|---------|
-| `server` | HTTP handlers, SSE plumbing, file watcher, chat orchestration |
-| `sessions` | JSONL parsing, caching, lookup by ID |
+| `server` | HTTP handlers, SSE plumbing, file watcher, chat orchestration (incl. btw scratch-chats, auto-titling, metrics, push) |
+| `sessions` | JSONL parsing, caching, lookup by ID, new-session/fork/clone creation |
 | `auth` | Token middleware (`Authorization: Bearer`, `X-Pi-Token`, `?token=` cookie) |
 | `workers` | Per-session `pi --mode rpc` lifecycle (spawn, reuse, reap, crash recovery) |
 | `rpc` | Subprocess wrapper + streaming previews |
+| `share` | Export a session to a private GitHub Gist via the `gh` CLI (`Runner` interface) |
+| `git` | Low-level git queries used by `/api/git/*` (branch info, rename) |
+| `files` | Bounded filesystem walk backing the `@mention` autocomplete (`GET /api/files`) |
+| `updater` | Self-update version/changelog checks (powers `/api/version`, `/api/check-update`) |
+| `render` | Tiny shared HTTP/render helpers (Vite manifest lookup, JSON responses) |
+| `frontend` | Vite output embedding + manifest parsing + static asset serving |
+| `agentdir` | Resolves the `~/.pi/agent` base directory |
+| `ui` | Live SPA shell + export-snapshot rendering (see Key Files) |
 
 ### Frontend
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -9,14 +9,13 @@ pi-web is a local HTTP server that lets you browse and interact with your pi cod
 | Layer | Technology |
 |-------|------------|
 | Backend | Go 1.25+ |
-| Frontend (index) | Vite + vanilla JS |
-| Frontend (session) | Vite + vanilla JS (Go renders only the HTML shell + initial data) |
-| Static export | Go `html/template` + inlined JS/CSS (self-contained Gist) |
+| Frontend (live app) | Svelte 5 SPA (`web/src/main.js` → `App.svelte`) over vanilla-JS runtime modules, built by Vite; Go serves a single embedded shell (`internal/ui/embedded/app.html`) + injects bootstrap data |
+| Static export | Go `html/template` (`internal/ui/embedded/session.html`) + inlined `export.js`/CSS, built from the same `web/src/session/` modules (self-contained Gist) |
 | Styling | Custom CSS (multi-theme: dark/light/nord/dracula/custom) |
 | Live Updates | Server-Sent Events (SSE) |
 | Chat RPC | JSONL over stdin/stdout via `pi --mode rpc` |
 | Session Storage | JSONL files on disk; pi-web creates new session files and appends `session_info` for browser rename |
-| Local DB | SQLite (`~/.pi/agent/pi-web.sqlite`) for per-project scratchpads, per-session review annotations, project visibility prefs, and server-backed user settings |
+| Local DB | SQLite (`~/.pi/agent/pi-web.sqlite`) for per-project scratchpads, per-session review annotations, project visibility prefs, server-backed user settings, and the btw scratch-chat registry |
 | Auth | Token cookie/query/header (optional on localhost) |
 
 ## Component Diagram
@@ -25,16 +24,17 @@ pi-web is a local HTTP server that lets you browse and interact with your pi cod
 ┌──────────────────────────────────────────────────────────────────────────┐
 │                                 Browser                                   │
 │                                                                           │
-│   ┌─────────────┐      ┌─────────────┐      ┌─────────────────────────┐  │
-│   │ Index Page  │      │ Session Page│      │   EventSource Client    │  │
-│   │  /index.js  │      │  (embedded) │      │      /events?id=…       │  │
-│   │  vanilla JS │      │  marked.js  │      │                         │  │
-│   │  highlight  │      │  highlight  │      │  • reload (session)     │  │
-│   │             │      │  chat UI    │      │  • new-session (index)  │  │
-│   │  Search     │      │  Share btn  │      │  • status-delta         │  │
-│   │  New Sess   │      │  Model sel  │      │  • status-snapshot      │  │
-│   │  Run badges │      │  Thinking   │      │                         │  │
-│   └─────────────┘      └─────────────┘      └─────────────────────────┘  │
+│   ┌──────────────────────────────────────┐  ┌─────────────────────────┐  │
+│   │        Svelte 5 SPA (#spa-root)       │  │   EventSource Client    │  │
+│   │  main.js → App.svelte (path router)   │  │      /events?id=…       │  │
+│   │                                       │  │                         │  │
+│   │  / → SessionsPage    (index runtime)  │  │  • reload (session)     │  │
+│   │  /session → SessionPage (viewer +     │  │  • new-session (index)  │  │
+│   │     chat, marked.js, highlight)       │  │  • status-delta         │  │
+│   │  /settings → SettingsPage             │  │  • status-snapshot      │  │
+│   │  /login → LoginPage                   │  │  • annotations, btw…    │  │
+│   │  delegates to web/src/{session,index} │  │                         │  │
+│   └──────────────────────────────────────┘  └─────────────────────────┘  │
 └──────────────────────────────────────────────────────────────────────────┘
                                     │
                                     │ HTTP
@@ -53,8 +53,12 @@ pi-web is a local HTTP server that lets you browse and interact with your pi cod
 │   POST /api/set-thinking-level → handleSetThinkingLevel                  │
 │   POST /api/new-session / fork-session / clone-session                   │
 │   POST /api/rename-session → handleRenameSession                         │
+│   POST /api/label-session → handleLabelSessionEntry                      │
 │   GET  /api/models    →  handleAvailableModels                           │
+│   GET  /api/commands  →  handleCommands       (slash-command palette)    │
 │   GET  /api/worker-status → handleWorkerStatus                           │
+│   GET  /api/btw / POST /api/btw/new → btw scratch-chats (SQLite, SSE)    │
+│   GET  /api/files     →  handleApiFiles       (@mention autocomplete)    │
 │   GET  /api/git/info  / POST /api/git/rename-branch                      │
 │   GET/POST /api/scratchpad → scratchpad (SQLite)                         │
 │   GET/POST/DELETE /api/annotations → review annotations (SQLite, SSE)    │
@@ -67,6 +71,7 @@ pi-web is a local HTTP server that lets you browse and interact with your pi cod
 │   GET  /custom-themes.css → handleCustomThemes                           │
 │   /api/push/{vapid,subscribe,unsubscribe}  (web-push, optional)         │
 │   /api/{version,check-update,update,restart} (self-update, optional)    │
+│   GET  /metrics / /api/metrics → worker metrics dashboard (gopsutil)    │
 │   PWA: /manifest.webmanifest, /sw.js, /icon.svg, /cat.webm, …           │
 │   GET  /static/…      →  embedded Vite assets                            │
 │                                                                           │
@@ -131,7 +136,7 @@ name, while pi-web itself continues listening only on localhost.
 ├── session-status/
 │   ├── 2026-01-15T10-30-00.000Z_a1b2c3d4.jsonl   ← terminal writes here
 │   └── …
-├── pi-web.sqlite           ← scratchpads + annotations + project visibility prefs + user settings
+├── pi-web.sqlite           ← scratchpads + annotations + project visibility prefs + user settings + btw registry
 └── pi-web/
     ├── pi-web-state.json   ← server state file
     ├── custom-themes.css   ← optional user custom theme

--- a/docs/sequence-flows/README.md
+++ b/docs/sequence-flows/README.md
@@ -11,4 +11,5 @@ This directory documents the key runtime sequences in pi-web.
 | [artifacts.md](./artifacts.md) | Detecting (path-keyed/edit-aware), rendering, and sandbox-previewing artifacts |
 | [annotations.md](./annotations.md) | Anchoring, persisting, syncing, and sending review notes |
 | [mention-autocomplete.md](./mention-autocomplete.md) | `@`-triggered file/folder path autocomplete in the chat composer |
+| [btw.md](./btw.md) | Throwaway "btw" floating scratch-chats attached to a session page |
 | [share.md](./share.md) | Exporting a session to a private GitHub Gist |

--- a/docs/sequence-flows/btw.md
+++ b/docs/sequence-flows/btw.md
@@ -1,0 +1,86 @@
+# Sequence Flow: btw scratch-chats
+
+A **btw** ("by the way") is a throwaway, floating chat window attached to a
+session page. It lets you start a quick side conversation with a fresh `pi`
+worker without leaving — or disturbing — the session you're reading. Each btw is
+backed by a real session file on disk, but it is registered in a separate table
+so it can be **hidden from the index** and **reaped when its parent disappears**.
+
+Backend: `internal/server/btw.go`. Frontend: `web/src/session/` btw window (user
+strings under the `btw.*` / `settings.showBtw*` keys in
+`web/src/shared/locales/en.js`).
+
+## Data model
+
+btw chats live in their own SQLite table (created in `server.New`):
+
+```sql
+CREATE TABLE IF NOT EXISTS btw_sessions (
+    btw_id    TEXT PRIMARY KEY,
+    parent_id TEXT NOT NULL,
+    active    INTEGER NOT NULL DEFAULT 1
+)
+```
+
+- **One active btw per parent.** Each parent session page has at most one
+  `active=1` btw. Pressing **new** orphans the previous one (`active=0`) but keeps
+  the row and the file on disk, so orphaned btws stay identifiable and hideable
+  for their whole lifetime.
+- **`parent_id`** is the session the btw was opened from. A btw opened with no
+  parent uses the `__global__` sentinel (`btwGlobalParent`) — the slot the legacy
+  single global btw migrates into.
+- **Legacy migration** (`migrateLegacyBtwSession`): the old single-row
+  `app_settings` pointer (`btw_session_id`) is moved into `btw_sessions` under
+  `__global__` on startup, then the legacy key is deleted. Idempotent.
+
+## Open / resume: `GET /api/btw?parent=<id>`
+
+`handleGetBtw` returns the active btw id for a parent, or `""` (empty state):
+
+1. Look up the `active=1` row for the (normalized) parent.
+2. If an id is found but its **session file no longer exists**, delete the
+   registry row, broadcast `btw-changed` with an empty id, and return `""` so the
+   client falls back to its empty state.
+3. Respond `{"sessionId": id}`.
+
+## New: `POST /api/btw/new`
+
+`handleNewBtw` body: `{ "path": "<cwd>", "parent": "<parent session id>" }`.
+
+1. Default `path` to the user's home directory when omitted.
+2. `CreateSessionFileWithSettings` writes a fresh JSONL session file.
+3. `setBtwSessionID(parent, id)` records it as the active btw for that parent,
+   **orphaning the prior active btw** in a single transaction (`active=0` for the
+   parent, then upsert the new row `active=1`).
+4. On a real change, **broadcast `btw-changed`** (`{sessionId}`) on the parent's
+   SSE topic so other devices viewing that page re-sync in realtime.
+5. Pre-warm a `pi --mode rpc` worker (mirrors `handleNewSession`) so the first
+   message lands quickly.
+6. Respond `{"ok": true, "id": id}`.
+
+From here, chatting in the btw window uses the normal chat path
+(`POST /api/chat`, see [chat.md](./chat.md)) against the btw's session id — a btw
+is an ordinary session as far as the worker is concerned.
+
+## Index hiding
+
+btw chats are **hidden from the sessions list by default**:
+
+- `showBtwInIndex()` reads the `pi-web:v1:show-btw-in-index` setting (default
+  `false`; toggled on the `/settings` page — `settings.showBtw`).
+- `filterBtwSummaries(...)` drops every id in `btwSessionIDs()` (all btws, active
+  or orphaned) from the list unless showing is enabled. Applied server-side in the
+  index/sessions handlers, so there is no client flash.
+
+## Reaping orphans
+
+`reapOrphanedBtw(all)` keeps btws from outliving their parent. Given the full,
+unfiltered session list it deletes — **both the registry row and the session
+file** — every btw whose `parent_id` is neither `__global__` nor a still-existing
+session. The `__global__` sentinel parent is never reaped.
+
+## SSE
+
+| Event | Topic | Payload | Meaning |
+|-------|-------|---------|---------|
+| `btw-changed` | parent session id (or `__global__`) | `{"sessionId": "<id or empty>"}` | The active btw for this parent changed (created, switched, or cleared). Windows opened from that page re-sync; empty id means "no btw". |

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -1,0 +1,260 @@
+package share
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"pi-web/internal/sessions"
+)
+
+// fakeRunner is a configurable Runner stub: it records the html path it was
+// handed and returns canned auth/gist results so Handle can be exercised
+// without a real gh binary or network.
+type fakeRunner struct {
+	authErr     error
+	gistStdout  string
+	gistStderr  string
+	gistErr     error
+	gotHTMLPath string
+}
+
+func (f *fakeRunner) AuthStatus() error { return f.authErr }
+
+func (f *fakeRunner) CreateGist(htmlPath string) (string, string, error) {
+	f.gotHTMLPath = htmlPath
+	return f.gistStdout, f.gistStderr, f.gistErr
+}
+
+// baseDeps returns Dependencies that resolve any id to a fixed session and
+// render a recognizable HTML body. Individual tests override fields as needed.
+func baseDeps(runner Runner) Dependencies {
+	return Dependencies{
+		Runner: runner,
+		Resolve: func(id string) (sessions.Session, error) {
+			return sessions.Session{}, nil
+		},
+		RenderExport: func(sessions.Session, string) string {
+			return "<html>exported</html>"
+		},
+	}
+}
+
+func TestHandlePreviewReturnsHTML(t *testing.T) {
+	deps := baseDeps(nil) // preview must not need a runner
+	deps.RenderExport = func(_ sessions.Session, theme string) string {
+		return "<html>theme=" + theme + "</html>"
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/share?id=abc&preview=1", nil)
+	req.AddCookie(&http.Cookie{Name: "pi-web-theme", Value: "nord"})
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, deps)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("content-type = %q, want text/html", ct)
+	}
+	if body := rec.Body.String(); body != "<html>theme=nord</html>" {
+		t.Fatalf("body = %q; want themed export html", body)
+	}
+}
+
+func TestHandlePreviewRejectsNonGet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/share?id=abc&preview=1", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, baseDeps(nil))
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestHandlePreviewMissingID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/share?preview=1", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, baseDeps(nil))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleRejectsNonPost(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/share?id=abc", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, baseDeps(&fakeRunner{}))
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestHandleMissingID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/share", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, baseDeps(&fakeRunner{}))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleGhNotInstalled(t *testing.T) {
+	deps := baseDeps(nil) // nil runner forces the FindGh path
+	deps.FindGh = func() string { return "" }
+
+	req := httptest.NewRequest(http.MethodPost, "/share?id=abc", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, deps)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "gh") {
+		t.Fatalf("body = %q; want a gh-not-installed message", rec.Body.String())
+	}
+}
+
+func TestHandleAuthFailure(t *testing.T) {
+	runner := &fakeRunner{authErr: errors.New("not logged in")}
+
+	req := httptest.NewRequest(http.MethodPost, "/share?id=abc", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, baseDeps(runner))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "auth login") {
+		t.Fatalf("body = %q; want a gh-auth-login hint", rec.Body.String())
+	}
+}
+
+func TestHandleResolveFailure(t *testing.T) {
+	deps := baseDeps(&fakeRunner{})
+	deps.Resolve = func(id string) (sessions.Session, error) {
+		return sessions.Session{}, errors.New("nope")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/share?id=missing", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, deps)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleEmptyExportIsNotFound(t *testing.T) {
+	deps := baseDeps(&fakeRunner{})
+	deps.RenderExport = func(sessions.Session, string) string { return "" }
+
+	req := httptest.NewRequest(http.MethodPost, "/share?id=abc", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, deps)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleGistFailureReportsStderr(t *testing.T) {
+	runner := &fakeRunner{gistErr: errors.New("boom"), gistStderr: "gh: rate limited"}
+
+	req := httptest.NewRequest(http.MethodPost, "/share?id=abc", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, baseDeps(runner))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "rate limited") {
+		t.Fatalf("body = %q; want surfaced stderr", rec.Body.String())
+	}
+}
+
+func TestHandleSuccess(t *testing.T) {
+	runner := &fakeRunner{gistStdout: "https://gist.github.com/user/deadbeef\n"}
+	deps := baseDeps(runner)
+	deps.RenderExport = func(sessions.Session, string) string { return "<html>snapshot</html>" }
+
+	req := httptest.NewRequest(http.MethodPost, "/share?id=abc", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, deps)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`"gistUrl":"https://gist.github.com/user/deadbeef"`,
+		`"gistId":"deadbeef"`,
+		`"previewUrl":"https://pi.dev/session/#deadbeef"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body = %q; missing %q", body, want)
+		}
+	}
+
+	// The runner should have been handed a real temp file containing the
+	// rendered snapshot.
+	if runner.gotHTMLPath == "" {
+		t.Fatal("CreateGist never received an html path")
+	}
+	if filepath.Base(runner.gotHTMLPath) != "session.html" {
+		t.Fatalf("html path = %q; want a session.html file", runner.gotHTMLPath)
+	}
+}
+
+func TestHandleDefaultsThemeWithoutCookie(t *testing.T) {
+	var gotTheme string
+	deps := baseDeps(&fakeRunner{gistStdout: "https://gist.github.com/u/abc"})
+	deps.RenderExport = func(_ sessions.Session, theme string) string {
+		gotTheme = theme
+		return "<html>x</html>"
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/share?id=abc", nil)
+	rec := httptest.NewRecorder()
+
+	Handle(rec, req, deps)
+
+	if gotTheme != "dark" {
+		t.Fatalf("theme = %q; want dark default", gotTheme)
+	}
+}
+
+func TestFindGhPrefersLocalBinary(t *testing.T) {
+	// FindGh checks a fixed list of absolute paths before falling back to
+	// PATH lookup. We can't write to those, but we can assert the fallback:
+	// with an empty PATH and no candidates present, it returns "".
+	t.Setenv("PATH", "")
+	if got := FindGh(); got != "" {
+		// A real /usr/bin/gh etc. may exist on the host; only assert when the
+		// well-known candidates are genuinely absent.
+		for _, c := range []string{"/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh", "/bin/gh"} {
+			if _, err := os.Stat(c); err == nil {
+				return // a candidate legitimately exists; nothing to assert
+			}
+		}
+		t.Fatalf("FindGh = %q; want empty when no gh on PATH or known paths", got)
+	}
+}


### PR DESCRIPTION
- system-overview.md: replace stale "vanilla JS" frontend description
  with the Svelte 5 SPA; add btw/label-session/commands/files/metrics
  routes and the btw SQLite registry to the diagrams/tables.
- Document the btw scratch-chat subsystem (docs/sequence-flows/btw.md)
  and link it from AGENTS.md + the sequence-flows index.
- AGENTS.md backend table: add the previously-undocumented packages
  (share, git, files, updater, render, frontend, agentdir, ui).
- Add internal/share tests via the Runner interface (preview, method/
  id validation, gh-missing, auth failure, resolve/empty-export, gist
  failure, success, theme default) — 0% -> 79% coverage.