### PR TITLE
feat: client-side SPA navigation + session registry refactor

### DIFF
--- a/e2e/tests/cat.spec.ts
+++ b/e2e/tests/cat.spec.ts
@@ -30,6 +30,12 @@ test.describe("cat gatekeeper", () => {
               "pi-web:v1:cat:enabled": "true",
               "pi-web:v1:cat:focus-min": "25",
               "pi-web:v1:cat:break-min": "5",
+              // Equal bedtime/wakeup = zero-width sleep window, so the gatekeeper
+              // never enters bedtime mode. Otherwise a run during 23:00–07:00
+              // (the default window) shows the sleep overlay and skip-to-break,
+              // which only fires in the focus phase, can't open the break.
+              "pi-web:v1:cat:bedtime": "07:00",
+              "pi-web:v1:cat:wakeup": "07:00",
             },
           },
         });
@@ -40,6 +46,10 @@ test.describe("cat gatekeeper", () => {
     await page.addInitScript(() => {
       try {
         localStorage.setItem("pi-web:v1:cat:enabled", "true");
+        // Mirror the zero-width sleep window for the synchronous pre-hydration
+        // read so the controller's first tick never enters bedtime mode.
+        localStorage.setItem("pi-web:v1:cat:bedtime", "07:00");
+        localStorage.setItem("pi-web:v1:cat:wakeup", "07:00");
       } catch {
         /* ignore */
       }

--- a/e2e/tests/load-earlier.spec.ts
+++ b/e2e/tests/load-earlier.spec.ts
@@ -72,19 +72,30 @@ test.describe("load-earlier banner (large session pagination)", () => {
     await expect(page.locator("#messages")).not.toContainText(EARLY_MARKER);
 
     // Click through preceding windows until everything is loaded. The banner
-    // removes itself once `from` reaches 0 (load-earlier.js).
-    const button = banner.getByRole("button");
+    // re-enables its button between windows and removes itself once `from`
+    // reaches 0 (LoadEarlier.svelte). Playwright's click() auto-waits for the
+    // enabled state, so we don't assert it separately. We deliberately avoid a
+    // hard intermediate poll: under the full parallel matrix the synchronous
+    // re-render of the merged conversation can briefly jam the main thread and
+    // blow a fixed poll budget even though the load itself succeeded. The settle
+    // below is best-effort; only the final state (banner gone + earliest message
+    // rendered) is asserted, via auto-retrying locator assertions that absorb
+    // that jam.
     for (let i = 0; i < 6 && (await banner.count()) > 0; i += 1) {
-      await expect(button).toBeEnabled({ timeout: WINDOW_TIMEOUT });
-      await button.click();
-      // Either the banner is gone, or it re-enabled for the next window.
-      await expect
-        .poll(
-          async () =>
-            (await banner.count()) === 0 || (await button.isEnabled()),
+      await banner.getByRole("button").click();
+      // Wait for this window to settle (button re-enabled or banner detached)
+      // so the next iteration targets a ready control. Non-fatal — the final
+      // assertions are authoritative.
+      await page
+        .waitForFunction(
+          () => {
+            const b = document.querySelector("#load-earlier-banner");
+            const btn = b?.querySelector("button");
+            return !b || (btn != null && !(btn as HTMLButtonElement).disabled);
+          },
           { timeout: WINDOW_TIMEOUT },
         )
-        .toBe(true);
+        .catch(() => {});
     }
 
     await expect(page.locator("#load-earlier-banner")).toHaveCount(0, {

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -144,4 +144,39 @@ test.describe("settings page", () => {
 
     expect(flexDirection).toBe("column");
   });
+
+  // Regression: AppearanceSettings used to write $state while computing the font
+  // <select> value during render. With a custom font configured, that throws
+  // svelte state_unsafe_mutation when the component mounts during a client-side
+  // route swap (not a fresh page load), blanking the settings page. Direct loads
+  // happened to be safe, so this only reproduces via in-app navigation.
+  test("client-side nav to settings is safe with a custom font set", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (e) => errors.push(e.message));
+
+    // A custom font (not a builtin) must be the active value when AppearanceSettings
+    // mounts during the route swap — that's when its font-select renders inside an
+    // {#each} block effect, where the old code wrote $state. Serve it from settings
+    // hydration so the value survives (a localStorage-only seed gets overwritten by
+    // hydration before we navigate).
+    await page.route("**/api/settings", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({ json: { settings: { "pi-web:v1:font-ui": "Comic Sans MS" } } });
+      } else {
+        await route.fulfill({ json: { ok: true } });
+      }
+    });
+
+    await page.goto("/");
+    await expect(page.locator("[data-sessions-content]")).toBeVisible();
+
+    // Navigate to settings client-side (Cmd+,), not a full page load.
+    await page.keyboard.press("Meta+Comma");
+
+    // The swap must complete: the settings page renders instead of blanking, and
+    // no state_unsafe_mutation is thrown computing the font <select> value.
+    await expect(page).toHaveURL(/\/settings$/);
+    await expect(page.locator(".settings-page h1")).toHaveText("Settings");
+    expect(errors.filter((m) => /state_unsafe_mutation/.test(m))).toEqual([]);
+  });
 });

--- a/internal/server/chat_test.go
+++ b/internal/server/chat_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,33 +20,42 @@ import (
 )
 
 type fakeSender struct {
+	// Config fields below are set at construction (before the server starts any
+	// goroutine) and only read afterwards, so they need no locking.
+	state          workers.WorkerStatus
+	status         workers.WorkerStatus
+	getStateErr    error
+	ensureWorkerCh chan struct{}
+	sendCh         chan struct{}
+	commands       []workers.SlashCommand
+	commandsReady  bool
+	commandsErr    error
+
+	// mu guards every field below it. handleNewSession (and friends) initialize
+	// workers on a background goroutine, so the sender methods run concurrently
+	// with test assertions that read these fields.
+	mu                      sync.Mutex
 	sessionID               string
 	sessionPath             string
 	chat                    chat.Request
-	state                   workers.WorkerStatus
-	status                  workers.WorkerStatus
 	getStateCalls           int
-	getStateErr             error
 	ensureWorkerCalled      bool
 	ensureWorkerSessionID   string
 	ensureWorkerSessionPath string
-	ensureWorkerCh          chan struct{}
 	setModelSessionID       string
 	setModelProvider        string
 	setModelID              string
 	setThinkingSessionID    string
 	setThinkingLevel        string
-	sendCh                  chan struct{}
-	commands                []workers.SlashCommand
-	commandsReady           bool
-	commandsErr             error
 	getCommandsCalls        int
 }
 
 func (f *fakeSender) Send(ctx context.Context, sessionID, sessionPath string, chat chat.Request) error {
+	f.mu.Lock()
 	f.sessionID = sessionID
 	f.sessionPath = sessionPath
 	f.chat = chat
+	f.mu.Unlock()
 	if f.sendCh != nil {
 		f.sendCh <- struct{}{}
 	}
@@ -53,15 +63,19 @@ func (f *fakeSender) Send(ctx context.Context, sessionID, sessionPath string, ch
 }
 
 func (f *fakeSender) SetModel(ctx context.Context, sessionID, sessionPath, provider, modelID string) error {
+	f.mu.Lock()
 	f.setModelSessionID = sessionID
 	f.setModelProvider = provider
 	f.setModelID = modelID
+	f.mu.Unlock()
 	return nil
 }
 
 func (f *fakeSender) SetThinkingLevel(ctx context.Context, sessionID, sessionPath, level string) error {
+	f.mu.Lock()
 	f.setThinkingSessionID = sessionID
 	f.setThinkingLevel = level
+	f.mu.Unlock()
 	return nil
 }
 
@@ -70,7 +84,9 @@ func (f *fakeSender) Abort(ctx context.Context, sessionID string) error {
 }
 
 func (f *fakeSender) GetState(ctx context.Context, sessionID string) (workers.WorkerStatus, error) {
+	f.mu.Lock()
 	f.getStateCalls++
+	f.mu.Unlock()
 	if f.getStateErr != nil {
 		return workers.WorkerStatus{}, f.getStateErr
 	}
@@ -81,7 +97,9 @@ func (f *fakeSender) GetState(ctx context.Context, sessionID string) (workers.Wo
 }
 
 func (f *fakeSender) GetCommands(ctx context.Context, sessionID string) ([]workers.SlashCommand, bool, error) {
+	f.mu.Lock()
 	f.getCommandsCalls++
+	f.mu.Unlock()
 	return f.commands, f.commandsReady, f.commandsErr
 }
 
@@ -93,13 +111,48 @@ func (f *fakeSender) Status(sessionID string) workers.WorkerStatus {
 }
 
 func (f *fakeSender) EnsureWorker(ctx context.Context, sessionID, sessionPath string) error {
+	f.mu.Lock()
 	f.ensureWorkerCalled = true
 	f.ensureWorkerSessionID = sessionID
 	f.ensureWorkerSessionPath = sessionPath
+	f.mu.Unlock()
 	if f.ensureWorkerCh != nil {
 		f.ensureWorkerCh <- struct{}{}
 	}
 	return nil
+}
+
+// Accessors for the mutex-guarded fields, so tests read them safely from a
+// goroutine other than the one the sender method ran on.
+
+func (f *fakeSender) sentInfo() (sessionID, sessionPath string, req chat.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.sessionID, f.sessionPath, f.chat
+}
+
+func (f *fakeSender) stateCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.getStateCalls
+}
+
+func (f *fakeSender) ensureWorkerInfo() (called bool, sessionID, sessionPath string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ensureWorkerCalled, f.ensureWorkerSessionID, f.ensureWorkerSessionPath
+}
+
+func (f *fakeSender) modelSessionID() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.setModelSessionID
+}
+
+func (f *fakeSender) thinkingSessionID() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.setThinkingSessionID
 }
 
 func TestHandleChatQueuesResolvedSession(t *testing.T) {
@@ -130,8 +183,9 @@ func TestHandleChatQueuesResolvedSession(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Send was not called asynchronously")
 	}
-	if fake.sessionID != "session.jsonl" || fake.sessionPath != wantPath || fake.chat.Message != "hello" {
-		t.Fatalf("fake = %#v, want path %q", fake, wantPath)
+	sentID, sentPath, sentReq := fake.sentInfo()
+	if sentID != "session.jsonl" || sentPath != wantPath || sentReq.Message != "hello" {
+		t.Fatalf("sent id=%q path=%q msg=%q, want path %q", sentID, sentPath, sentReq.Message, wantPath)
 	}
 }
 
@@ -246,8 +300,8 @@ func TestHandleWorkerStatusSkipsGetStateWhenLocalStatusRunning(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d", w.Code)
 	}
-	if sender.getStateCalls != 0 {
-		t.Fatalf("GetState calls = %d, want 0", sender.getStateCalls)
+	if calls := sender.stateCalls(); calls != 0 {
+		t.Fatalf("GetState calls = %d, want 0", calls)
 	}
 	if got := w.Body.String(); got != "{\"state\":\"running\"}\n" {
 		t.Fatalf("body = %q", got)
@@ -322,7 +376,7 @@ func TestHandleCommandsReturnsWorkerCommands(t *testing.T) {
 	if len(body.Commands) != 1 || body.Commands[0].Name != "skill:memory" {
 		t.Fatalf("commands = %#v", body.Commands)
 	}
-	if sender.ensureWorkerCalled {
+	if called, _, _ := sender.ensureWorkerInfo(); called {
 		t.Fatalf("EnsureWorker called without ?load=1")
 	}
 }
@@ -353,7 +407,7 @@ func TestHandleCommandsLoadEnsuresWorker(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d", w.Code)
 	}
-	if !sender.ensureWorkerCalled {
+	if called, _, _ := sender.ensureWorkerInfo(); !called {
 		t.Fatalf("EnsureWorker not called for ?load=1")
 	}
 }
@@ -552,7 +606,7 @@ func TestHandleWorkerStatusDoesNotSpawnWorkerWhenModelUnknown(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d", w.Code)
 	}
-	if sender.ensureWorkerCalled {
+	if called, _, _ := sender.ensureWorkerInfo(); called {
 		t.Fatal("worker-status should not prewarm/create workers")
 	}
 }
@@ -587,10 +641,11 @@ func TestHandleNewSessionPreinitializesWorker(t *testing.T) {
 	// Verify EnsureWorker was called
 	select {
 	case <-fake.ensureWorkerCh:
-		if !fake.ensureWorkerCalled {
+		called, sessionID, _ := fake.ensureWorkerInfo()
+		if !called {
 			t.Fatal("EnsureWorker not marked as called")
 		}
-		if fake.ensureWorkerSessionID == "" {
+		if sessionID == "" {
 			t.Fatal("EnsureWorker called with empty sessionID")
 		}
 	case <-time.After(time.Second):
@@ -632,10 +687,11 @@ func TestHandleNewSessionCopiesSourceModelAndThinking(t *testing.T) {
 	}
 
 	waitForCondition(t, time.Second, func() bool {
-		return fake.ensureWorkerSessionID == id
+		_, sessionID, _ := fake.ensureWorkerInfo()
+		return sessionID == id
 	})
-	if fake.setModelSessionID != "" || fake.setThinkingSessionID != "" {
-		t.Fatalf("new session initialization should not append visible setting changes, got setModel=%q setThinking=%q", fake.setModelSessionID, fake.setThinkingSessionID)
+	if modelID, thinkingID := fake.modelSessionID(), fake.thinkingSessionID(); modelID != "" || thinkingID != "" {
+		t.Fatalf("new session initialization should not append visible setting changes, got setModel=%q setThinking=%q", modelID, thinkingID)
 	}
 	projectDir := filepath.Join(root, sessions.EncodeProjectName("/tmp/test-project"))
 	data, err := os.ReadFile(filepath.Join(projectDir, id))

--- a/internal/ui/mobile_sidebar_test.go
+++ b/internal/ui/mobile_sidebar_test.go
@@ -32,7 +32,7 @@ func TestMobileSidebarClosesWhenNavigatingTree(t *testing.T) {
 			t.Fatalf("sidebar.js missing %q; mobile sidebar can remain stuck over chat", check)
 		}
 	}
-	if !strings.Contains(string(liveTreeSrc), "__piCloseSidebar") {
+	if !strings.Contains(string(liveTreeSrc), "sessionRuntime.layout?.closeSidebar") {
 		t.Fatal("SessionTree.svelte missing mobile close-on-navigate; sidebar can remain stuck over chat")
 	}
 	if !strings.Contains(string(exportSrc), "ui.closeSidebar()") {

--- a/internal/ui/toggle_state_test.go
+++ b/internal/ui/toggle_state_test.go
@@ -35,7 +35,7 @@ func TestSessionToggleButtonsReflectPersistedActiveState(t *testing.T) {
 			"btn.classList.toggle('active', isActive);",
 			"btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');",
 		},
-		runnerSrc: {"windowImpl.sessionToggleState = toggleController;"},
+		runnerSrc: {"sessionRuntime.toggleState = toggleController;"},
 		headerSrc: {`data-action="toggle-tool-output"`, "show/hide thinking"},
 	}
 	for src, checks := range srcChecks {
@@ -78,7 +78,7 @@ func TestNavigationReappliesCurrentToggleStateAfterRenderingMessages(t *testing.
 		contentSrc: {"afterRender(containerEl)"},
 		runtimeSrc: {
 			"contentRuntime.afterRender =",
-			"target.applyToggleStateToNode?.(container)",
+			"sessionRuntime.toggleState?.applyToNode(container)",
 		},
 	}
 	for src, checks := range srcChecks {
@@ -103,7 +103,7 @@ func TestLiveReloadEntriesInheritCurrentToggleState(t *testing.T) {
 			"export function applyToggleStateToNode(node, state) {",
 			"const applyToNode = (node) => applyToggleStateToNode(node, state);",
 		},
-		runnerSrc: {"windowImpl.applyToggleStateToNode = (node) => toggleController.applyToNode(node);"},
+		runnerSrc: {"sessionRuntime.toggleState = toggleController;"},
 	}
 	for src, checks := range hookChecks {
 		for _, check := range checks {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -6,21 +6,32 @@
   import SettingsPage from './routes/SettingsPage.svelte';
   import VersionController from './components/shared/VersionController.svelte';
 
-  let { path: initialPath = typeof window !== 'undefined' ? window.location.pathname : '/' } = $props();
+  let {
+    path: initialPath = typeof window !== 'undefined' ? window.location.pathname : '/',
+    search: initialSearch = typeof window !== 'undefined' ? window.location.search : '',
+  } = $props();
 
-  // Reactive current route. Seeded from the prop (so prop-driven tests stay
+  // Reactive current route. Seeded from the props (so prop-driven tests stay
   // deterministic) and thereafter updated only by real navigation events, never
   // re-read on mount.
   let path = $state(untrack(() => initialPath));
+  let search = $state(untrack(() => initialSearch));
+
+  // The session route is keyed on this so a session→session navigation (same
+  // pathname, different ?id=) tears down and remounts <SessionPage>, which reads
+  // ?id= only at mount. Within-session navigation never changes the URL, so this
+  // stays stable while reading a session.
+  const sessionId = $derived(new URLSearchParams(search).get('id') || '');
 
   // Make in-app history navigation swap views without a full reload. popstate
   // covers back/forward; pushState/replaceState don't emit a native event, so
-  // we wrap them to dispatch one. We only re-read pathname (not the query) — a
-  // pushState that keeps the same pathname (e.g. FullScreenSheet's mobile
-  // back-button trap, or /session?id=… → different id) is intentionally a no-op
-  // here, matching the previous full-navigation behaviour.
+  // we wrap them to dispatch one. syncPath re-reads pathname + search: the
+  // pathname drives which page renders, and search drives the session-route
+  // {#key} so /session?id=A → ?id=B remounts <SessionPage>. A pushState that
+  // changes neither (e.g. FullScreenSheet's mobile back-button trap, which
+  // pushes the same URL) is a no-op.
   onMount(() => {
-    const syncPath = () => { path = window.location.pathname; };
+    const syncPath = () => { path = window.location.pathname; search = window.location.search; };
     const { history } = window;
     const wrap = (name) => {
       const original = history[name];
@@ -51,7 +62,9 @@
 {#if path === '/'}
   <SessionsPage />
 {:else if path === '/session'}
-  <SessionPage />
+  {#key sessionId}
+    <SessionPage />
+  {/key}
 {:else if path === '/settings'}
   <SettingsPage />
 {:else if path === '/login'}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,11 +1,51 @@
 <script>
+  import { onMount, untrack } from 'svelte';
   import LoginPage from './routes/LoginPage.svelte';
   import SessionsPage from './routes/SessionsPage.svelte';
   import SessionPage from './routes/SessionPage.svelte';
   import SettingsPage from './routes/SettingsPage.svelte';
   import VersionController from './components/shared/VersionController.svelte';
 
-  let { path = typeof window !== 'undefined' ? window.location.pathname : '/' } = $props();
+  let { path: initialPath = typeof window !== 'undefined' ? window.location.pathname : '/' } = $props();
+
+  // Reactive current route. Seeded from the prop (so prop-driven tests stay
+  // deterministic) and thereafter updated only by real navigation events, never
+  // re-read on mount.
+  let path = $state(untrack(() => initialPath));
+
+  // Make in-app history navigation swap views without a full reload. popstate
+  // covers back/forward; pushState/replaceState don't emit a native event, so
+  // we wrap them to dispatch one. We only re-read pathname (not the query) — a
+  // pushState that keeps the same pathname (e.g. FullScreenSheet's mobile
+  // back-button trap, or /session?id=… → different id) is intentionally a no-op
+  // here, matching the previous full-navigation behaviour.
+  onMount(() => {
+    const syncPath = () => { path = window.location.pathname; };
+    const { history } = window;
+    const wrap = (name) => {
+      const original = history[name];
+      if (typeof original !== 'function' || original.__piPatched) return original;
+      const patched = function (...args) {
+        const result = original.apply(this, args);
+        window.dispatchEvent(new window.CustomEvent('pi:locationchange'));
+        return result;
+      };
+      patched.__piPatched = true;
+      patched.__piOriginal = original;
+      history[name] = patched;
+      return original;
+    };
+    const originalPush = wrap('pushState');
+    const originalReplace = wrap('replaceState');
+    window.addEventListener('popstate', syncPath);
+    window.addEventListener('pi:locationchange', syncPath);
+    return () => {
+      window.removeEventListener('popstate', syncPath);
+      window.removeEventListener('pi:locationchange', syncPath);
+      if (history.pushState?.__piOriginal === originalPush) history.pushState = originalPush;
+      if (history.replaceState?.__piOriginal === originalReplace) history.replaceState = originalReplace;
+    };
+  });
 </script>
 
 {#if path === '/'}

--- a/web/src/App.test.js
+++ b/web/src/App.test.js
@@ -63,4 +63,49 @@ describe('App', () => {
 
     expect(document.querySelector('[aria-label="Svelte app probe"]')?.textContent).toContain('Svelte ready for pi-web');
   });
+
+  it('swaps views on pushState navigation', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    mounted = mountApp({ props: { path: '/' } });
+    flushSync(); // let onMount attach the history listeners
+    expect(document.querySelector('[data-sessions-content]')).toBeTruthy();
+
+    window.history.pushState({}, '', '/settings');
+    flushSync();
+
+    expect(document.querySelector('.settings-page h1')?.textContent).toBe('Settings');
+  });
+
+  it('swaps views on browser back/forward (popstate)', async () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    window.history.pushState({}, '', '/');
+    mounted = mountApp({ props: { path: '/' } });
+    flushSync(); // let onMount attach the history listeners
+
+    window.history.pushState({}, '', '/settings');
+    flushSync();
+    expect(document.querySelector('.settings-page')).toBeTruthy();
+
+    const popped = new Promise((resolve) => window.addEventListener('popstate', resolve, { once: true }));
+    window.history.back();
+    await popped;
+    flushSync();
+
+    expect(document.querySelector('[data-sessions-content]')).toBeTruthy();
+  });
+
+  it('does not swap when pushState keeps the same pathname', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    window.history.pushState({}, '', '/settings');
+    mounted = mountApp({ props: { path: '/settings' } });
+    flushSync(); // let onMount attach the history listeners
+    expect(document.querySelector('.settings-page')).toBeTruthy();
+
+    // Mirrors FullScreenSheet's mobile back-button trap: a pushState that keeps
+    // the pathname must not tear down and remount the current page.
+    window.history.pushState({}, '', '/settings?sheet=1');
+    flushSync();
+
+    expect(document.querySelector('.settings-page')).toBeTruthy();
+  });
 });

--- a/web/src/App.test.js
+++ b/web/src/App.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { flushSync, unmount } from 'svelte';
 import { mountApp } from './main.js';
 
@@ -107,5 +107,48 @@ describe('App', () => {
     flushSync();
 
     expect(document.querySelector('.settings-page')).toBeTruthy();
+  });
+
+  // SessionPage fetches /api/session?id=<id> as it mounts, so a fetch for the new
+  // id is a reliable "it remounted and loaded the new session" signal.
+  it('remounts SessionPage on session→session navigation (?id change)', () => {
+    const fetchSpy = vi.fn(() => Promise.reject(new Error('stub')));
+    const origFetch = window.fetch;
+    window.fetch = fetchSpy;
+    try {
+      document.body.innerHTML = '<div id="app"></div>';
+      window.history.pushState({}, '', '/session?id=A');
+      mounted = mountApp({ props: { path: '/session', search: '?id=A' } });
+      flushSync();
+      expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('id=A'))).toBe(true);
+
+      fetchSpy.mockClear();
+      window.history.pushState({}, '', '/session?id=B');
+      flushSync();
+      expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('id=B'))).toBe(true);
+    } finally {
+      window.fetch = origFetch;
+    }
+  });
+
+  it('does not remount SessionPage when the id is unchanged', () => {
+    const fetchSpy = vi.fn(() => Promise.reject(new Error('stub')));
+    const origFetch = window.fetch;
+    window.fetch = fetchSpy;
+    try {
+      document.body.innerHTML = '<div id="app"></div>';
+      window.history.pushState({}, '', '/session?id=A');
+      mounted = mountApp({ props: { path: '/session', search: '?id=A' } });
+      flushSync();
+
+      // A within-session URL change (non-id query param) must not tear down and
+      // reload the live session view.
+      fetchSpy.mockClear();
+      window.history.pushState({}, '', '/session?id=A&panel=tree');
+      flushSync();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      window.fetch = origFetch;
+    }
   });
 });

--- a/web/src/components/index/HomeMenu.svelte
+++ b/web/src/components/index/HomeMenu.svelte
@@ -2,6 +2,7 @@
   import { t } from '../../shared/i18n.js';
   import { icon, SquarePen, FolderGit2, BookOpen, Send, Settings, Tag } from '../../shared/icons.js';
   import { openVersionModal } from '../../shared/version.js';
+  import { handleNavClick } from '../../shared/navigation.js';
 
   let { open = false, onClose = () => {}, onNewSession = () => {}, onManageProjects = () => {} } = $props();
 
@@ -20,7 +21,7 @@
   <div class="web-menu-section">
     <a class="web-menu-item" href="https://github.com/ygncode/pi-web/tree/main/user-docs" target="_blank" rel="noreferrer" role="menuitem" onclick={onClose}><span class="menu-item-label">{@html icon(BookOpen, { size: 15 })}{t('common.userDocs')}</span></a>
     <a class="web-menu-item" href="https://t.me/+NJvFOTTa0wNjNTc9" target="_blank" rel="noreferrer" role="menuitem" onclick={onClose}><span class="menu-item-label">{@html icon(Send, { size: 15 })}{t('common.telegram')}</span></a>
-    <a class="web-menu-item" href="/settings" role="menuitem" onclick={onClose}><span class="menu-item-label">{@html icon(Settings, { size: 15 })}{t('common.settings')}</span><kbd>⌘,</kbd></a>
+    <a class="web-menu-item" href="/settings" role="menuitem" onclick={(event) => { onClose(); handleNavClick(event, '/settings'); }}><span class="menu-item-label">{@html icon(Settings, { size: 15 })}{t('common.settings')}</span><kbd>⌘,</kbd></a>
     <button class="web-menu-item" type="button" id="index-version-row" data-version-row role="menuitem" onclick={() => { onClose(); openVersionModal(); }}><span class="menu-item-label">{@html icon(Tag, { size: 15 })}{t('common.version')}</span><span class="version-status" data-version-status>…</span></button>
   </div>
 </div>

--- a/web/src/components/index/SessionCard.svelte
+++ b/web/src/components/index/SessionCard.svelte
@@ -1,5 +1,6 @@
 <script>
   import { t } from '../../shared/i18n.js';
+  import { handleNavClick } from '../../shared/navigation.js';
   import { formatRelativeTime, formatRunningModel, sessionModelLabel, sessionSearchText } from '../../index/sessions.js';
 
   let { session, running = false, runningStatus = null, now = Date.now() } = $props();
@@ -15,6 +16,7 @@
   class="session-card"
   class:session-card--running={running}
   href={href}
+  onclick={(event) => handleNavClick(event, href)}
   data-id={session.id}
   data-session-id={session.id}
   data-search={search}

--- a/web/src/components/session/AnnotationLayer.svelte
+++ b/web/src/components/session/AnnotationLayer.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { t } from '../../shared/i18n.js';
   import { getSelectionInfo, applyHighlights } from '../../session/annotations/annotation-range.js';
+  import { sessionRuntime } from '../../session/session-runtime.js';
 
   // Reactive view state. The notes list, floating "Comment" popover, and note
   // modal are rendered declaratively; the selection/highlight machinery and API
@@ -331,7 +332,7 @@
       else if (action === 'cancel-note') closeNote();
     });
 
-    window.__piAnnotationLayer = { init, setAnnotations, reapply, refresh };
+    sessionRuntime.annotations = { init, setAnnotations, reapply, refresh };
 
     return () => {
       observer?.disconnect();
@@ -341,7 +342,7 @@
       document.removeEventListener('keydown', onKeyDown);
       popoverEl?.remove();
       modalEl?.remove();
-      delete window.__piAnnotationLayer;
+      sessionRuntime.annotations = null;
     };
   });
 </script>

--- a/web/src/components/session/AnnotationLayer.test.js
+++ b/web/src/components/session/AnnotationLayer.test.js
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { tick } from 'svelte';
 import { render, cleanup } from '@testing-library/svelte';
 import AnnotationLayer from './AnnotationLayer.svelte';
+import { sessionRuntime, resetSessionRuntime } from '../../session/session-runtime.js';
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
 const waitFor = async (fn, { timeout = 1000, interval = 5 } = {}) => {
@@ -17,7 +18,7 @@ const waitFor = async (fn, { timeout = 1000, interval = 5 } = {}) => {
 afterEach(() => {
   cleanup();
   document.body.innerHTML = '';
-  delete window.__piAnnotationLayer;
+  resetSessionRuntime();
   vi.restoreAllMocks();
 });
 
@@ -52,7 +53,7 @@ function setup({ api, selectionDelayMs = 250, onCreate = null, onSend = null, on
   document.body.appendChild(count);
 
   render(AnnotationLayer);
-  const layer = window.__piAnnotationLayer;
+  const layer = sessionRuntime.annotations;
   const resolvedApi = api || fakeApi();
   if (init) {
     layer.init({ api: resolvedApi, scopes: [messages], composerEl: composer, countEl: count, onCreate, onSend, onAddToChat, selectionDelayMs });
@@ -214,7 +215,7 @@ describe('AnnotationLayer', () => {
       : null);
 
     render(AnnotationLayer);
-    const layer = window.__piAnnotationLayer;
+    const layer = sessionRuntime.annotations;
     layer.init({ api: fakeApi(), scopes: [messages], composerEl: composer, resolveArtifact });
     layer.setAnnotations([
       { id: 'n1', anchorId: 'artifact-art-1', startOffset: 0, endOffset: 4, text: 'add (burmese)', original: 'line' },
@@ -275,7 +276,7 @@ describe('AnnotationLayer', () => {
     const api = fakeApi();
 
     render(AnnotationLayer);
-    const layer = window.__piAnnotationLayer;
+    const layer = sessionRuntime.annotations;
     layer.init({ api, scopes: [messages, artHost], countEl: count });
     await flush();
 
@@ -300,7 +301,7 @@ describe('AnnotationLayer', () => {
 
   it('is a no-op when required deps are missing', () => {
     render(AnnotationLayer);
-    const layer = window.__piAnnotationLayer;
+    const layer = sessionRuntime.annotations;
     expect(() => { layer.init({}); layer.setAnnotations([]); layer.reapply(); }).not.toThrow();
   });
 });

--- a/web/src/components/session/ArtifactPanel.svelte
+++ b/web/src/components/session/ArtifactPanel.svelte
@@ -6,6 +6,7 @@
   import { collectArtifacts } from '../../session/artifacts/artifact-registry.js';
   import { filterArtifacts, readArtifactSettings, ARTIFACT_SETTING_KEYS } from '../../session/artifacts/artifact-filter.js';
   import { t } from '../../shared/i18n.js';
+  import { sessionRuntime } from '../../session/session-runtime.js';
 
   // `highlight`/`renderMarkdown` are injectable for tests; in the live app the
   // component lazy-loads highlight.js itself and renders markdown via marked.
@@ -14,8 +15,8 @@
   // The panel collects artifacts straight from the shared reactive model: on
   // mount and whenever entries change (live reload), it re-runs collection +
   // filtering. Standalone (tests, no context) the model is undefined and the
-  // panel is driven imperatively via the window.__piArtifactPanel.setArtifacts
-  // bridge instead.
+  // panel is driven imperatively via the sessionRuntime.artifacts.setArtifacts
+  // handle instead.
   const model = getSessionModel();
   // Bumped by the cross-tab `storage` listener so the collection effect re-reads
   // the artifact settings (enable/include filter) without a reload.
@@ -183,7 +184,7 @@
       if (e.key === null || ARTIFACT_SETTING_KEYS.includes(e.key)) settingsTick += 1;
     };
     if (model) window.addEventListener('storage', onStorage);
-    window.__piArtifactPanel = {
+    sessionRuntime.artifacts = {
       setArtifacts,
       selectArtifact,
       render: () => {},
@@ -193,7 +194,7 @@
     };
     return () => {
       if (model) window.removeEventListener('storage', onStorage);
-      delete window.__piArtifactPanel;
+      sessionRuntime.artifacts = null;
     };
   });
 </script>

--- a/web/src/components/session/ArtifactPanel.test.js
+++ b/web/src/components/session/ArtifactPanel.test.js
@@ -2,10 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { tick } from 'svelte';
 import { render, cleanup } from '@testing-library/svelte';
 import ArtifactPanel from './ArtifactPanel.svelte';
+import { sessionRuntime, resetSessionRuntime } from '../../session/session-runtime.js';
 
 afterEach(() => {
   cleanup();
-  delete window.__piArtifactPanel;
+  resetSessionRuntime();
   vi.restoreAllMocks();
 });
 
@@ -13,7 +14,7 @@ afterEach(() => {
 // data-highlight-pending) and skips the component's lazy highlight.js import.
 function renderPanel(props = {}) {
   render(ArtifactPanel, { props: { highlight: () => null, ...props } });
-  return window.__piArtifactPanel;
+  return sessionRuntime.artifacts;
 }
 
 const arts = [
@@ -78,14 +79,14 @@ describe('ArtifactPanel', () => {
   it('uses highlight output when available, else falls back to escaped text', async () => {
     const highlight = vi.fn(() => '<span class="tok">x</span>');
     renderPanel({ highlight });
-    window.__piArtifactPanel.setArtifacts(arts);
+    sessionRuntime.artifacts.setArtifacts(arts);
     await tick();
     expect(highlight).toHaveBeenCalled();
     expect(document.querySelector('.artifact-source code').innerHTML).toContain('tok');
     cleanup();
 
     renderPanel();
-    window.__piArtifactPanel.setArtifacts([{ id: 'x', kind: 'code', title: 't', lang: '', content: '<b>raw</b>' }]);
+    sessionRuntime.artifacts.setArtifacts([{ id: 'x', kind: 'code', title: 't', lang: '', content: '<b>raw</b>' }]);
     await tick();
     expect(document.querySelector('.artifact-source code').innerHTML).toContain('&lt;b&gt;');
     expect(document.querySelector('code[data-highlight-pending]')).not.toBeNull();

--- a/web/src/components/session/CatGatekeeper.svelte
+++ b/web/src/components/session/CatGatekeeper.svelte
@@ -19,10 +19,13 @@
   let showMessage = $state(false);
   let showSnooze = $state(false);
 
+  // Assigned in onMount; the snooze button (rendered before mount) reads it here.
+  let controller = null;
+
   function onSnooze(e) {
     e.preventDefault();
     e.stopPropagation();
-    window.__piCatGatekeeper?.snooze?.();
+    controller?.snooze?.();
   }
 
   onMount(() => {
@@ -96,15 +99,14 @@
       return !hidden && focused;
     };
 
-    const controller = setupCatGatekeeper({ windowImpl: win, storage: win.localStorage, isActive, view });
-    win.__piCatGatekeeper = controller;
+    controller = setupCatGatekeeper({ windowImpl: win, storage: win.localStorage, isActive, view });
     controller.start();
 
     return () => {
       controller.destroy();
       unblockInput();
       overlayEl?.remove();
-      if (win.__piCatGatekeeper === controller) delete win.__piCatGatekeeper;
+      controller = null;
     };
   });
 </script>

--- a/web/src/components/session/CatGatekeeper.svelte
+++ b/web/src/components/session/CatGatekeeper.svelte
@@ -102,10 +102,17 @@
     controller = setupCatGatekeeper({ windowImpl: win, storage: win.localStorage, isActive, view });
     controller.start();
 
+    // Test seam: the enforced break only fires after the (25-min) focus timer,
+    // so the e2e suite forces it via skipToBreak(). The controller has no in-app
+    // consumers, so this stays a plain window hook rather than a sessionRuntime
+    // registry slot. Cleared on destroy so SPA re-entry never sees a stale one.
+    win.__piCatGatekeeper = controller;
+
     return () => {
       controller.destroy();
       unblockInput();
       overlayEl?.remove();
+      if (win.__piCatGatekeeper === controller) win.__piCatGatekeeper = null;
       controller = null;
     };
   });

--- a/web/src/components/session/CommandMenu.svelte
+++ b/web/src/components/session/CommandMenu.svelte
@@ -10,6 +10,7 @@
   import { icon, Search, Pencil, Share2, GitFork, Copy, Terminal, ListTree, FileDiff, ChartColumn, BookOpen, Send, Settings, Tag } from '../../shared/icons.js';
   import * as sidebarApi from '../../session/ui/sidebar.js';
   import { openVersionModal } from '../../shared/version.js';
+  import { openModelUsage, openFork } from '../../session/session-modals.svelte.js';
 
   let { sessionId = '' } = $props();
 
@@ -111,7 +112,7 @@
           else sidebarApi.setSidebarCollapsed(false, { documentImpl: document });
           closeMenu();
           break;
-        case 'model-usage': window.__piOpenModelUsage?.(); closeMenu(); break;
+        case 'model-usage': openModelUsage(); closeMenu(); break;
         case 'rename': {
           const titleEl = document.getElementById('session-header-title');
           const current = titleEl ? titleEl.textContent : '';
@@ -149,7 +150,7 @@
                   })
                   .catch(() => showToast('Fork failed'));
               };
-              const opened = window.__piOpenForkModal?.({ entries, onSelect });
+              const opened = openFork({ entries, onSelect });
               if (opened === false) showToast('No user messages to fork from');
             })
             .catch(() => showToast('Failed to load messages'));

--- a/web/src/components/session/CommandMenu.svelte
+++ b/web/src/components/session/CommandMenu.svelte
@@ -10,6 +10,7 @@
   import { icon, Search, Pencil, Share2, GitFork, Copy, Terminal, ListTree, FileDiff, ChartColumn, BookOpen, Send, Settings, Tag } from '../../shared/icons.js';
   import * as sidebarApi from '../../session/ui/sidebar.js';
   import { openVersionModal } from '../../shared/version.js';
+  import { navigate } from '../../shared/navigation.js';
   import { openModelUsage, openFork } from '../../session/session-modals.svelte.js';
 
   let { sessionId = '' } = $props();
@@ -145,7 +146,7 @@
                 })
                   .then((res) => res.json())
                   .then((data) => {
-                    if (data.id) window.location.href = '/session?id=' + encodeURIComponent(data.id);
+                    if (data.id) navigate('/session?id=' + encodeURIComponent(data.id));
                     else showToast(data.error || 'Fork failed');
                   })
                   .catch(() => showToast('Fork failed'));
@@ -165,7 +166,7 @@
           })
             .then((res) => res.json())
             .then((data) => {
-              if (data.id) window.location.href = '/session?id=' + encodeURIComponent(data.id);
+              if (data.id) navigate('/session?id=' + encodeURIComponent(data.id));
               else showToast(data.error || 'Clone failed');
             })
             .catch(() => showToast('Clone failed'));

--- a/web/src/components/session/CommandMenu.test.js
+++ b/web/src/components/session/CommandMenu.test.js
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { tick } from 'svelte';
 import { render, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
 import CommandMenu from './CommandMenu.svelte';
+import { sessionModals, resetSessionModals } from '../../session/session-modals.svelte.js';
 
 // The menu button (#command-menu-btn) + title live in SessionHeader; the menu
 // reads them by id, so the test provides them in the document.
@@ -17,7 +18,7 @@ beforeEach(() => {
   window.matchMedia = vi.fn(() => ({ matches: false }));
 });
 
-afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+afterEach(() => { cleanup(); vi.restoreAllMocks(); resetSessionModals(); });
 
 describe('CommandMenu', () => {
   it('renames via the API and updates the page title', async () => {
@@ -43,17 +44,15 @@ describe('CommandMenu', () => {
     expect(document.getElementById('session-header-title').textContent).toBe('Old');
   });
 
-  it('opens model usage + the session-list palette via window bridges', async () => {
-    window.__piOpenModelUsage = vi.fn();
+  it('opens model usage via the modal store + the session-list palette via its window bridge', async () => {
     window.__piOpenSessionPalette = vi.fn();
     render(CommandMenu, { props: { sessionId: 's' } });
     await tick();
 
     await fireEvent.click(document.querySelector('[data-action="model-usage"]'));
     await fireEvent.click(document.querySelector('[data-action="list-sessions"]'));
-    expect(window.__piOpenModelUsage).toHaveBeenCalled();
+    expect(sessionModals.modelUsage).toBe(true);
     expect(window.__piOpenSessionPalette).toHaveBeenCalled();
-    delete window.__piOpenModelUsage;
     delete window.__piOpenSessionPalette;
   });
 });

--- a/web/src/components/session/LiveReload.svelte
+++ b/web/src/components/session/LiveReload.svelte
@@ -549,6 +549,7 @@ export function updateStatsDom(entries, { documentImpl = document } = {}) {
   import { marked } from 'marked';
   import { escapeHtml } from '../../session/render/session-format.js';
   import { safeMarkedParse } from '../../session/render/markdown.js';
+  import { sessionRuntime } from '../../session/session-runtime.js';
 
   onMount(() => {
     const documentImpl = document;
@@ -773,7 +774,7 @@ export function updateStatsDom(entries, { documentImpl = document } = {}) {
         eventSource: es,
         onReload: triggerReload,
         onChatPreview: renderChatPreview,
-        onAnnotations: (list) => windowImpl.__piAnnotationLayer?.setAnnotations(list),
+        onAnnotations: (list) => sessionRuntime.annotations?.setAnnotations(list),
         onError: () => {
           // EventSource onerror fires for transient blips (auto-retried) and
           // terminal closures (readyState===CLOSED, e.g. device wake). Handle

--- a/web/src/components/session/RightSidebar.svelte
+++ b/web/src/components/session/RightSidebar.svelte
@@ -4,6 +4,7 @@
   import { t } from '../../shared/i18n.js';
   import ArtifactPanel from './ArtifactPanel.svelte';
   import AnnotationLayer from './AnnotationLayer.svelte';
+  import { sessionRuntime } from '../../session/session-runtime.js';
 
   let { scratchpad = '', projectPath = '' } = $props();
 
@@ -59,13 +60,13 @@
     // ── Sidebar visibility/resize/scratchpad ─────────────────────────────────
     const cleanups = [];
     if (!sidebar) {
-      window.__piRightSidebar = {
+      sessionRuntime.rightSidebar = {
         toggle: () => {},
         open: () => {},
         collapse: () => {},
         activateTab,
       };
-      return () => { delete window.__piRightSidebar; };
+      return () => { sessionRuntime.rightSidebar = null; };
     }
 
     function isCollapsed() {
@@ -288,7 +289,7 @@
       });
     }
 
-    window.__piRightSidebar = {
+    sessionRuntime.rightSidebar = {
       toggle: toggleSidebar,
       open: openSidebar,
       collapse: collapseSidebar,
@@ -297,7 +298,7 @@
 
     return () => {
       for (const fn of cleanups) fn();
-      delete window.__piRightSidebar;
+      sessionRuntime.rightSidebar = null;
     };
   });
 </script>

--- a/web/src/components/session/RightSidebar.test.js
+++ b/web/src/components/session/RightSidebar.test.js
@@ -2,13 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { tick } from 'svelte';
 import { render, cleanup } from '@testing-library/svelte';
 import RightSidebar from './RightSidebar.svelte';
+import { sessionRuntime, resetSessionRuntime } from '../../session/session-runtime.js';
 
 afterEach(() => {
   cleanup();
   document.body.className = '';
   document.documentElement.removeAttribute('style');
   localStorage.clear();
-  delete window.__piRightSidebar;
+  resetSessionRuntime();
 });
 
 beforeEach(() => {
@@ -52,7 +53,7 @@ describe('RightSidebar tabs', () => {
 
   it('ignores activation for an unknown pane name via the window bridge', () => {
     render(RightSidebar);
-    window.__piRightSidebar.activateTab('nonexistent');
+    sessionRuntime.rightSidebar.activateTab('nonexistent');
     expect(document.querySelector('[data-pane="scratchpad"]').classList.contains('active')).toBe(true);
   });
 });
@@ -62,13 +63,13 @@ describe('RightSidebar visibility controls', () => {
     document.body.classList.add('right-sidebar-collapsed');
     render(RightSidebar);
 
-    window.__piRightSidebar.open();
+    sessionRuntime.rightSidebar.open();
     expect(document.body.classList.contains('right-sidebar-collapsed')).toBe(false);
 
-    window.__piRightSidebar.collapse();
+    sessionRuntime.rightSidebar.collapse();
     expect(document.body.classList.contains('right-sidebar-collapsed')).toBe(true);
 
-    window.__piRightSidebar.toggle();
+    sessionRuntime.rightSidebar.toggle();
     expect(document.body.classList.contains('right-sidebar-collapsed')).toBe(false);
   });
 

--- a/web/src/components/session/SessionHeader.svelte
+++ b/web/src/components/session/SessionHeader.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { icon, PanelLeft, Plus, SquarePen, MoreHorizontal } from '../../shared/icons.js';
   import { t } from '../../shared/i18n.js';
+  import { navigate } from '../../shared/navigation.js';
   let { title = 'Session', cwd = '', sessionId = '' } = $props();
 
   // Resume ("Terminal") + New Session behavior, absorbed from the former
@@ -79,7 +80,7 @@
         if (data.error) {
           showToast('new-session-toast', data.error || 'Failed to create session', newHolder, 2500);
         } else if (data.id) {
-          window.location.href = '/session?id=' + encodeURIComponent(data.id);
+          navigate('/session?id=' + encodeURIComponent(data.id));
           return;
         } else {
           showToast('new-session-toast', 'Failed to create session', newHolder, 2500);

--- a/web/src/components/session/SessionTree.svelte
+++ b/web/src/components/session/SessionTree.svelte
@@ -2,6 +2,7 @@
   import { icon, PanelLeftClose, X } from '../../shared/icons.js';
   import { t } from '../../shared/i18n.js';
   import { getSessionModel } from '../../session/session-context.js';
+  import { sessionRuntime } from '../../session/session-runtime.js';
   import SessionTreeNodes from './SessionTreeNodes.svelte';
 
   const model = getSessionModel();
@@ -15,7 +16,7 @@
   function onNavigate(id) {
     const leaf = model?.newestLeaf(id) || id;
     window.navigateTo?.(leaf, 'target', id);
-    if (window.__piIsMobileLayout?.()) window.__piCloseSidebar?.();
+    if (sessionRuntime.layout?.isMobileLayout?.()) sessionRuntime.layout?.closeSidebar?.();
   }
 </script>
 

--- a/web/src/components/settings/AppearanceSettings.svelte
+++ b/web/src/components/settings/AppearanceSettings.svelte
@@ -6,23 +6,40 @@
 
   let { settings = {}, onSave = () => {}, onSaved = () => {} } = $props();
   const FONT_KEYS = { ui: 'pi-web:v1:font-ui', content: 'pi-web:v1:font-content', code: 'pi-web:v1:font-code' };
+  const BUILTIN_FONTS = ['mono', 'system', 'sans', 'serif'];
   const uiSizeKey = 'pi-web:v1:font-ui-size';
   const contentSizeKey = 'pi-web:v1:font-content-size';
   let theme = $derived(valueFor(settings, 'pi-web-theme', 'dark'));
   let uiSize = $derived(valueFor(settings, uiSizeKey, '14'));
   let contentSize = $derived(valueFor(settings, contentSizeKey, '15'));
   let detectedFonts = $state([]);
-  let customVisible = $state({ ui: false, content: false, code: false });
-  let customValues = $state({ ui: '', content: '', code: '' });
+  // User explicitly picked "Custom…" for a kind, so the text field shows even
+  // before a family is committed (auto-detected custom families don't need it).
+  let manualCustom = $state({ ui: false, content: false, code: false });
+  // In-progress edit to the custom-family text (null = not editing; fall back to
+  // the stored value). Kept separate from settings so typing isn't clobbered.
+  let customDraft = $state({ ui: null, content: null, code: null });
 
   function fontValue(kind) { return valueFor(settings, FONT_KEYS[kind], 'mono'); }
-  function fontSelectValue(kind) {
+  function isCustomFont(kind) {
     const v = fontValue(kind);
-    const builtins = ['mono', 'system', 'sans', 'serif'];
-    if (builtins.includes(v) || detectedFonts.includes(v)) return v;
-    customVisible[kind] = true;
-    customValues[kind] = v;
-    return '__custom__';
+    return !BUILTIN_FONTS.includes(v) && !detectedFonts.includes(v);
+  }
+  // All pure (reads only) — safe to call from the template. The previous version
+  // wrote $state inside fontSelectValue(), which throws state_unsafe_mutation when
+  // this component mounts during a reactive route swap rather than a fresh load.
+  function fontSelectValue(kind) {
+    return isCustomFont(kind) ? '__custom__' : fontValue(kind);
+  }
+  function customShown(kind) {
+    return manualCustom[kind] || isCustomFont(kind);
+  }
+  function customValue(kind) {
+    if (customDraft[kind] != null) return customDraft[kind];
+    return isCustomFont(kind) ? fontValue(kind) : '';
+  }
+  function setDraft(kind, value) {
+    customDraft = { ...customDraft, [kind]: value };
   }
 
   function commitTheme(value) {
@@ -58,17 +75,21 @@
   async function handleFontSelect(kind, value) {
     if (value === '__detect__') { await detectInstalledFonts(); return; }
     if (value === '__custom__') {
-      customVisible = { ...customVisible, [kind]: true };
-      customValues = { ...customValues, [kind]: fontValue(kind) };
+      manualCustom = { ...manualCustom, [kind]: true };
+      setDraft(kind, fontValue(kind));
       return;
     }
-    customVisible = { ...customVisible, [kind]: false };
+    manualCustom = { ...manualCustom, [kind]: false };
+    setDraft(kind, null);
     commitFont(kind, value);
   }
 
   function commitCustom(kind) {
-    const fam = String(customValues[kind] || '').trim();
-    if (fam) commitFont(kind, fam);
+    const fam = String(customValue(kind)).trim();
+    if (fam) {
+      commitFont(kind, fam);
+      setDraft(kind, null); // stored value is now the source of truth
+    }
   }
 </script>
 
@@ -85,10 +106,10 @@
       <div class="settings-control settings-font-control">
         <select data-font-select={item.kind} value={fontSelectValue(item.kind)} onchange={(e) => handleFontSelect(item.kind, e.currentTarget.value)}>
           <optgroup label={t('settings.fontBuiltIn')}><option value="mono">{t('settings.fontMono')}</option><option value="system">{t('settings.fontSystem')}</option><option value="sans">{t('settings.fontSans')}</option><option value="serif">{t('settings.fontSerif')}</option></optgroup>
-          {#if detectedFonts.length}<optgroup label={t('settings.fontInstalled')}>{#each detectedFonts as fam}<option value={fam}>{fam}</option>{/each}</optgroup>{/if}
+          {#if detectedFonts.length}<optgroup label={t('settings.fontInstalled')}>{#each detectedFonts as fam (fam)}<option value={fam}>{fam}</option>{/each}</optgroup>{/if}
           <optgroup label={t('settings.fontActions')}><option value="__detect__">{t('settings.fontDetect')}</option><option value="__custom__">{t('settings.fontCustomOption')}</option></optgroup>
         </select>
-        <input type="text" class="settings-font-custom" data-font-custom={item.kind} placeholder={t('settings.fontFamilyPlaceholder')} hidden={!customVisible[item.kind]} bind:value={customValues[item.kind]} onchange={() => commitCustom(item.kind)}>
+        <input type="text" class="settings-font-custom" data-font-custom={item.kind} placeholder={t('settings.fontFamilyPlaceholder')} hidden={!customShown(item.kind)} value={customValue(item.kind)} oninput={(e) => setDraft(item.kind, e.currentTarget.value)} onchange={() => commitCustom(item.kind)}>
       </div>
     </div>
     {#if item.kind === 'ui'}

--- a/web/src/export/export-entry.js
+++ b/web/src/export/export-entry.js
@@ -37,6 +37,7 @@ import * as toggleStateApi from '../session/ui/toggle-state.js';
 import * as sidebarApi from '../session/ui/sidebar.js';
 import * as searchFiltersApi from '../session/ui/search-filters.js';
 import { setupSessionUi } from '../session/ui/session-ui-runner.js';
+import { sessionRuntime } from '../session/session-runtime.js';
 import { setupKeyboardNav } from '../shared/keyboard-nav.js';
 
 // In a sandboxed iframe (e.g. a srcdoc preview without `allow-same-origin`),
@@ -80,7 +81,6 @@ export function runExportApp({ target = window } = {}) {
 
   let filterMode = 'default';
   let searchQuery = '';
-  target.__piFilterState = { filterMode, searchQuery };
 
   const sessionFormat = {
     shortenPath,
@@ -100,8 +100,6 @@ export function runExportApp({ target = window } = {}) {
 
   // Push view state into the reactive model; <SessionTreeNodes> recomputes.
   const syncTreeRendererState = () => {
-    target.__piFilterState.filterMode = filterMode;
-    target.__piFilterState.searchQuery = searchQuery;
     treeModel.filterMode = filterMode;
     treeModel.searchQuery = searchQuery;
     treeModel.currentLeafId = currentLeafId;
@@ -181,7 +179,7 @@ export function runExportApp({ target = window } = {}) {
       props: {
         model: treeModel,
         afterRender: (container) => {
-          target.applyToggleStateToNode?.(container);
+          sessionRuntime.toggleState?.applyToNode(container);
           highlightPending(container);
         },
       },

--- a/web/src/routes/SessionPage.svelte
+++ b/web/src/routes/SessionPage.svelte
@@ -10,7 +10,7 @@
   import ImageModal from '../components/session/ImageModal.svelte';
   import ShortcutsModal from '../components/session/ShortcutsModal.svelte';
   import ModelUsageModal from '../components/session/ModelUsageModal.svelte';
-  import ForkModal, { buildUserMessageList } from '../components/session/ForkModal.svelte';
+  import ForkModal from '../components/session/ForkModal.svelte';
   import CatGatekeeperSettings from '../components/session/CatGatekeeperSettings.svelte';
   import CatGatekeeper from '../components/session/CatGatekeeper.svelte';
   import BtwPopup from '../components/session/BtwPopup.svelte';
@@ -33,6 +33,7 @@
   import { createSessionDataModel, decodeBase64JSON } from '../session/data/session-data.js';
   import { createSessionNavigator } from '../session/navigation/session-navigation.js';
   import { setSessionModel } from '../session/session-context.js';
+  import { sessionModals, resetSessionModals } from '../session/session-modals.svelte.js';
   import { configureSettingsSync, hydrateSettings } from '../shared/settings-store.js';
   import { t } from '../shared/i18n.js';
 
@@ -48,27 +49,10 @@
   // lazy highlight); the $state proxy makes the hook apply reactively.
   const contentRuntime = $state({ afterRender: null });
 
-  // Keyboard-shortcuts modal: opened imperatively (Cmd+/ and #shortcuts-help-btn,
-  // wired in setupSessionGlobals) via a window bridge set in onMount.
-  let shortcutsOpen = $state(false);
-  // Model-usage modal: opened from the command menu via a window bridge.
-  let modelUsageOpen = $state(false);
-  // Fork palette: opened from the command menu, which fetches fresh entries and
-  // passes them + the fork callback through the window bridge.
-  let forkOpen = $state(false);
-  let forkEntries = $state([]);
-  let forkOnSelect = $state(null);
-  // Cat Gatekeeper settings: opened by the cat-gatekeeper controller, which
-  // passes its live-status controller + onChange through the window bridge.
-  let catSettingsOpen = $state(false);
-  let catController = $state(null);
-  let catOnChange = $state(() => {});
-  // Label modal: opened from the per-entry label button (delegated in the content
-  // runtime).
-  let labelOpen = $state(false);
-  let labelEntryId = $state('');
-  let labelCurrent = $state('');
-  let labelOnSave = $state(null);
+  // Modal/sheet open-state lives in the shared sessionModals store so the
+  // command menu, keyboard globals, content runtime, and cat-gatekeeper can open
+  // them by importing the store helpers instead of via window bridges. The modal
+  // components below bind directly to it.
 
   let loading = $state(true);
   let showLoading = $state(false);
@@ -189,29 +173,6 @@
       });
     };
 
-    // Bridge for the imperative shortcuts triggers to open the <ShortcutsModal>
-    // component.
-    window.__piOpenShortcuts = () => { shortcutsOpen = true; };
-    window.__piOpenModelUsage = () => { modelUsageOpen = true; };
-    window.__piOpenForkModal = ({ entries, onSelect } = {}) => {
-      // Returns false (no open) when there are no user messages to fork from.
-      if (buildUserMessageList(entries || []).length === 0) return false;
-      forkEntries = entries;
-      forkOnSelect = onSelect;
-      forkOpen = true;
-      return true;
-    };
-    window.__piOpenCatSettings = ({ controller, onChange } = {}) => {
-      catController = controller || null;
-      catOnChange = onChange || (() => {});
-      catSettingsOpen = true;
-    };
-    window.__piOpenLabelModal = ({ entryId, currentLabel, onSave } = {}) => {
-      labelEntryId = entryId || '';
-      labelCurrent = currentLabel || '';
-      labelOnSave = onSave || null;
-      labelOpen = true;
-    };
     // The session view is a fixed app shell (no body scroll, internal scroll
     // containers). Mark the document so the session-only layout rules in the
     // shared SPA stylesheet do not pin body height on the index/settings pages.
@@ -279,6 +240,7 @@
       active = false;
       clearTimeout(loadingTimer);
       disposeGlobals?.();
+      resetSessionModals();
       document.title = previousTitle;
       document.documentElement.classList.remove('pi-session-page');
       document.body.classList.remove('pi-session-page');
@@ -312,11 +274,11 @@
     <ImageModal />
   </div>
 
-  <ShortcutsModal bind:open={shortcutsOpen} />
-  <ModelUsageModal bind:open={modelUsageOpen} />
-  <ForkModal bind:open={forkOpen} entries={forkEntries} onSelect={forkOnSelect} />
-  <CatGatekeeperSettings bind:open={catSettingsOpen} controller={catController} onChange={catOnChange} />
-  <LabelModal bind:open={labelOpen} entryId={labelEntryId} currentLabel={labelCurrent} onSave={labelOnSave} />
+  <ShortcutsModal bind:open={sessionModals.shortcuts} />
+  <ModelUsageModal bind:open={sessionModals.modelUsage} />
+  <ForkModal bind:open={sessionModals.fork.open} entries={sessionModals.fork.entries} onSelect={sessionModals.fork.onSelect} />
+  <CatGatekeeperSettings bind:open={sessionModals.catSettings.open} controller={sessionModals.catSettings.controller} onChange={sessionModals.catSettings.onChange} />
+  <LabelModal bind:open={sessionModals.label.open} entryId={sessionModals.label.entryId} currentLabel={sessionModals.label.currentLabel} onSave={sessionModals.label.onSave} />
 
   <ShareDialog {sessionId} />
   <CatGatekeeper />

--- a/web/src/routes/SessionPage.svelte
+++ b/web/src/routes/SessionPage.svelte
@@ -73,6 +73,7 @@
     const previousTitle = document.title;
     let active = true;
     let disposeGlobals = null;
+    let removeAnnotationReload = null;
 
     // Live session runtime — the imperative wiring that used to live in
     // session.js's runSessionApp (Svelte migration teardown). Runs once the
@@ -158,7 +159,9 @@
           },
           resolveArtifact: (artifactId) => sessionRuntime.artifacts?.getArtifact(artifactId) || null,
         });
-        window.addEventListener('pi-session-reload', () => annotationLayer.reapply());
+        const onAnnotationReload = () => annotationLayer.reapply();
+        window.addEventListener('pi-session-reload', onAnnotationReload);
+        removeAnnotationReload = () => window.removeEventListener('pi-session-reload', onAnnotationReload);
       }
 
       // Page-global glue (keyboard shortcuts, done-notifier,
@@ -240,6 +243,7 @@
       active = false;
       clearTimeout(loadingTimer);
       disposeGlobals?.();
+      removeAnnotationReload?.();
       resetSessionModals();
       resetSessionRuntime();
       document.title = previousTitle;

--- a/web/src/routes/SessionPage.svelte
+++ b/web/src/routes/SessionPage.svelte
@@ -34,6 +34,7 @@
   import { createSessionNavigator } from '../session/navigation/session-navigation.js';
   import { setSessionModel } from '../session/session-context.js';
   import { sessionModals, resetSessionModals } from '../session/session-modals.svelte.js';
+  import { sessionRuntime, resetSessionRuntime } from '../session/session-runtime.js';
   import { configureSettingsSync, hydrateSettings } from '../shared/settings-store.js';
   import { t } from '../shared/i18n.js';
 
@@ -115,8 +116,7 @@
       });
 
       // Exposed for <SessionTree>'s node-click handler (auto-close mobile drawer).
-      window.__piIsMobileLayout = ui.isMobileLayout;
-      window.__piCloseSidebar = ui.closeSidebar;
+      sessionRuntime.layout = { isMobileLayout: ui.isMobileLayout, closeSidebar: ui.closeSidebar };
 
       // The header card is a persistent <SessionInfoHeader>, so bind its toggle
       // buttons exactly once.
@@ -127,10 +127,10 @@
       // below the stub and the conversation appears duplicated).
       window.navigateTo(model.currentLeafId, model.urlTargetId ? 'target' : 'bottom', model.urlTargetId || null);
 
-      // Annotation layer (right-sidebar "Notes" tab) — <AnnotationLayer> exposes
-      // init/setAnnotations/reapply on window.__piAnnotationLayer; supply its
+      // Annotation layer (right-sidebar "Notes" tab) — <AnnotationLayer> registers
+      // init/setAnnotations/reapply in sessionRuntime.annotations; supply its
       // runtime deps here. Anchors to entries by `entry-<id>` + offsets.
-      const annotationLayer = window.__piAnnotationLayer || null;
+      const annotationLayer = sessionRuntime.annotations || null;
       const messagesEl = document.getElementById('messages');
       if (annotationLayer && messagesEl && sessionId) {
         const annotationArtifactHost = document.getElementById('artifact-panel-host');
@@ -141,7 +141,7 @@
           countEl: document.getElementById('annotation-tab-count'),
           onSelectArtifact: (artifactId) => {
             ui.activateRightTab('artifacts');
-            window.__piArtifactPanel?.selectArtifact(artifactId);
+            sessionRuntime.artifacts?.selectArtifact(artifactId);
           },
           onCreate: () => {
             ui.openRightSidebar();
@@ -156,7 +156,7 @@
             window.dispatchEvent(new window.CustomEvent('pi-chat-attach-text', { detail: attachment }));
             if (ui.isMobileLayout()) ui.collapseRightSidebar();
           },
-          resolveArtifact: (artifactId) => window.__piArtifactPanel?.getArtifact(artifactId) || null,
+          resolveArtifact: (artifactId) => sessionRuntime.artifacts?.getArtifact(artifactId) || null,
         });
         window.addEventListener('pi-session-reload', () => annotationLayer.reapply());
       }
@@ -241,6 +241,7 @@
       clearTimeout(loadingTimer);
       disposeGlobals?.();
       resetSessionModals();
+      resetSessionRuntime();
       document.title = previousTitle;
       document.documentElement.classList.remove('pi-session-page');
       document.body.classList.remove('pi-session-page');

--- a/web/src/routes/SessionsPage.svelte
+++ b/web/src/routes/SessionsPage.svelte
@@ -10,6 +10,7 @@
   import { setupKeyboardNav } from '../shared/keyboard-nav.js';
   import { toggleTheme, syncThemeIcons } from '../shared/theme.js';
   import { configureSettingsSync, hydrateSettings, writeSetting } from '../shared/settings-store.js';
+  import { navigate } from '../shared/navigation.js';
   import { icon, Sun, Moon } from '../shared/icons.js';
   import { t } from '../shared/i18n.js';
   import {
@@ -133,7 +134,7 @@
     try {
       const response = await defaultCreateSession(path);
       if (response.ok && response.id) {
-        window.location.href = '/session?id=' + encodeURIComponent(response.id);
+        navigate('/session?id=' + encodeURIComponent(response.id));
         return;
       }
       newSessionError = response.error || t('index.failedCreateSession');
@@ -268,7 +269,7 @@
 
 <button class="new-session-btn new-session-btn-mobile" id="newSessionBtn" type="button" data-new-session-btn aria-label={t('index.startNewSession')} title={t('index.newSession')} onclick={openNewSessionModal}>+</button>
 
-<CommandPalette onQueryChange={(q) => { query = q; }} onNewSession={openNewSessionModal} />
+<CommandPalette onQueryChange={(q) => { query = q; }} onNewSession={openNewSessionModal} navigate={(url) => navigate(url)} />
 
 <SessionsList {sessions} {layout} {query} {runningSessionIds} {runningStatuses} {loading} {layoutReady} />
 

--- a/web/src/session/cat-gatekeeper/cat-gatekeeper.js
+++ b/web/src/session/cat-gatekeeper/cat-gatekeeper.js
@@ -14,6 +14,7 @@
  */
 
 import { loadCatSettings } from './cat-settings.js';
+import { openCatSettings } from '../session-modals.svelte.js';
 
 const TICK_MS = 1000;
 // Cap how much a single focus tick can subtract so a throttled/backgrounded
@@ -235,9 +236,9 @@ export function setupCatGatekeeper({
   }
 
   function openSettings() {
-    // The settings sheet is the <CatGatekeeperSettings> Svelte component;
-    // SessionPage exposes the opener and reads cat-settings storage directly.
-    return windowImpl?.__piOpenCatSettings?.({
+    // The settings sheet is the <CatGatekeeperSettings> Svelte component, opened
+    // via the shared sessionModals store; it reads cat-settings storage directly.
+    return openCatSettings({
       controller: { getStatusText, skipToBreak },
       onChange: (next) => {
         // Apply focus duration changes immediately when idle in focus phase so

--- a/web/src/session/session-content-runtime.js
+++ b/web/src/session/session-content-runtime.js
@@ -11,6 +11,7 @@
 import { setIconElement, Loader } from '../shared/icons.js';
 import { t } from '../shared/i18n.js';
 import { openLabel } from './session-modals.svelte.js';
+import { sessionRuntime } from './session-runtime.js';
 import { extractContent } from './tree/session-filter.js';
 import { escapeHtml, formatToolCall, getTreeNodeDisplayHtml, shortenPath, truncate } from './render/session-format.js';
 import { buildShareUrl, copyToClipboard, downloadSessionJson } from './render/session-entry-actions.js';
@@ -112,7 +113,7 @@ export function wireSessionContentRuntime({
   // state and lazy-highlight any pending code blocks.
   if (contentRuntime) {
     contentRuntime.afterRender = (container) => {
-      target.applyToggleStateToNode?.(container);
+      sessionRuntime.toggleState?.applyToNode(container);
       applyLazyHighlighting(documentImpl);
     };
   }

--- a/web/src/session/session-content-runtime.js
+++ b/web/src/session/session-content-runtime.js
@@ -10,6 +10,7 @@
 
 import { setIconElement, Loader } from '../shared/icons.js';
 import { t } from '../shared/i18n.js';
+import { openLabel } from './session-modals.svelte.js';
 import { extractContent } from './tree/session-filter.js';
 import { escapeHtml, formatToolCall, getTreeNodeDisplayHtml, shortenPath, truncate } from './render/session-format.js';
 import { buildShareUrl, copyToClipboard, downloadSessionJson } from './render/session-entry-actions.js';
@@ -84,10 +85,10 @@ export function wireSessionContentRuntime({
       });
   };
 
-  // Set/clear an entry's tree label. The modal is <LabelModal> (SessionPage
-  // exposes the opener); this owns the save (API + reactive labelMap update).
+  // Set/clear an entry's tree label. The modal is <LabelModal>, opened via the
+  // shared sessionModals store; this owns the save (API + reactive labelMap update).
   const labelEntry = (entryId) => {
-    target.__piOpenLabelModal?.({
+    openLabel({
       entryId,
       currentLabel: model.labelMap.get(entryId) || '',
       onSave: ({ entryId: id, label }) => {

--- a/web/src/session/session-content-runtime.js
+++ b/web/src/session/session-content-runtime.js
@@ -11,6 +11,7 @@
 import { setIconElement, Loader } from '../shared/icons.js';
 import { t } from '../shared/i18n.js';
 import { openLabel } from './session-modals.svelte.js';
+import { navigate } from '../shared/navigation.js';
 import { sessionRuntime } from './session-runtime.js';
 import { extractContent } from './tree/session-filter.js';
 import { escapeHtml, formatToolCall, getTreeNodeDisplayHtml, shortenPath, truncate } from './render/session-format.js';
@@ -65,7 +66,7 @@ export function wireSessionContentRuntime({
       .then((res) => res.json())
       .then((data) => {
         if (data.id) {
-          target.location.href = '/session?id=' + encodeURIComponent(data.id);
+          navigate('/session?id=' + encodeURIComponent(data.id), { windowImpl: target });
         } else {
           restoreButton();
           btn.disabled = false;

--- a/web/src/session/session-globals.js
+++ b/web/src/session/session-globals.js
@@ -11,6 +11,7 @@ import * as doneNotifier from './chat/done-notifier.js';
 import * as sidebarApi from './ui/sidebar.js';
 import { setupKeyboardNav } from '../shared/keyboard-nav.js';
 import { openShortcuts } from './session-modals.svelte.js';
+import { sessionRuntime } from './session-runtime.js';
 import { toggleTheme, syncThemeIcons } from '../shared/theme.js';
 
 export function setupSessionGlobals({
@@ -94,7 +95,7 @@ export function setupSessionGlobals({
   on(target, 'keydown', (e) => {
     if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'n') {
       e.preventDefault();
-      target.__piRightSidebar?.toggle();
+      sessionRuntime.rightSidebar?.toggle();
     }
   });
 

--- a/web/src/session/session-globals.js
+++ b/web/src/session/session-globals.js
@@ -10,6 +10,7 @@
 import * as doneNotifier from './chat/done-notifier.js';
 import * as sidebarApi from './ui/sidebar.js';
 import { setupKeyboardNav } from '../shared/keyboard-nav.js';
+import { openShortcuts } from './session-modals.svelte.js';
 import { toggleTheme, syncThemeIcons } from '../shared/theme.js';
 
 export function setupSessionGlobals({
@@ -98,11 +99,11 @@ export function setupSessionGlobals({
   });
 
   // Cmd+/ — keyboard shortcuts help modal (the <ShortcutsModal> Svelte
-  // component; SessionPage exposes the opener on window).
+  // component, opened via the shared sessionModals store).
   on(target, 'keydown', (e) => {
     if ((e.metaKey || e.ctrlKey) && e.key === '/') {
       e.preventDefault();
-      target.__piOpenShortcuts?.();
+      openShortcuts();
     }
   });
 
@@ -110,7 +111,7 @@ export function setupSessionGlobals({
   if (shortcutsBtn) {
     on(shortcutsBtn, 'click', (e) => {
       e.stopPropagation();
-      target.__piOpenShortcuts?.();
+      openShortcuts();
     });
   }
 

--- a/web/src/session/session-globals.test.js
+++ b/web/src/session/session-globals.test.js
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupSessionGlobals } from './session-globals.js';
 import { sessionModals, resetSessionModals } from './session-modals.svelte.js';
+import { sessionRuntime, resetSessionRuntime } from './session-runtime.js';
 
 // Focused coverage for the global keyboard shortcuts + relay buttons, which the
 // e2e suite does not exercise. The other wiring (done-notifier, version, palette,
@@ -47,7 +48,7 @@ describe('setupSessionGlobals — keyboard shortcuts', () => {
     vi.restoreAllMocks();
     document.body.innerHTML = '';
     resetSessionModals();
-    delete window.__piRightSidebar;
+    resetSessionRuntime();
     delete window.__piOpenSessionPalette;
   });
 
@@ -71,9 +72,9 @@ describe('setupSessionGlobals — keyboard shortcuts', () => {
     expect(document.body.classList.contains('sidebar-collapsed')).toBe(true);
   });
 
-  it('Cmd+Shift+N toggles the right sidebar via its window bridge', () => {
+  it('Cmd+Shift+N toggles the right sidebar via the runtime registry', () => {
     const toggle = vi.fn();
-    window.__piRightSidebar = { toggle };
+    sessionRuntime.rightSidebar = { toggle };
     dispatchKey('n', { meta: true, shift: true });
     expect(toggle).toHaveBeenCalledOnce();
   });

--- a/web/src/session/session-globals.test.js
+++ b/web/src/session/session-globals.test.js
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupSessionGlobals } from './session-globals.js';
+import { sessionModals, resetSessionModals } from './session-modals.svelte.js';
 
 // Focused coverage for the global keyboard shortcuts + relay buttons, which the
 // e2e suite does not exercise. The other wiring (done-notifier, version, palette,
@@ -45,7 +46,7 @@ describe('setupSessionGlobals — keyboard shortcuts', () => {
     dispose?.();
     vi.restoreAllMocks();
     document.body.innerHTML = '';
-    delete window.__piOpenShortcuts;
+    resetSessionModals();
     delete window.__piRightSidebar;
     delete window.__piOpenSessionPalette;
   });
@@ -77,18 +78,16 @@ describe('setupSessionGlobals — keyboard shortcuts', () => {
     expect(toggle).toHaveBeenCalledOnce();
   });
 
-  it('Cmd+/ opens the shortcuts modal via its window bridge', () => {
-    const open = vi.fn();
-    window.__piOpenShortcuts = open;
+  it('Cmd+/ opens the shortcuts modal via the modal store', () => {
+    expect(sessionModals.shortcuts).toBe(false);
     dispatchKey('/', { meta: true });
-    expect(open).toHaveBeenCalledOnce();
+    expect(sessionModals.shortcuts).toBe(true);
   });
 
   it('the shortcuts-help button opens the shortcuts modal', () => {
-    const open = vi.fn();
-    window.__piOpenShortcuts = open;
+    expect(sessionModals.shortcuts).toBe(false);
     document.getElementById('shortcuts-help-btn').click();
-    expect(open).toHaveBeenCalledOnce();
+    expect(sessionModals.shortcuts).toBe(true);
   });
 
   it('the header new-session button clicks the hidden new-session relay', () => {

--- a/web/src/session/session-modals.svelte.js
+++ b/web/src/session/session-modals.svelte.js
@@ -1,0 +1,62 @@
+// Reactive open-state for the session viewer's modals/sheets. Replaces the
+// window.__piOpen* bridge: <SessionPage> binds the modal components to this
+// state, and any consumer — Svelte component or plain-JS runtime module
+// (session-globals, session-content-runtime, cat-gatekeeper) — imports the
+// open* helpers directly instead of reaching through window. There is one
+// session viewer at a time, so a module singleton is sufficient; resetSessionModals()
+// clears it when <SessionPage> unmounts so SPA re-entry never shows a stale modal.
+import { buildUserMessageList } from '../components/session/ForkModal.svelte';
+
+export const sessionModals = $state({
+  shortcuts: false,
+  modelUsage: false,
+  fork: { open: false, entries: [], onSelect: null },
+  catSettings: { open: false, controller: null, onChange: () => {} },
+  label: { open: false, entryId: '', currentLabel: '', onSave: null },
+});
+
+export function openShortcuts() {
+  sessionModals.shortcuts = true;
+}
+
+export function openModelUsage() {
+  sessionModals.modelUsage = true;
+}
+
+// Returns false (and does not open) when there are no user messages to fork
+// from, so the command menu can surface a toast.
+export function openFork({ entries = [], onSelect = null } = {}) {
+  if (buildUserMessageList(entries).length === 0) return false;
+  sessionModals.fork.entries = entries;
+  sessionModals.fork.onSelect = onSelect;
+  sessionModals.fork.open = true;
+  return true;
+}
+
+export function openCatSettings({ controller = null, onChange = () => {} } = {}) {
+  sessionModals.catSettings.controller = controller;
+  sessionModals.catSettings.onChange = onChange;
+  sessionModals.catSettings.open = true;
+}
+
+export function openLabel({ entryId = '', currentLabel = '', onSave = null } = {}) {
+  sessionModals.label.entryId = entryId;
+  sessionModals.label.currentLabel = currentLabel;
+  sessionModals.label.onSave = onSave;
+  sessionModals.label.open = true;
+}
+
+export function resetSessionModals() {
+  sessionModals.shortcuts = false;
+  sessionModals.modelUsage = false;
+  sessionModals.fork.open = false;
+  sessionModals.fork.entries = [];
+  sessionModals.fork.onSelect = null;
+  sessionModals.catSettings.open = false;
+  sessionModals.catSettings.controller = null;
+  sessionModals.catSettings.onChange = () => {};
+  sessionModals.label.open = false;
+  sessionModals.label.entryId = '';
+  sessionModals.label.currentLabel = '';
+  sessionModals.label.onSave = null;
+}

--- a/web/src/session/session-runtime.js
+++ b/web/src/session/session-runtime.js
@@ -14,6 +14,7 @@ export const sessionRuntime = {
   artifacts: null, // { setArtifacts, selectArtifact, getArtifact, getCount, ... }
   rightSidebar: null, // { toggle, open, collapse, activateTab }
   layout: null, // { isMobileLayout, closeSidebar }
+  toggleState: null, // toggle controller { applyToNode, toggleThinking, ... }
 };
 
 export function resetSessionRuntime() {
@@ -21,4 +22,5 @@ export function resetSessionRuntime() {
   sessionRuntime.artifacts = null;
   sessionRuntime.rightSidebar = null;
   sessionRuntime.layout = null;
+  sessionRuntime.toggleState = null;
 }

--- a/web/src/session/session-runtime.js
+++ b/web/src/session/session-runtime.js
@@ -1,0 +1,24 @@
+// Imperative-handle registry for the live session viewer. Replaces the
+// window.__pi* bridges by which child components published their imperative
+// control surfaces for other components and plain-JS runtime modules to call.
+// Each component assigns its slot on mount and clears it (null) on destroy;
+// consumers read `sessionRuntime.<slot>?.method()`. Reads are all imperative
+// (event handlers / onMount), so a plain object is enough — no reactivity needed.
+//
+// There is one session viewer at a time, so a module singleton suffices;
+// resetSessionRuntime() clears it when <SessionPage> unmounts so SPA re-entry
+// never sees a stale handle. Kept dependency-free so it stays safe to pull into
+// the server-less export bundle (via session-ui-runner).
+export const sessionRuntime = {
+  annotations: null, // { init, setAnnotations, reapply, refresh }
+  artifacts: null, // { setArtifacts, selectArtifact, getArtifact, getCount, ... }
+  rightSidebar: null, // { toggle, open, collapse, activateTab }
+  layout: null, // { isMobileLayout, closeSidebar }
+};
+
+export function resetSessionRuntime() {
+  sessionRuntime.annotations = null;
+  sessionRuntime.artifacts = null;
+  sessionRuntime.rightSidebar = null;
+  sessionRuntime.layout = null;
+}

--- a/web/src/session/ui/session-ui-runner.js
+++ b/web/src/session/ui/session-ui-runner.js
@@ -1,3 +1,5 @@
+import { sessionRuntime } from '../session-runtime.js';
+
 export function setupSessionUi({
   documentImpl = document,
   windowImpl = window,
@@ -64,11 +66,11 @@ export function setupSessionUi({
     attachHeaderHandlers,
     toggleController,
     // The right-sidebar chrome (scratchpad/resize/tabs) lives in <RightSidebar>,
-    // which exposes its controls on window.__piRightSidebar. Read lazily so the
-    // calls resolve against the mounted component.
-    toggleRightSidebar: () => windowImpl.__piRightSidebar?.toggle(),
-    openRightSidebar: () => windowImpl.__piRightSidebar?.open(),
-    collapseRightSidebar: () => windowImpl.__piRightSidebar?.collapse(),
-    activateRightTab: (pane) => windowImpl.__piRightSidebar?.activateTab(pane),
+    // which registers its controls in sessionRuntime.rightSidebar. Read lazily so
+    // the calls resolve against the mounted component.
+    toggleRightSidebar: () => sessionRuntime.rightSidebar?.toggle(),
+    openRightSidebar: () => sessionRuntime.rightSidebar?.open(),
+    collapseRightSidebar: () => sessionRuntime.rightSidebar?.collapse(),
+    activateRightTab: (pane) => sessionRuntime.rightSidebar?.activateTab(pane),
   };
 }

--- a/web/src/session/ui/session-ui-runner.js
+++ b/web/src/session/ui/session-ui-runner.js
@@ -43,8 +43,9 @@ export function setupSessionUi({
   }
 
   const toggleController = toggleStateApi.createToggleController({ documentImpl, storage });
-  windowImpl.sessionToggleState = toggleController;
-  windowImpl.applyToggleStateToNode = (node) => toggleController.applyToNode(node);
+  // Registered so the message-pane afterRender hook (live content-runtime +
+  // export-entry) can re-apply persisted collapse/toggle state to new nodes.
+  sessionRuntime.toggleState = toggleController;
 
   const attachHeaderHandlers = () => toggleController.attachHeaderHandlers();
   const toggleThinking = () => toggleController.toggleThinking();

--- a/web/src/session/ui/session-ui-runner.test.js
+++ b/web/src/session/ui/session-ui-runner.test.js
@@ -1,9 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { setupSessionUi } from './session-ui-runner.js';
 import * as searchFiltersApi from './search-filters.js';
 import * as sidebarApi from './sidebar.js';
 import * as toggleStateApi from './toggle-state.js';
+import { sessionRuntime, resetSessionRuntime } from '../session-runtime.js';
+
+afterEach(() => resetSessionRuntime());
 
 describe('session UI runner', () => {
   it('sets up markdown, sidebar, and toggles', () => {
@@ -29,7 +32,7 @@ describe('session UI runner', () => {
     });
     expect(markdownApi.configureSessionMarkdown).toHaveBeenCalled();
     expect(result.safeMarkedParse('x')).toBe('<p>x</p>');
-    expect(dom.window.sessionToggleState).toBeTruthy();
+    expect(sessionRuntime.toggleState).toBeTruthy();
     expect(typeof result.attachHeaderHandlers).toBe('function');
   });
 

--- a/web/src/settings/settings-support.js
+++ b/web/src/settings/settings-support.js
@@ -1,4 +1,5 @@
 import { configureSettingsSync, hydrateSettings, writeSetting } from '../shared/settings-store.js';
+import { navigate } from '../shared/navigation.js';
 import { t } from '../shared/i18n.js';
 
 export async function loadSettings({ windowImpl = window } = {}) {
@@ -37,13 +38,25 @@ export function setupBackLink(documentImpl, windowImpl) {
   } catch {
     fromApp = false;
   }
-  if (!fromApp) return;
-  const label = link.querySelector('[data-settings-back-label]');
-  if (label) label.textContent = t('common.back');
+  if (fromApp) {
+    const label = link.querySelector('[data-settings-back-label]');
+    if (label) label.textContent = t('common.back');
+  }
   link.addEventListener('click', (e) => {
+    // Defer to the browser for modified clicks (open in new tab/window) and
+    // non-primary buttons so the link's usual affordances keep working.
+    if (e.defaultPrevented) return;
+    if (typeof e.button === 'number' && e.button !== 0) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     e.preventDefault();
-    if (windowImpl.history && windowImpl.history.length > 1) windowImpl.history.back();
-    else windowImpl.location.href = '/';
+    // Arrived from within the app: step back so the index's prior scroll/state
+    // is restored (the popstate listener in App.svelte swaps the view).
+    // Otherwise (direct load / external referrer) navigate to the index route.
+    if (fromApp && windowImpl.history && windowImpl.history.length > 1) {
+      windowImpl.history.back();
+    } else {
+      navigate('/', { windowImpl });
+    }
   });
 }
 

--- a/web/src/settings/settings-support.test.js
+++ b/web/src/settings/settings-support.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { setupBackLink } from './settings-support.js';
+
+function makeLink() {
+  const label = { textContent: '' };
+  let clickHandler = null;
+  const link = {
+    querySelector: (sel) => (sel === '[data-settings-back-label]' ? label : null),
+    addEventListener: (type, handler) => { if (type === 'click') clickHandler = handler; },
+    _click: (init = {}) => {
+      const e = {
+        button: 0,
+        defaultPrevented: false,
+        metaKey: false,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        preventDefault: vi.fn(),
+        ...init,
+      };
+      clickHandler?.(e);
+      return e;
+    },
+  };
+  return { link, label };
+}
+
+function makeDoc(link, referrer) {
+  return {
+    referrer,
+    querySelector: (sel) => (sel === '[data-settings-back]' ? link : null),
+  };
+}
+
+function makeWin({ historyLength = 5 } = {}) {
+  return {
+    location: { origin: 'http://localhost', href: '' },
+    history: { length: historyLength, back: vi.fn(), pushState: vi.fn() },
+  };
+}
+
+describe('setupBackLink', () => {
+  it('does nothing when the back link is absent', () => {
+    const doc = makeDoc(null, 'http://localhost/');
+    expect(() => setupBackLink(doc, makeWin())).not.toThrow();
+  });
+
+  it('from within the app: relabels and steps back through history', () => {
+    const { link, label } = makeLink();
+    const doc = makeDoc(link, 'http://localhost/');
+    const win = makeWin({ historyLength: 5 });
+
+    setupBackLink(doc, win);
+    expect(label.textContent).toBeTruthy(); // relabelled to "Back"
+
+    const e = link._click();
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(win.history.back).toHaveBeenCalled();
+    expect(win.history.pushState).not.toHaveBeenCalled();
+  });
+
+  it('direct load (no app referrer): navigates client-side to the index', () => {
+    const { link } = makeLink();
+    const doc = makeDoc(link, '');
+    const win = makeWin();
+
+    setupBackLink(doc, win);
+    const e = link._click();
+
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(win.history.pushState).toHaveBeenCalledWith({}, '', '/');
+    expect(win.history.back).not.toHaveBeenCalled();
+    expect(win.location.href).toBe('');
+  });
+
+  it('from app but no history to pop: falls back to client-side navigate', () => {
+    const { link } = makeLink();
+    const doc = makeDoc(link, 'http://localhost/');
+    const win = makeWin({ historyLength: 1 });
+
+    setupBackLink(doc, win);
+    link._click();
+
+    expect(win.history.back).not.toHaveBeenCalled();
+    expect(win.history.pushState).toHaveBeenCalledWith({}, '', '/');
+  });
+
+  it('defers to the browser for modified clicks', () => {
+    const { link } = makeLink();
+    const doc = makeDoc(link, '');
+    const win = makeWin();
+
+    setupBackLink(doc, win);
+    const e = link._click({ metaKey: true });
+
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(win.history.pushState).not.toHaveBeenCalled();
+    expect(win.history.back).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/shared/keyboard-nav.js
+++ b/web/src/shared/keyboard-nav.js
@@ -1,3 +1,5 @@
+import { navigate } from './navigation.js';
+
 const SCROLL_AMOUNT = 300;
 const GG_TIMEOUT = 500; // ms window for double-tap 'gg'
 
@@ -78,7 +80,7 @@ export function setupKeyboardNav({
   documentImpl.addEventListener('keydown', (e) => {
     if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === ',') {
       e.preventDefault();
-      windowImpl.location.href = '/settings';
+      navigate('/settings', { windowImpl });
     }
   });
 

--- a/web/src/shared/keyboard-nav.test.js
+++ b/web/src/shared/keyboard-nav.test.js
@@ -65,6 +65,7 @@ describe('setupKeyboardNav', () => {
     return {
       scrollBy: vi.fn(),
       scrollTo: vi.fn(),
+      history: { pushState: vi.fn() },
     };
   }
 
@@ -181,28 +182,26 @@ describe('setupKeyboardNav', () => {
   it('navigates to /settings on Cmd+, (and Ctrl+,)', () => {
     const doc = createMockDocument();
     const win = createMockWindow();
-    win.location = { href: '' };
 
     setupKeyboardNav({ windowImpl: win, documentImpl: doc });
 
     const e1 = doc._dispatch('keydown', { key: ',', metaKey: true });
-    expect(win.location.href).toBe('/settings');
+    expect(win.history.pushState).toHaveBeenCalledWith({}, '', '/settings');
     expect(e1.preventDefault).toHaveBeenCalled();
 
-    win.location.href = '';
+    win.history.pushState.mockClear();
     doc._dispatch('keydown', { key: ',', ctrlKey: true });
-    expect(win.location.href).toBe('/settings');
+    expect(win.history.pushState).toHaveBeenCalledWith({}, '', '/settings');
   });
 
   it('does not navigate to /settings on Cmd+Shift+,', () => {
     const doc = createMockDocument();
     const win = createMockWindow();
-    win.location = { href: '' };
 
     setupKeyboardNav({ windowImpl: win, documentImpl: doc });
     doc._dispatch('keydown', { key: ',', metaKey: true, shiftKey: true });
 
-    expect(win.location.href).toBe('');
+    expect(win.history.pushState).not.toHaveBeenCalled();
   });
 
   it('scrolls down on j', () => {

--- a/web/src/shared/navigation.js
+++ b/web/src/shared/navigation.js
@@ -1,0 +1,29 @@
+// Client-side SPA navigation. App.svelte (the root router) wraps
+// history.pushState to emit a 'pi:locationchange' event and swaps the active
+// page whenever window.location.pathname changes, so pushing a URL here
+// navigates between SPA routes (e.g. the sessions index → a session view)
+// without a full page reload.
+
+function resolveWindow(windowImpl) {
+  if (windowImpl) return windowImpl;
+  return typeof window !== 'undefined' ? window : undefined;
+}
+
+export function navigate(url, { windowImpl } = {}) {
+  const win = resolveWindow(windowImpl);
+  if (!url || !win) return;
+  win.history.pushState({}, '', url);
+}
+
+// Click handler for <a> elements that point at an internal SPA route. Defers to
+// the browser's default navigation for modified clicks (open in new tab/window),
+// non-primary mouse buttons, and already-handled events, so the usual link
+// affordances keep working; otherwise it intercepts and navigates client-side.
+export function handleNavClick(event, url, { windowImpl } = {}) {
+  if (!url || !event) return;
+  if (event.defaultPrevented) return;
+  if (typeof event.button === 'number' && event.button !== 0) return;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+  event.preventDefault();
+  navigate(url, { windowImpl });
+}

--- a/web/src/shared/navigation.test.js
+++ b/web/src/shared/navigation.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { navigate, handleNavClick } from './navigation.js';
+
+function makeWindow() {
+  return { history: { pushState: vi.fn() } };
+}
+
+function makeEvent(overrides = {}) {
+  return {
+    button: 0,
+    defaultPrevented: false,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    preventDefault: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('navigate', () => {
+  it('pushes the url onto history', () => {
+    const windowImpl = makeWindow();
+    navigate('/session?id=abc', { windowImpl });
+    expect(windowImpl.history.pushState).toHaveBeenCalledWith({}, '', '/session?id=abc');
+  });
+
+  it('ignores empty urls', () => {
+    const windowImpl = makeWindow();
+    navigate('', { windowImpl });
+    expect(windowImpl.history.pushState).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleNavClick', () => {
+  it('intercepts a plain left click and navigates', () => {
+    const windowImpl = makeWindow();
+    const event = makeEvent();
+    handleNavClick(event, '/session?id=abc', { windowImpl });
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(windowImpl.history.pushState).toHaveBeenCalledWith({}, '', '/session?id=abc');
+  });
+
+  it.each([
+    ['metaKey', { metaKey: true }],
+    ['ctrlKey', { ctrlKey: true }],
+    ['shiftKey', { shiftKey: true }],
+    ['altKey', { altKey: true }],
+    ['middle click', { button: 1 }],
+    ['already handled', { defaultPrevented: true }],
+  ])('defers to the browser for %s', (_label, overrides) => {
+    const windowImpl = makeWindow();
+    const event = makeEvent(overrides);
+    handleNavClick(event, '/session?id=abc', { windowImpl });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(windowImpl.history.pushState).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without a url', () => {
+    const windowImpl = makeWindow();
+    const event = makeEvent();
+    handleNavClick(event, '', { windowImpl });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(windowImpl.history.pushState).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add client-side SPA navigation: route browser navigation via `pushState`/`popstate` in `App.svelte`, and key `<SessionPage>` on the `?id=` param so session→session navigation tears down and remounts instead of no-op'ing. Fork/clone/new-session flows now go through `navigate()` instead of full page reloads.
- Replace the session component-handle, modal, and toggle-state `window` bridges with a reactive store (`session-modals.svelte.js`) and a `session-runtime` registry.
- Fix a blank settings page during client-side navigation when a custom font is set: make `AppearanceSettings` template helpers pure so they no longer write `$state` inside an `{#each}` block effect (`state_unsafe_mutation`).
- Test/CI hardening: guard `fakeSender` shared fields with a mutex to fix a `-race` data race; restore the `window.__piCatGatekeeper` e2e seam dropped by the registry refactor and pin its sleep window; de-flake the load-earlier e2e by relying on auto-retrying assertions.

## Testing
- Not run (not requested)
