### PR TITLE
feat(chat): one-click /compact button + ⌘⇧K shortcut in context popover

### DIFF
--- a/e2e/tests/compact.spec.ts
+++ b/e2e/tests/compact.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, collapseScratchpad, isMobileLayout } from "../lib/test";
+import {
+  buildSession,
+  realWorkingDir,
+  uniqueSessionName,
+  writeSession,
+} from "../lib/sessions";
+
+// /compact is triggered from the context-usage popover (and Cmd/Ctrl+Shift+K).
+// It is sent as a plain chat message down the same POST /api/chat -> worker path
+// as any prompt, so the worker emits agent_end and the chat does not hang. The
+// stub pi treats "/compact" as an ordinary prompt and echoes "Stub reply: ...".
+test.describe("compact (stubbed pi)", () => {
+  test("popover button sends /compact and the chat completes", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const cwd = realWorkingDir();
+    const { entries } = buildSession({ cwd });
+    // Attach usage to the assistant reply so the context-usage capsule renders.
+    const assistant = entries.find(
+      (e: any) => e?.message?.role === "assistant",
+    ) as any;
+    assistant.message.usage = {
+      input: 1331,
+      output: 220,
+      cacheRead: 6144,
+      cacheWrite: 0,
+      totalTokens: 7695,
+    };
+    const name = uniqueSessionName(testInfo, "compact");
+    const id = writeSession(sessionsDir, name, entries);
+
+    await collapseScratchpad(page);
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+
+    const composer = page.locator("#pi-chat-composer");
+    await expect(composer).toHaveAttribute("data-chat-available", "true");
+
+    // /compact is disabled while the worker is "running" (incl. the initial
+    // warm-up). Wait for idle — Cancel is shown only while running — first.
+    await expect(page.locator("#pi-chat-cancel")).toBeHidden({ timeout: 20000 });
+
+    // Open the context popover and click the compact button.
+    const capsule = page.locator("#pi-chat-context-usage");
+    await expect(capsule).toBeVisible();
+    const popover = page.locator("#pi-chat-context-popover");
+    await capsule.click();
+    await expect(popover).toBeVisible();
+
+    const compactBtn = page.locator("#pi-chat-compact");
+    await expect(compactBtn).toBeVisible();
+    await compactBtn.click();
+
+    // The popover closes on trigger, the stub reply lands (no hang), and the
+    // worker returns to idle — the Cancel button (shown only while running)
+    // disappears, proving the chat completed instead of hanging.
+    await expect(popover).toBeHidden();
+    await expect(page.locator("#messages")).toContainText("Stub reply: /compact", {
+      timeout: 20000,
+    });
+    await expect(page.locator("#pi-chat-cancel")).toBeHidden({ timeout: 20000 });
+  });
+
+  test("Cmd/Ctrl+Shift+K sends /compact while preserving the draft path", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const cwd = realWorkingDir();
+    const { entries } = buildSession({ cwd });
+    const name = uniqueSessionName(testInfo, "compact-kbd");
+    const id = writeSession(sessionsDir, name, entries);
+
+    await collapseScratchpad(page);
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+
+    test.skip(await isMobileLayout(page), "keyboard shortcut is desktop-only");
+
+    const composer = page.locator("#pi-chat-composer");
+    await expect(composer).toHaveAttribute("data-chat-available", "true");
+
+    // /compact is guarded against firing while the worker is "running" (e.g. the
+    // initial worker warm-up after load). Wait for idle — the Cancel button is
+    // shown only while running — to mirror a real user compacting a settled chat.
+    await expect(page.locator("#pi-chat-cancel")).toBeHidden({ timeout: 20000 });
+
+    const textarea = page.locator("#pi-chat-message");
+    await textarea.click();
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+    await textarea.press(`${modifier}+Shift+KeyK`);
+
+    await expect(page.locator("#messages")).toContainText("Stub reply: /compact", {
+      timeout: 20000,
+    });
+  });
+});

--- a/internal/ui/embedded/styles/session.css
+++ b/internal/ui/embedded/styles/session.css
@@ -5307,6 +5307,56 @@
       color: var(--error, #cc6666);
     }
 
+    .pi-popover-compact {
+      width: 100%;
+      margin-top: 10px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 7px 9px;
+      border-radius: 7px;
+      background: var(--surface-2);
+      color: var(--text);
+      border: 1px solid color-mix(in srgb, var(--dim) 40%, transparent);
+      cursor: pointer;
+      font-size: 11px;
+      font-weight: 600;
+    }
+
+    .pi-popover-compact:hover {
+      border-color: var(--accent);
+    }
+
+    .pi-popover-compact:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    .pi-chat-context-popover.warning .pi-popover-compact {
+      border-color: color-mix(in srgb, var(--warning, #f0c674) 50%, transparent);
+      color: var(--warning, #f0c674);
+    }
+
+    .pi-chat-context-popover.danger .pi-popover-compact {
+      border-color: color-mix(in srgb, var(--error, #cc6666) 55%, transparent);
+      background: color-mix(in srgb, var(--error, #cc6666) 12%, var(--surface-2));
+      color: var(--error, #cc6666);
+    }
+
+    .pi-popover-compact .pi-compact-kbd {
+      margin-left: auto;
+      display: inline-flex;
+      gap: 2px;
+      opacity: 0.7;
+    }
+
+    .pi-popover-compact .pi-compact-kbd kbd {
+      font-size: 9px;
+      padding: 1px 3px;
+      border-radius: 3px;
+      background: color-mix(in srgb, var(--dim) 25%, transparent);
+    }
+
     /* ===================================================================
        Cat Gatekeeper — focus/break + bedtime overlay (live app only).
        The overlay DOM is created by web/src/session/cat-gatekeeper/.

--- a/web/src/components/session/ChatComposer.svelte
+++ b/web/src/components/session/ChatComposer.svelte
@@ -688,6 +688,12 @@ export function runChatComposer({
           _thinkingSelectorApi.cycle();
         }
       }
+      // Cmd/Ctrl+Shift+K: compact context (/compact)
+      if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        triggerCompact();
+        return;
+      }
       // Ctrl+I or Ctrl+L: open model selector, focus returns to textarea after selection
       if (event.ctrlKey && (event.key.toLowerCase() === 'i' || event.key.toLowerCase() === 'l')) {
         event.preventDefault();
@@ -762,6 +768,18 @@ export function runChatComposer({
         sendButton.disabled = false;
         updateSendEnabled();
       }
+    }
+
+    // Trigger /compact as a plain chat message: it travels the same
+    // POST /api/chat → worker.Prompt path as any prompt, so the worker emits
+    // agent_end normally (unlike extension commands, which would hang the chat).
+    // Sent directly instead of via the slash palette so the user's draft in the
+    // textarea is preserved.
+    async function triggerCompact() {
+      if (lastWorkerState === 'running') return;
+      const popover = document.getElementById('pi-chat-context-popover');
+      if (popover) popover.style.display = 'none';
+      await sendChatMessage('/compact', []);
     }
 
     form.addEventListener('submit', async (event) => {
@@ -884,6 +902,8 @@ export function runChatComposer({
           } catch (_) {}
         }
         if (data.state) lastWorkerState = data.state;
+        const compactBtn = document.getElementById('pi-chat-compact');
+        if (compactBtn) compactBtn.disabled = lastWorkerState === 'running';
         setModelLabel(knownModelLabel);
         setThinkingLabel(knownThinkingLevel);
         updateContextUsage();
@@ -994,6 +1014,8 @@ export function runChatComposer({
       popover.addEventListener('click', (e) => {
         if (e.target.closest('.pi-popover-close')) {
           popover.style.display = 'none';
+        } else if (e.target.closest('#pi-chat-compact')) {
+          triggerCompact();
         }
         e.stopPropagation();
       });
@@ -2044,6 +2066,10 @@ export function setupMentionAutocomplete({
             <span class="pi-row-value" id="pi-popover-val-total">0</span>
           </div>
         </div>
+        <button type="button" id="pi-chat-compact" class="pi-popover-compact" title={t('composer.compact')}>
+          <span class="pi-compact-label">{t('composer.compactLabel')}</span>
+          <span class="pi-compact-kbd"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>K</kbd></span>
+        </button>
       </div>
     </div>
   </div>

--- a/web/src/components/session/ChatComposer.test.js
+++ b/web/src/components/session/ChatComposer.test.js
@@ -586,4 +586,75 @@ describe('chat composer runner', () => {
     const popover = dom.window.document.getElementById('pi-chat-context-popover');
     expect(popover.querySelector('.pi-popover-limit').textContent).toBe('1.2M'); // 1,234,567 formats to 1.2M
   });
+
+  // /compact: triggered from the context popover button + Cmd/Ctrl+Shift+K, sent
+  // as a plain chat message so the worker emits agent_end normally (no hang).
+  const compactDom = () => new JSDOM('<body><form id="pi-chat-composer" data-chat-available="true" data-session-id="s1"><div class="pi-chat-shell"><textarea id="pi-chat-message"></textarea><input id="pi-chat-images"><button id="pi-chat-attach"></button><div id="pi-chat-attachments"></div><button id="pi-chat-send"></button><span id="pi-chat-status"></span><button id="pi-chat-model-label"></button><div id="pi-chat-context-usage" style="display:none"><svg class="pi-context-circle"><path class="pi-context-fill" stroke-dasharray="0, 100"></path></svg><span class="pi-context-text">0%</span></div><div id="pi-chat-context-popover" style="display:block"><button type="button" id="pi-chat-compact"><span class="pi-compact-label">Compact context</span></button></div></div></form></body>');
+
+  const runCompact = (dom, { sendChat, state = 'idle' }) => {
+    runChatComposer({
+      documentImpl: dom.window.document,
+      windowImpl: dom.window,
+      chatApi: {
+        getWorkerStatus: () => Promise.resolve(new Response(JSON.stringify({ state }), { status: 200 })),
+        sendChat
+      },
+      chatSelectors: { THINKING_LEVELS: [] },
+      modelSelector: { setupModelSelector: vi.fn(() => ({ open: vi.fn() })) },
+      thinkingSelector: { setupThinkingLevelSelector: vi.fn(() => ({ cycle: vi.fn() })) },
+      FormDataImpl: dom.window.FormData,
+      CustomEventImpl: dom.window.CustomEvent,
+      setIntervalImpl: () => {}
+    });
+    // No manual DOMContentLoaded dispatch: JSDOM fires it during the awaited
+    // tick below, so init runs exactly once (a manual dispatch would double it).
+  };
+
+  it('clicking the compact button sends /compact and closes the popover', async () => {
+    const tick = () => new Promise((r) => setTimeout(r, 0));
+    const dom = compactDom();
+    const sendChat = vi.fn(() => Promise.resolve(new Response('{"status":"queued"}', { status: 200 })));
+    runCompact(dom, { sendChat });
+    await tick();
+
+    dom.window.document.getElementById('pi-chat-compact').click();
+    await tick();
+
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expect(sendChat.mock.calls[0][1].get('message')).toBe('/compact');
+    expect(dom.window.document.getElementById('pi-chat-context-popover').style.display).toBe('none');
+  });
+
+  it('Cmd/Ctrl+Shift+K sends /compact without clearing the draft', async () => {
+    const tick = () => new Promise((r) => setTimeout(r, 0));
+    const dom = compactDom();
+    const sendChat = vi.fn(() => Promise.resolve(new Response('{"status":"queued"}', { status: 200 })));
+    runCompact(dom, { sendChat });
+    await tick();
+
+    const textarea = dom.window.document.getElementById('pi-chat-message');
+    textarea.value = 'my draft';
+    const event = new dom.window.KeyboardEvent('keydown', { key: 'K', ctrlKey: true, shiftKey: true, bubbles: true, cancelable: true });
+    textarea.dispatchEvent(event);
+    await tick();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expect(sendChat.mock.calls[0][1].get('message')).toBe('/compact');
+    expect(textarea.value).toBe('my draft');
+  });
+
+  it('does not send /compact while the worker is running', async () => {
+    const tick = () => new Promise((r) => setTimeout(r, 0));
+    const dom = compactDom();
+    const sendChat = vi.fn(() => Promise.resolve(new Response('{"status":"queued"}', { status: 200 })));
+    runCompact(dom, { sendChat, state: 'running' });
+    await tick();
+
+    dom.window.document.getElementById('pi-chat-compact').click();
+    await tick();
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(dom.window.document.getElementById('pi-chat-compact').disabled).toBe(true);
+  });
 });

--- a/web/src/components/session/ShortcutsModal.svelte
+++ b/web/src/components/session/ShortcutsModal.svelte
@@ -28,6 +28,7 @@
         { desc: t('shortcuts.focusInput'), keys: ['⇧', 'I'], keysWin: ['Shift', 'I'], note: t('shortcuts.noteOutsideInput') },
         { desc: t('shortcuts.cycleThinking'), keys: ['⇧', '⇥'], keysWin: ['Shift', 'Tab'], note: t('shortcuts.noteInsideInput') },
         { desc: t('shortcuts.switchModel'), keys: ['⌃', 'I'], keysWin: ['Ctrl', 'I'], note: t('shortcuts.noteInsideInput') },
+        { desc: t('shortcuts.compact'), keys: ['⌘', '⇧', 'K'], keysWin: ['Ctrl', 'Shift', 'K'], note: t('shortcuts.noteInsideInput') },
         { desc: t('shortcuts.submit'), keys: ['↩'], keysWin: ['Enter'], note: t('shortcuts.noteInsideInput') },
       ],
     },

--- a/web/src/shared/locales/en.js
+++ b/web/src/shared/locales/en.js
@@ -147,6 +147,8 @@ export default {
   'composer.cancelRunning': 'Cancel running response',
   'composer.contextDetails': 'Click for details',
   'composer.pathCopied': 'Path copied',
+  'composer.compact': 'Compact conversation context (/compact)',
+  'composer.compactLabel': 'Compact context',
 
   // ── Share / export ──
   'share.copiedSuffix': '{label} copied',
@@ -262,6 +264,7 @@ export default {
   'shortcuts.focusInput': 'Focus chat input',
   'shortcuts.cycleThinking': 'Cycle thinking mode',
   'shortcuts.switchModel': 'Choose/switch model',
+  'shortcuts.compact': 'Compact context (/compact)',
   'shortcuts.submit': 'Submit message',
   'shortcuts.scrollDown': 'Scroll down',
   'shortcuts.scrollUp': 'Scroll up',


### PR DESCRIPTION
## Summary

Makes `/compact` one-click triggerable from the web UI (issue #41):

- Adds a **"Compact context"** button at the bottom of the context-usage popover.
- Adds a composer-scoped keyboard shortcut **`⌘/Ctrl + ⇧ + K`**.
- Both send `/compact` as a **plain chat message** down the same `POST /api/chat` → `worker.Prompt` path as any prompt — **not** via the slash palette — so the worker emits `agent_end` normally and the user's textarea draft is preserved.
- Guarded against firing while the worker is `running` (incl. initial warm-up); the button disables in sync via the existing worker-status poll.
- Context ring/popover auto-fall-back is handled by the existing `pi-session-reload` path — no extra refresh logic.

### Why not the slash palette?
The palette filters out `extension` commands (they never emit `agent_end` and would hang the chat). `/compact` is a pi **built-in** command (verified: not present in `get_commands`, whose entries are only `extension` + `skill`), so sending it as a normal prompt follows the standard agent lifecycle and does **not** hang.

### Shortcut choice
`Ctrl+L` (originally suggested in the issue) is already bound to the model selector in `ChatComposer.svelte`, so `⌘/Ctrl+⇧+K` was used to avoid changing existing behavior.

## Changes
- `web/src/components/session/ChatComposer.svelte` — button markup, `triggerCompact()`, `⌘⇧K` keydown, popover click wiring, disable-on-running sync
- `internal/ui/embedded/styles/session.css` — button styles (hover/disabled, warning/danger emphasis)
- `web/src/shared/locales/en.js` — i18n strings (en is the universal fallback)
- `web/src/components/session/ShortcutsModal.svelte` — shortcut help entry
- `web/src/components/session/ChatComposer.test.js` — 3 vitest cases
- `e2e/tests/compact.spec.ts` — 2 Playwright cases

## Test plan
- [x] Vitest: click sends `/compact`; `⌘⇧K` sends and preserves draft; no send while worker running
- [x] Playwright (Desktop Chrome): popover button sends `/compact` and the chat completes (no hang); `⌘⇧K` sends `/compact`
- [x] `go vet` clean, `go test ./...` pass, `make build` succeeds
- [ ] Maintainer sanity check on a real pi worker