### PR TITLE
refactor(session): extract live runtime context

### DIFF
--- a/docs/dev/codex-goal.md
+++ b/docs/dev/codex-goal.md
@@ -1,0 +1,114 @@
+Refactor the pi-web frontend session architecture according to the plan in plan.md.
+
+Goal: reduce SessionPage.svelte complexity, replace implicit window bridges with explicit runtime context where possible, strengthen live/export boundaries, and improve maintainability without changing user-visible behavior.
+
+Important constraints:
+- Do not rewrite the app from scratch.
+- Do not merge live app and export paths.
+- Do not break static export/share.
+- Do not remove all window.* bridges in one risky change; replace them incrementally with compatibility shims where needed.
+- Preserve current behavior for chat, SSE live reload, annotations, artifacts, navigation, session tree, right sidebar, keyboard shortcuts, settings, and export.
+- Keep changes small and testable.
+- Follow existing project architecture and docs, especially:
+  - AGENTS.md
+  - docs/architecture/system-overview.md
+  - docs/dev/templates-vs-web.md
+  - docs/sequence-flows/chat.md
+  - docs/sequence-flows/live-reload.md
+  - docs/sequence-flows/artifacts.md
+  - docs/sequence-flows/annotations.md
+
+Implementation plan:
+
+1. Add explicit session runtime context
+   - Create a focused runtime context module, likely:
+     web/src/session/session-runtime-context.js
+   - It should expose APIs similar to:
+     setSessionRuntime(...)
+     getSessionRuntime(...)
+     resetSessionRuntimeContext(...)
+   - Runtime context should hold explicit references for:
+     model
+     navigator
+     navigateTo
+     reconcileEntries
+     contentRuntime
+     annotations/artifacts hooks if appropriate
+   - Keep existing window.* bridges as temporary compatibility shims if still required:
+     window.navigateTo
+     window.__piSessionDataModel
+     window.__piReconcileEntries
+     window.__piContentRuntime
+   - Prefer new code using context instead of window.
+
+2. Shrink SessionPage.svelte
+   - Extract session loading/model hydration into a focused module, likely under:
+     web/src/session/page/
+   - Extract layout/body class handling into a focused helper.
+   - Extract navigation setup into a focused helper.
+   - Extract annotation setup into a focused helper.
+   - Extract runtime bootstrapping into a focused helper.
+   - Keep SessionPage.svelte mostly declarative: load state, initialize runtime, render components.
+   - If useful, create:
+     web/src/components/session/SessionShell.svelte
+     to hold the large rendered session component tree.
+
+3. Preserve session behavior
+   - SessionPage must still:
+     load session data from the existing API/bootstrap flow
+     hydrate SessionDataModel
+     set document title
+     support navigateTo behavior
+     support LiveReload reconciliation
+     support ChatComposer
+     support annotations
+     support artifacts/right sidebar
+     support keyboard shortcuts
+     support lazy highlighting
+     cleanup all runtime/global listeners on unmount
+
+4. Replace window bridges gradually
+   - Migrate direct consumers to the new runtime context where practical.
+   - Keep compatibility aliases only when needed.
+   - Add comments marking remaining window bridges as temporary compatibility shims.
+   - Do not remove a bridge unless tests and source search confirm it is unused.
+
+5. Strengthen export/live boundary safety
+   - Add or improve tests that prevent export-reachable code from importing live-only modules.
+   - Export must not import or bundle:
+     web/src/session/chat/
+     web/src/session/live/
+     web/src/session/session-globals.js
+     web/src/components/session/ChatComposer.svelte
+     web/src/components/session/LiveReload.svelte
+   - Preserve existing TestExportBundleIsSelfContained behavior.
+   - Add a source-level import-boundary test if appropriate so violations fail earlier.
+
+6. CSS
+   - Do not do a large CSS migration.
+   - Only make CSS changes if required by component extraction.
+   - Keep global/shared CSS in internal/ui/embedded/styles unless there is a very low-risk component-specific move.
+   - Preserve live/export styling.
+
+7. Tests and validation
+   - Add/update tests for new helper modules.
+   - Update existing tests only where refactor changes structure, not behavior.
+   - Run relevant frontend tests.
+   - Run Go tests if export boundary or embed-related code changes.
+   - Prefer:
+     npm test -- --run
+     go test ./...
+     make build
+   - If full test/build is too slow, run targeted tests first, then clearly run broader validation before finishing.
+
+Acceptance criteria:
+- SessionPage.svelte is significantly smaller and easier to read.
+- Session boot logic is split into focused modules with clear names.
+- New session runtime context exists and is used by new/refactored code.
+- Remaining window.* bridges are minimized and documented as compatibility shims.
+- Live session behavior remains unchanged.
+- Static export remains self-contained and does not import live-only modules.
+- Existing tests pass, and new tests cover important extracted helpers/boundary checks.
+- No unrelated UI/behavior changes are introduced.
+
+Work continuously through the full refactor. Do not stop after only writing a plan. Implement, test, fix regressions, and only finish when the acceptance criteria are met.

--- a/web/src/components/session/ChatComposer.svelte
+++ b/web/src/components/session/ChatComposer.svelte
@@ -1955,6 +1955,7 @@ export function setupMentionAutocomplete({
 <script>
   import { onMount } from 'svelte';
   import { escapeHtml } from '../../session/render/session-format.js';
+  import { getSessionRuntime } from '../../session/session-runtime-context.js';
   import * as chatApi from '../../session/chat/chat-api.js';
   import GitFooter from './GitFooter.svelte';
 
@@ -1967,12 +1968,13 @@ export function setupMentionAutocomplete({
   } = $props();
 
   // The composer runtime lives in <script module> (runChatComposer). It reads the
-  // shared model + navigateTo (owned by SessionPage, on window) at mount — both
-  // are ready before this onMount. <LiveReload> mounts first, so its
+  // shared model + navigateTo (owned by SessionPage runtime context) at mount —
+  // both are ready before this onMount. <LiveReload> mounts first, so its
   // pi-chat-message-sent listener is attached before the user can send. Live-only.
   onMount(() => {
     const target = window;
-    const model = target.__piSessionDataModel;
+    const runtime = getSessionRuntime();
+    const model = runtime.model || target.__piSessionDataModel;
     globalThis.__PI_TEST_CHAT_COMPOSER_HOOK__?.();
     runChatComposer({
       documentImpl: document,
@@ -1982,7 +1984,7 @@ export function setupMentionAutocomplete({
       leafId: model?.leafId || '',
       urlTargetId: model?.urlTargetId || '',
       byId: model?.byId || new Map(),
-      navigateTo: target.navigateTo,
+      navigateTo: runtime.navigateTo || target.navigateTo,
       escapeHtml: (text) => escapeHtml(text, { documentImpl: document }),
       chatApi,
       FormDataImpl: target.FormData,

--- a/web/src/components/session/LiveReload.svelte
+++ b/web/src/components/session/LiveReload.svelte
@@ -536,7 +536,7 @@ export function updateStatsDom(entries, { documentImpl = document } = {}) {
   // and reconciles the shared reactive model when the session JSONL changes. The
   // Svelte <SessionContent> owns #messages and re-renders from the model, so this
   // never patches the message DOM (reactive-only): on reload it reconciles the
-  // model (window.__piReconcileEntries) and only tracks brand-new ids for the
+  // model (session runtime context, with window shim fallback) and only tracks brand-new ids for the
   // follow/scroll/highlight decisions. Live-only: never imported by the static
   // export bundle.
   //
@@ -550,11 +550,13 @@ export function updateStatsDom(entries, { documentImpl = document } = {}) {
   import { escapeHtml } from '../../session/render/session-format.js';
   import { safeMarkedParse } from '../../session/render/markdown.js';
   import { sessionRuntime } from '../../session/session-runtime.js';
+  import { getSessionRuntime } from '../../session/session-runtime-context.js';
 
   onMount(() => {
     const documentImpl = document;
     const windowImpl = window;
-    const model = windowImpl.__piSessionDataModel;
+    const runtime = getSessionRuntime();
+    const model = runtime.model || windowImpl.__piSessionDataModel;
     globalThis.__PI_TEST_LIVE_RELOAD_HOOK__?.();
 
     const fetchImpl = windowImpl.fetch.bind(windowImpl);
@@ -754,7 +756,7 @@ export function updateStatsDom(entries, { documentImpl = document } = {}) {
         scrollAfterLayout,
         incrementPending: (count) => { pendingCount += count; },
         showFollowButton,
-        onReloaded: (data) => { windowImpl.__piReconcileEntries?.(data.entries); },
+        onReloaded: (data) => { (runtime.reconcileEntries || windowImpl.__piReconcileEntries)?.(data.entries); },
         onNewEntries: highlightNewEntries,
       }).catch((err) => { console.error('Live update failed:', err); });
     }

--- a/web/src/components/session/SessionShell.svelte
+++ b/web/src/components/session/SessionShell.svelte
@@ -1,0 +1,71 @@
+<script>
+  import ChatComposer from './ChatComposer.svelte';
+  import LiveReload from './LiveReload.svelte';
+  import CommandMenu from './CommandMenu.svelte';
+  import RightSidebar from './RightSidebar.svelte';
+  import SessionHeader from './SessionHeader.svelte';
+  import SessionInfoHeader from './SessionInfoHeader.svelte';
+  import SessionContent from './SessionContent.svelte';
+  import ImageModal from './ImageModal.svelte';
+  import ShortcutsModal from './ShortcutsModal.svelte';
+  import ModelUsageModal from './ModelUsageModal.svelte';
+  import ForkModal from './ForkModal.svelte';
+  import CatGatekeeperSettings from './CatGatekeeperSettings.svelte';
+  import CatGatekeeper from './CatGatekeeper.svelte';
+  import BtwPopup from './BtwPopup.svelte';
+  import LabelModal from './LabelModal.svelte';
+  import LoadEarlier from './LoadEarlier.svelte';
+  import SessionTree from './SessionTree.svelte';
+  import ShareDialog from './ShareDialog.svelte';
+  import { sessionModals } from '../../session/session-modals.svelte.js';
+  import { getSessionRuntime } from '../../session/session-runtime-context.js';
+
+  let {
+    sessionModel,
+    contentRuntime,
+    sessionId = '',
+    title = 'Session',
+    scratchpad = '',
+    cwd = '',
+    chatAvailable = true,
+    chatDisabledReason = '',
+    modelLabel = '',
+    dataEl = $bindable(null),
+  } = $props();
+
+  const runtime = getSessionRuntime();
+</script>
+
+<SessionHeader {title} {cwd} {sessionId} />
+
+<CommandMenu {sessionId} />
+
+<!-- Live reload (SSE) mounts before <ChatComposer> so its optimistic
+     "message sent" listener is attached before the user can send. -->
+<LiveReload />
+
+<div id="sidebar-overlay"></div>
+<div id="app">
+  <SessionTree />
+  <div id="content-container" class="content-container">
+    <main id="content">
+      <div id="header-container"><SessionInfoHeader model={sessionModel} /></div>
+      <LoadEarlier model={sessionModel} {sessionId} navigateTo={runtime.navigateTo} />
+      <div id="messages"><SessionContent model={sessionModel} afterRender={contentRuntime.afterRender} live /></div>
+    </main>
+    <ChatComposer {sessionId} {chatAvailable} {chatDisabledReason} {cwd} {modelLabel} />
+  </div>
+  <RightSidebar {scratchpad} projectPath={cwd} />
+  <ImageModal />
+</div>
+
+<ShortcutsModal bind:open={sessionModals.shortcuts} />
+<ModelUsageModal bind:open={sessionModals.modelUsage} />
+<ForkModal bind:open={sessionModals.fork.open} entries={sessionModals.fork.entries} onSelect={sessionModals.fork.onSelect} />
+<CatGatekeeperSettings bind:open={sessionModals.catSettings.open} controller={sessionModals.catSettings.controller} onChange={sessionModals.catSettings.onChange} />
+<LabelModal bind:open={sessionModals.label.open} entryId={sessionModals.label.entryId} currentLabel={sessionModals.label.currentLabel} onSave={sessionModals.label.onSave} />
+
+<ShareDialog {sessionId} />
+<CatGatekeeper />
+<BtwPopup {cwd} parentId={sessionId} />
+<svelte:element this={'script'} id="session-data" type="application/json" bind:this={dataEl}></svelte:element>

--- a/web/src/components/session/SessionTree.svelte
+++ b/web/src/components/session/SessionTree.svelte
@@ -3,19 +3,21 @@
   import { t } from '../../shared/i18n.js';
   import { getSessionModel } from '../../session/session-context.js';
   import { sessionRuntime } from '../../session/session-runtime.js';
+  import { getSessionRuntime } from '../../session/session-runtime-context.js';
   import SessionTreeNodes from './SessionTreeNodes.svelte';
 
   const model = getSessionModel();
 
-  // Route a tree-node click through the imperative navigator (window.navigateTo,
-  // installed by session.js) so message content scrolls/renders; the navigator's
+  // Route a tree-node click through the imperative navigator so message content
+  // scrolls/renders; the navigator's
   // onNavigate writes back to the model, which re-highlights the tree reactively.
   // Parity with the old tree-renderer: navigate to the newest leaf under the
   // clicked node, with the clicked node as the scroll target; auto-close the
   // drawer on mobile.
   function onNavigate(id) {
     const leaf = model?.newestLeaf(id) || id;
-    window.navigateTo?.(leaf, 'target', id);
+    const navigateTo = getSessionRuntime().navigateTo || window.navigateTo;
+    navigateTo?.(leaf, 'target', id);
     if (sessionRuntime.layout?.isMobileLayout?.()) sessionRuntime.layout?.closeSidebar?.();
   }
 </script>

--- a/web/src/components/shared/CommandPalette.svelte
+++ b/web/src/components/shared/CommandPalette.svelte
@@ -1,4 +1,6 @@
 <script module>
+  import { getSessionRuntime } from '../../session/session-runtime-context.js';
+
   function debounce(fn, ms) {
     let timer;
     return (...args) => {
@@ -62,7 +64,7 @@
 
   export function defaultSessionPaletteCwd(windowImpl = window) {
     try {
-      const preload = windowImpl.__piSessionDataModel;
+      const preload = getSessionRuntime().model || windowImpl.__piSessionDataModel;
       const data = preload && typeof preload.header === 'object' ? preload.header : {};
       return data.cwd || '';
     } catch {

--- a/web/src/export/export-boundary.test.js
+++ b/web/src/export/export-boundary.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const exportEntry = path.join(srcRoot, 'export', 'export-entry.js');
+
+const forbidden = [
+  'session/chat/',
+  'session/live/',
+  'session/session-globals.js',
+  'components/session/ChatComposer.svelte',
+  'components/session/LiveReload.svelte',
+];
+
+function normalize(file) {
+  return path.relative(srcRoot, file).split(path.sep).join('/');
+}
+
+function resolveImport(specifier, importer) {
+  if (!specifier.startsWith('.')) return null;
+  const base = path.resolve(path.dirname(importer), specifier);
+  const candidates = [
+    base,
+    `${base}.js`,
+    `${base}.svelte`,
+    path.join(base, 'index.js'),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile()) || null;
+}
+
+function importsFor(file) {
+  const source = fs.readFileSync(file, 'utf8');
+  const specs = [];
+  const re = /\bimport\s+(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/g;
+  let match;
+  while ((match = re.exec(source))) specs.push(match[1]);
+  return specs;
+}
+
+function collectGraph(entry) {
+  const seen = new Set();
+  const stack = [entry];
+  while (stack.length) {
+    const file = stack.pop();
+    if (!file || seen.has(file)) continue;
+    seen.add(file);
+    for (const specifier of importsFor(file)) {
+      const resolved = resolveImport(specifier, file);
+      if (resolved) stack.push(resolved);
+    }
+  }
+  return Array.from(seen).map(normalize).sort();
+}
+
+describe('export source boundary', () => {
+  it('does not import live-only session modules', () => {
+    const graph = collectGraph(exportEntry);
+    const leaks = graph.filter((file) => forbidden.some((prefix) => file.startsWith(prefix) || file === prefix));
+    expect(leaks).toEqual([]);
+  });
+});

--- a/web/src/routes/SessionPage.svelte
+++ b/web/src/routes/SessionPage.svelte
@@ -1,46 +1,21 @@
 <script>
   import { onMount, tick } from 'svelte';
-  import ChatComposer from '../components/session/ChatComposer.svelte';
-  import LiveReload from '../components/session/LiveReload.svelte';
-  import CommandMenu from '../components/session/CommandMenu.svelte';
-  import RightSidebar from '../components/session/RightSidebar.svelte';
-  import SessionHeader from '../components/session/SessionHeader.svelte';
-  import SessionInfoHeader from '../components/session/SessionInfoHeader.svelte';
-  import SessionContent from '../components/session/SessionContent.svelte';
-  import ImageModal from '../components/session/ImageModal.svelte';
-  import ShortcutsModal from '../components/session/ShortcutsModal.svelte';
-  import ModelUsageModal from '../components/session/ModelUsageModal.svelte';
-  import ForkModal from '../components/session/ForkModal.svelte';
-  import CatGatekeeperSettings from '../components/session/CatGatekeeperSettings.svelte';
-  import CatGatekeeper from '../components/session/CatGatekeeper.svelte';
-  import BtwPopup from '../components/session/BtwPopup.svelte';
-  import LabelModal from '../components/session/LabelModal.svelte';
-  import LoadEarlier from '../components/session/LoadEarlier.svelte';
-  import SessionTree from '../components/session/SessionTree.svelte';
-  import ShareDialog from '../components/session/ShareDialog.svelte';
-  import { marked } from 'marked';
+  import SessionShell from '../components/session/SessionShell.svelte';
   import { applyLazyHighlighting } from '../session/lazy-highlight.js';
-  import { wireSessionContentRuntime } from '../session/session-content-runtime.js';
-  import { setupSessionGlobals } from '../session/session-globals.js';
-  import { setupSessionUi } from '../session/ui/session-ui-runner.js';
-  import { createAnnotationApi } from '../session/annotations/annotation-api.js';
-  import { configureSessionMarkdown, safeMarkedParse } from '../session/render/markdown.js';
-  import * as sidebarApi from '../session/ui/sidebar.js';
-  import * as searchFiltersApi from '../session/ui/search-filters.js';
-  import * as toggleStateApi from '../session/ui/toggle-state.js';
   import { loadSessionPageState } from './session-page-data.js';
   import { SessionDataModel } from '../session/data/session-data.svelte.js';
-  import { createSessionDataModel, decodeBase64JSON } from '../session/data/session-data.js';
-  import { createSessionNavigator } from '../session/navigation/session-navigation.js';
+  import { hydrateSessionModel, createLiveSessionRuntime } from '../session/page/session-page-model.js';
+  import { applySessionPageBodyClasses, applyStoredSessionLayout } from '../session/page/session-page-layout.js';
+  import { startSessionPageRuntime } from '../session/page/session-page-runtime.js';
   import { setSessionModel } from '../session/session-context.js';
-  import { sessionModals, resetSessionModals } from '../session/session-modals.svelte.js';
-  import { sessionRuntime, resetSessionRuntime } from '../session/session-runtime.js';
-  import { configureSettingsSync, hydrateSettings } from '../shared/settings-store.js';
+  import { resetSessionModals } from '../session/session-modals.svelte.js';
+  import { resetSessionRuntime } from '../session/session-runtime.js';
+  import { resetSessionRuntimeContext } from '../session/session-runtime-context.js';
   import { t } from '../shared/i18n.js';
 
   // The reactive session model (docs/dev/svelte-migration-plan.md): created once
   // and provided via context so descendant components read from it. Hydrated
-  // from the session payload below; the live runtime (startSessionRuntime in
+  // from the session payload below; the live runtime (startSessionPageRuntime in
   // onMount) mutates it on reload.
   const sessionModel = setSessionModel(new SessionDataModel());
 
@@ -49,11 +24,6 @@
   // render. wireSessionContentRuntime() (in onMount) assigns it (toggle state +
   // lazy highlight); the $state proxy makes the hook apply reactively.
   const contentRuntime = $state({ afterRender: null });
-
-  // Modal/sheet open-state lives in the shared sessionModals store so the
-  // command menu, keyboard globals, content runtime, and cat-gatekeeper can open
-  // them by importing the store helpers instead of via window bridges. The modal
-  // components below bind directly to it.
 
   let loading = $state(true);
   let showLoading = $state(false);
@@ -68,119 +38,12 @@
   let modelLabel = $state('');
   let dataEl = $state(null);
 
-
   onMount(() => {
     const previousTitle = document.title;
     let active = true;
-    let disposeGlobals = null;
-    let removeAnnotationReload = null;
-
-    // Live session runtime — the imperative wiring that used to live in
-    // session.js's runSessionApp (Svelte migration teardown). Runs once the
-    // payload + reactive model are ready and the components have mounted.
-    const startSessionRuntime = () => {
-      const model = sessionModel;
-      // Per-page settings + markdown bootstrap (mirrors index/settings pages).
-      configureSettingsSync({ fetchImpl: window.fetch ? window.fetch.bind(window) : undefined });
-      hydrateSettings({ storage: window.localStorage });
-      window.marked = window.marked || marked;
-
-      // Wire the live message pane: entry renderer + content runtime + the
-      // delegated copy/fork/label handler on #messages.
-      const { sessionFormat } = wireSessionContentRuntime({
-        windowImpl: window,
-        documentImpl: document,
-        model,
-        sessionId,
-        contentRuntime,
-        applyLazyHighlighting,
-      });
-
-      // Sidebar / search / tree-toggle / header runtime.
-      const ui = setupSessionUi({
-        documentImpl: document,
-        windowImpl: window,
-        storage: window.localStorage,
-        marked,
-        hljs: null,
-        escapeHtml: sessionFormat.escapeHtml,
-        markdownApi: { configureSessionMarkdown, safeMarkedParse },
-        searchFiltersApi,
-        sidebarApi,
-        toggleStateApi,
-        getLeafId: () => model.leafId,
-        setSearchQuery: (value) => { model.searchQuery = value; },
-        setFilterMode: (value) => { model.filterMode = value; },
-        // The reactive model recomputes filteredNodes; no manual rerender needed.
-        forceTreeRerender: () => {},
-        navigateTo: (...args) => window.navigateTo(...args),
-      });
-
-      // Exposed for <SessionTree>'s node-click handler (auto-close mobile drawer).
-      sessionRuntime.layout = { isMobileLayout: ui.isMobileLayout, closeSidebar: ui.closeSidebar };
-
-      // The header card is a persistent <SessionInfoHeader>, so bind its toggle
-      // buttons exactly once.
-      ui.attachHeaderHandlers();
-
-      // Replace the server-rendered first-message LCP stub with the canonical
-      // active path before live reload starts (otherwise reload appends entries
-      // below the stub and the conversation appears duplicated).
-      window.navigateTo(model.currentLeafId, model.urlTargetId ? 'target' : 'bottom', model.urlTargetId || null);
-
-      // Annotation layer (right-sidebar "Notes" tab) — <AnnotationLayer> registers
-      // init/setAnnotations/reapply in sessionRuntime.annotations; supply its
-      // runtime deps here. Anchors to entries by `entry-<id>` + offsets.
-      const annotationLayer = sessionRuntime.annotations || null;
-      const messagesEl = document.getElementById('messages');
-      if (annotationLayer && messagesEl && sessionId) {
-        const annotationArtifactHost = document.getElementById('artifact-panel-host');
-        annotationLayer.init({
-          api: createAnnotationApi({ sessionId, fetchImpl: window.fetch.bind(window) }),
-          scopes: [messagesEl, annotationArtifactHost].filter(Boolean),
-          composerEl: document.getElementById('pi-chat-message'),
-          countEl: document.getElementById('annotation-tab-count'),
-          onSelectArtifact: (artifactId) => {
-            ui.activateRightTab('artifacts');
-            sessionRuntime.artifacts?.selectArtifact(artifactId);
-          },
-          onCreate: () => {
-            ui.openRightSidebar();
-            ui.activateRightTab('notes');
-          },
-          onSend: () => {
-            // On mobile the sidebar is a full-screen overlay; collapse it so the
-            // composer it just filled is visible and ready to type into.
-            if (ui.isMobileLayout()) ui.collapseRightSidebar();
-          },
-          onAddToChat: (attachment) => {
-            window.dispatchEvent(new window.CustomEvent('pi-chat-attach-text', { detail: attachment }));
-            if (ui.isMobileLayout()) ui.collapseRightSidebar();
-          },
-          resolveArtifact: (artifactId) => sessionRuntime.artifacts?.getArtifact(artifactId) || null,
-        });
-        const onAnnotationReload = () => annotationLayer.reapply();
-        window.addEventListener('pi-session-reload', onAnnotationReload);
-        removeAnnotationReload = () => window.removeEventListener('pi-session-reload', onAnnotationReload);
-      }
-
-      // Page-global glue (keyboard shortcuts, done-notifier,
-      // visual-viewport/scroll). After the
-      // above so the sidebar / right-sidebar window bridges exist.
-      disposeGlobals = setupSessionGlobals({
-        windowImpl: window,
-        documentImpl: document,
-        model,
-        sessionId,
-        navigateTo: window.navigateTo,
-      });
-    };
-
-    // The session view is a fixed app shell (no body scroll, internal scroll
-    // containers). Mark the document so the session-only layout rules in the
-    // shared SPA stylesheet do not pin body height on the index/settings pages.
-    document.documentElement.classList.add('pi-session-page');
-    document.body.classList.add('pi-session-page');
+    let disposeRuntime = null;
+    const disposeBodyClasses = applySessionPageBodyClasses({ documentImpl: document });
+    applyStoredSessionLayout({ documentImpl: document, windowImpl: window, storage: window.localStorage });
 
     // Avoid flashing the loading text on fast (localhost) loads: only reveal the
     // indicator if the fetch is still pending after a short delay.
@@ -201,27 +64,8 @@
         chatAvailable = state.chatAvailable;
         chatDisabledReason = state.chatDisabledReason;
         modelLabel = state.modelLabel;
-        // Hydrate the shared reactive model from the embedded payload and expose
-        // it on window so the live runtime + chat/live components share this one
-        // instance. The Svelte tree/content render from it; live reload mutates it.
-        sessionModel.load(createSessionDataModel(
-          decodeBase64JSON(payloadBase64, { atobImpl: window.atob?.bind(window) }),
-          new URLSearchParams(window.location.search),
-        ));
-        window.__piSessionDataModel = sessionModel;
-        // navigateTo ownership lives here: the navigator writes the reactive
-        // model's active leaf/target (→ <SessionContent>/<SessionTree> recompute)
-        // and scrolls. Exposed on window BEFORE the child components mount so the
-        // tree, chat composer, and live reload share this one instance.
-        const navigator = createSessionNavigator({
-          onNavigate: (leaf, target) => { sessionModel.currentLeafId = leaf; sessionModel.currentTargetId = target; },
-        });
-        window.navigateTo = navigator.navigateTo;
-        window.__piSessionNavigator = navigator;
-        // Model reconciliation for <LiveReload> (SSE) + the load-earlier banner.
-        // Set before the child components mount so a reload can never race it.
-        window.__piReconcileEntries = (entries) => sessionModel.reconcile(entries);
-        window.__piContentRuntime = contentRuntime;
+        hydrateSessionModel({ sessionModel, payloadBase64, locationSearch: window.location.search, windowImpl: window });
+        createLiveSessionRuntime({ sessionModel, contentRuntime, windowImpl: window, documentImpl: document });
         loading = false;
         clearTimeout(loadingTimer);
         await tick();
@@ -229,7 +73,12 @@
         // Svelte does not interpolate mustache tags inside a <script> raw-text
         // element, so the embedded session payload must be assigned directly.
         if (dataEl) dataEl.textContent = payloadBase64;
-        startSessionRuntime();
+        disposeRuntime = startSessionPageRuntime({
+          sessionId,
+          applyLazyHighlighting,
+          windowImpl: window,
+          documentImpl: document,
+        });
         applyLazyHighlighting(document);
       } catch (err) {
         if (!active) return;
@@ -242,13 +91,12 @@
     return () => {
       active = false;
       clearTimeout(loadingTimer);
-      disposeGlobals?.();
-      removeAnnotationReload?.();
+      disposeRuntime?.();
       resetSessionModals();
       resetSessionRuntime();
+      resetSessionRuntimeContext({ windowImpl: window });
       document.title = previousTitle;
-      document.documentElement.classList.remove('pi-session-page');
-      document.body.classList.remove('pi-session-page');
+      disposeBodyClasses();
     };
   });
 </script>
@@ -258,35 +106,16 @@
 {:else if error}
   <div class="session-loading"><h1>{error}</h1><p><a href="/">{t('session.backToSessions')}</a></p></div>
 {:else}
-  <script>try{const c=localStorage.getItem('pi-share:v1:sidebar-collapsed');if(c==='true')document.body.classList.add('sidebar-collapsed');}catch(e){}try{const lw=Number(localStorage.getItem('pi-share:v1:sidebar-width'));if(isFinite(lw)&&lw>0)document.documentElement.style.setProperty('--sidebar-width',Math.round(lw)+'px');}catch(e){}try{const rc=localStorage.getItem('pi-web:v1:right-sidebar-collapsed');const mobile=window.matchMedia&&window.matchMedia('(max-width: 900px)').matches;if(rc==='true'||mobile)document.body.classList.add('right-sidebar-collapsed');}catch(e){}try{const w=Number(localStorage.getItem('pi-web:v1:right-sidebar-width'));if(isFinite(w)&&w>0)document.documentElement.style.setProperty('--right-sidebar-width',Math.round(w)+'px');}catch(e){}</script>
-
-  <SessionHeader {title} {cwd} {sessionId} />
-
-  <CommandMenu {sessionId} />
-
-  <!-- Live reload (SSE) mounts before <ChatComposer> so its optimistic
-       "message sent" listener is attached before the user can send. -->
-  <LiveReload />
-
-  <div id="sidebar-overlay"></div>
-  <div id="app">
-    <SessionTree />
-    <div id="content-container" class="content-container">
-      <main id="content"><div id="header-container">{#if sessionModel}<SessionInfoHeader model={sessionModel} />{/if}</div>{#if sessionModel}<LoadEarlier model={sessionModel} {sessionId} navigateTo={typeof window !== 'undefined' ? window.navigateTo : null} />{/if}<div id="messages">{#if sessionModel}<SessionContent model={sessionModel} afterRender={contentRuntime.afterRender} live />{/if}</div></main>
-      <ChatComposer {sessionId} {chatAvailable} {chatDisabledReason} {cwd} {modelLabel} />
-    </div>
-    <RightSidebar {scratchpad} projectPath={cwd} />
-    <ImageModal />
-  </div>
-
-  <ShortcutsModal bind:open={sessionModals.shortcuts} />
-  <ModelUsageModal bind:open={sessionModals.modelUsage} />
-  <ForkModal bind:open={sessionModals.fork.open} entries={sessionModals.fork.entries} onSelect={sessionModals.fork.onSelect} />
-  <CatGatekeeperSettings bind:open={sessionModals.catSettings.open} controller={sessionModals.catSettings.controller} onChange={sessionModals.catSettings.onChange} />
-  <LabelModal bind:open={sessionModals.label.open} entryId={sessionModals.label.entryId} currentLabel={sessionModals.label.currentLabel} onSave={sessionModals.label.onSave} />
-
-  <ShareDialog {sessionId} />
-  <CatGatekeeper />
-  <BtwPopup {cwd} parentId={sessionId} />
-  <script id="session-data" type="application/json" bind:this={dataEl}></script>
+  <SessionShell
+    {sessionModel}
+    {contentRuntime}
+    {sessionId}
+    {title}
+    {scratchpad}
+    {cwd}
+    {chatAvailable}
+    {chatDisabledReason}
+    {modelLabel}
+    bind:dataEl
+  />
 {/if}

--- a/web/src/session/data/session-data.svelte.js
+++ b/web/src/session/data/session-data.svelte.js
@@ -5,7 +5,7 @@
 // (session-data.js): it exposes the same fields (entries, header, byId,
 // toolCallMap, labelMap, leafId, urlTargetId, systemPrompt, tools,
 // renderedTools, total/from/truncated) so the imperative session.js / export
-// runtimes can use it via window.__piSessionDataModel with no field changes —
+// runtimes can use it via the session runtime context/window shim with no field changes —
 // while ALSO being reactive so the Svelte tree updates automatically.
 //
 // Key reactivity rules that keep it compatible with the imperative code:

--- a/web/src/session/page/session-page-annotations.js
+++ b/web/src/session/page/session-page-annotations.js
@@ -1,0 +1,41 @@
+import { createAnnotationApi } from '../annotations/annotation-api.js';
+import { sessionRuntime } from '../session-runtime.js';
+
+export function setupSessionAnnotations({
+  sessionId,
+  ui,
+  windowImpl = window,
+  documentImpl = document,
+} = {}) {
+  const annotationLayer = sessionRuntime.annotations || null;
+  const messagesEl = documentImpl.getElementById('messages');
+  if (!annotationLayer || !messagesEl || !sessionId) return () => {};
+
+  const annotationArtifactHost = documentImpl.getElementById('artifact-panel-host');
+  annotationLayer.init({
+    api: createAnnotationApi({ sessionId, fetchImpl: windowImpl.fetch.bind(windowImpl) }),
+    scopes: [messagesEl, annotationArtifactHost].filter(Boolean),
+    composerEl: documentImpl.getElementById('pi-chat-message'),
+    countEl: documentImpl.getElementById('annotation-tab-count'),
+    onSelectArtifact: (artifactId) => {
+      ui.activateRightTab('artifacts');
+      sessionRuntime.artifacts?.selectArtifact(artifactId);
+    },
+    onCreate: () => {
+      ui.openRightSidebar();
+      ui.activateRightTab('notes');
+    },
+    onSend: () => {
+      if (ui.isMobileLayout()) ui.collapseRightSidebar();
+    },
+    onAddToChat: (attachment) => {
+      windowImpl.dispatchEvent(new windowImpl.CustomEvent('pi-chat-attach-text', { detail: attachment }));
+      if (ui.isMobileLayout()) ui.collapseRightSidebar();
+    },
+    resolveArtifact: (artifactId) => sessionRuntime.artifacts?.getArtifact(artifactId) || null,
+  });
+
+  const onAnnotationReload = () => annotationLayer.reapply();
+  windowImpl.addEventListener('pi-session-reload', onAnnotationReload);
+  return () => windowImpl.removeEventListener('pi-session-reload', onAnnotationReload);
+}

--- a/web/src/session/page/session-page-layout.js
+++ b/web/src/session/page/session-page-layout.js
@@ -1,0 +1,44 @@
+export function applySessionPageBodyClasses({ documentImpl = document } = {}) {
+  documentImpl.documentElement.classList.add('pi-session-page');
+  documentImpl.body.classList.add('pi-session-page');
+  return () => {
+    documentImpl.documentElement.classList.remove('pi-session-page');
+    documentImpl.body.classList.remove('pi-session-page');
+  };
+}
+
+export function applyStoredSessionLayout({
+  documentImpl = document,
+  windowImpl = window,
+  storage = windowImpl?.localStorage,
+} = {}) {
+  if (!documentImpl || !storage) return;
+
+  try {
+    if (storage.getItem('pi-share:v1:sidebar-collapsed') === 'true') {
+      documentImpl.body.classList.add('sidebar-collapsed');
+    }
+  } catch {}
+
+  try {
+    const width = Number(storage.getItem('pi-share:v1:sidebar-width'));
+    if (Number.isFinite(width) && width > 0) {
+      documentImpl.documentElement.style.setProperty('--sidebar-width', `${Math.round(width)}px`);
+    }
+  } catch {}
+
+  try {
+    const collapsed = storage.getItem('pi-web:v1:right-sidebar-collapsed');
+    const mobile = windowImpl?.matchMedia?.('(max-width: 900px)').matches;
+    if (collapsed === 'true' || mobile) {
+      documentImpl.body.classList.add('right-sidebar-collapsed');
+    }
+  } catch {}
+
+  try {
+    const width = Number(storage.getItem('pi-web:v1:right-sidebar-width'));
+    if (Number.isFinite(width) && width > 0) {
+      documentImpl.documentElement.style.setProperty('--right-sidebar-width', `${Math.round(width)}px`);
+    }
+  } catch {}
+}

--- a/web/src/session/page/session-page-layout.test.js
+++ b/web/src/session/page/session-page-layout.test.js
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { applySessionPageBodyClasses, applyStoredSessionLayout } from './session-page-layout.js';
+
+describe('session page layout helpers', () => {
+  afterEach(() => {
+    document.documentElement.className = '';
+    document.body.className = '';
+    document.documentElement.removeAttribute('style');
+    vi.restoreAllMocks();
+  });
+
+  it('adds and removes the session page body classes', () => {
+    const dispose = applySessionPageBodyClasses({ documentImpl: document });
+    expect(document.documentElement.classList.contains('pi-session-page')).toBe(true);
+    expect(document.body.classList.contains('pi-session-page')).toBe(true);
+
+    dispose();
+
+    expect(document.documentElement.classList.contains('pi-session-page')).toBe(false);
+    expect(document.body.classList.contains('pi-session-page')).toBe(false);
+  });
+
+  it('applies stored sidebar and right-sidebar state', () => {
+    const storage = new Map([
+      ['pi-share:v1:sidebar-collapsed', 'true'],
+      ['pi-share:v1:sidebar-width', '321'],
+      ['pi-web:v1:right-sidebar-width', '456'],
+    ]);
+    const windowImpl = {
+      matchMedia: vi.fn(() => ({ matches: true })),
+    };
+
+    applyStoredSessionLayout({
+      documentImpl: document,
+      windowImpl,
+      storage: { getItem: (key) => storage.get(key) ?? null },
+    });
+
+    expect(document.body.classList.contains('sidebar-collapsed')).toBe(true);
+    expect(document.body.classList.contains('right-sidebar-collapsed')).toBe(true);
+    expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('321px');
+    expect(document.documentElement.style.getPropertyValue('--right-sidebar-width')).toBe('456px');
+  });
+});

--- a/web/src/session/page/session-page-model.js
+++ b/web/src/session/page/session-page-model.js
@@ -1,0 +1,39 @@
+import { createSessionDataModel, decodeBase64JSON } from '../data/session-data.js';
+import { createSessionNavigator } from '../navigation/session-navigation.js';
+import { setSessionRuntime } from '../session-runtime-context.js';
+
+export function hydrateSessionModel({
+  sessionModel,
+  payloadBase64,
+  locationSearch = '',
+  windowImpl = window,
+} = {}) {
+  sessionModel.load(createSessionDataModel(
+    decodeBase64JSON(payloadBase64, { atobImpl: windowImpl.atob?.bind(windowImpl) }),
+    new URLSearchParams(locationSearch),
+  ));
+  return sessionModel;
+}
+
+export function createLiveSessionRuntime({
+  sessionModel,
+  contentRuntime,
+  windowImpl = window,
+  documentImpl = document,
+} = {}) {
+  const navigator = createSessionNavigator({
+    documentImpl,
+    onNavigate: (leaf, target) => {
+      sessionModel.currentLeafId = leaf;
+      sessionModel.currentTargetId = target;
+    },
+  });
+
+  return setSessionRuntime({
+    model: sessionModel,
+    navigator,
+    navigateTo: navigator.navigateTo,
+    reconcileEntries: (entries) => sessionModel.reconcile(entries),
+    contentRuntime,
+  }, { windowImpl });
+}

--- a/web/src/session/page/session-page-model.test.js
+++ b/web/src/session/page/session-page-model.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createLiveSessionRuntime, hydrateSessionModel } from './session-page-model.js';
+import { resetSessionRuntimeContext } from '../session-runtime-context.js';
+
+function encodeJSON(value) {
+  return btoa(String.fromCharCode(...new TextEncoder().encode(JSON.stringify(value))));
+}
+
+describe('session page model helpers', () => {
+  it('hydrates the reactive model from the encoded payload and creates runtime hooks', () => {
+    const payloadBase64 = encodeJSON({
+      header: { cwd: '/tmp/project' },
+      entries: [{ id: 'root' }, { id: 'leaf' }],
+      leafId: 'leaf',
+    });
+    const sessionModel = {
+      load: vi.fn(function load(data) { Object.assign(this, data); }),
+      reconcile: vi.fn((entries) => entries),
+    };
+
+    hydrateSessionModel({
+      sessionModel,
+      payloadBase64,
+      locationSearch: '?leafId=root&targetId=leaf',
+      windowImpl: window,
+    });
+
+    expect(sessionModel.load).toHaveBeenCalledOnce();
+    expect(sessionModel.header.cwd).toBe('/tmp/project');
+    expect(sessionModel.leafId).toBe('root');
+    expect(sessionModel.urlTargetId).toBe('leaf');
+
+    const runtime = createLiveSessionRuntime({
+      sessionModel,
+      contentRuntime: { afterRender: null },
+      windowImpl: window,
+      documentImpl: document,
+    });
+
+    runtime.navigateTo('leaf', 'none');
+    runtime.reconcileEntries([{ id: 'next' }]);
+
+    expect(sessionModel.currentLeafId).toBe('leaf');
+    expect(sessionModel.currentTargetId).toBe('leaf');
+    expect(sessionModel.reconcile).toHaveBeenCalledWith([{ id: 'next' }]);
+
+    resetSessionRuntimeContext({ windowImpl: window });
+  });
+});

--- a/web/src/session/page/session-page-runtime.js
+++ b/web/src/session/page/session-page-runtime.js
@@ -1,0 +1,74 @@
+import { marked } from 'marked';
+import { wireSessionContentRuntime } from '../session-content-runtime.js';
+import { setupSessionGlobals } from '../session-globals.js';
+import { sessionRuntime } from '../session-runtime.js';
+import { configureSessionMarkdown, safeMarkedParse } from '../render/markdown.js';
+import { setupSessionUi } from '../ui/session-ui-runner.js';
+import * as sidebarApi from '../ui/sidebar.js';
+import * as searchFiltersApi from '../ui/search-filters.js';
+import * as toggleStateApi from '../ui/toggle-state.js';
+import { configureSettingsSync, hydrateSettings } from '../../shared/settings-store.js';
+import { getSessionRuntime } from '../session-runtime-context.js';
+import { setupSessionAnnotations } from './session-page-annotations.js';
+
+export function startSessionPageRuntime({
+  sessionId,
+  applyLazyHighlighting,
+  windowImpl = window,
+  documentImpl = document,
+  runtime = getSessionRuntime(),
+} = {}) {
+  const model = runtime.model;
+  const navigateTo = runtime.navigateTo;
+
+  configureSettingsSync({ fetchImpl: windowImpl.fetch ? windowImpl.fetch.bind(windowImpl) : undefined });
+  hydrateSettings({ storage: windowImpl.localStorage });
+  windowImpl.marked = windowImpl.marked || marked;
+
+  const contentWiring = wireSessionContentRuntime({
+    windowImpl,
+    documentImpl,
+    model,
+    sessionId,
+    contentRuntime: runtime.contentRuntime,
+    applyLazyHighlighting,
+  });
+  const { sessionFormat } = contentWiring;
+
+  const ui = setupSessionUi({
+    documentImpl,
+    windowImpl,
+    storage: windowImpl.localStorage,
+    marked,
+    hljs: null,
+    escapeHtml: sessionFormat.escapeHtml,
+    markdownApi: { configureSessionMarkdown, safeMarkedParse },
+    searchFiltersApi,
+    sidebarApi,
+    toggleStateApi,
+    getLeafId: () => model.leafId,
+    setSearchQuery: (value) => { model.searchQuery = value; },
+    setFilterMode: (value) => { model.filterMode = value; },
+    forceTreeRerender: () => {},
+    navigateTo,
+  });
+
+  sessionRuntime.layout = { isMobileLayout: ui.isMobileLayout, closeSidebar: ui.closeSidebar };
+  ui.attachHeaderHandlers();
+  navigateTo(model.currentLeafId, model.urlTargetId ? 'target' : 'bottom', model.urlTargetId || null);
+
+  const disposeAnnotations = setupSessionAnnotations({ sessionId, ui, windowImpl, documentImpl });
+  const disposeGlobals = setupSessionGlobals({
+    windowImpl,
+    documentImpl,
+    model,
+    sessionId,
+    navigateTo,
+  });
+
+  return () => {
+    disposeGlobals?.();
+    disposeAnnotations?.();
+    contentWiring.dispose?.();
+  };
+}

--- a/web/src/session/session-content-runtime.js
+++ b/web/src/session/session-content-runtime.js
@@ -40,6 +40,7 @@ export function wireSessionContentRuntime({
     }),
   };
 
+  const previousDownloadSessionJson = target.downloadSessionJson;
   target.downloadSessionJson = () => downloadSessionJson({
     entries: model.entries,
     header: model.header,
@@ -122,7 +123,7 @@ export function wireSessionContentRuntime({
   // One delegated handler for the per-entry copy/fork/label buttons; survives the
   // reactive re-renders of #messages.
   const messagesEl = documentImpl.getElementById('messages');
-  messagesEl?.addEventListener('click', (e) => {
+  const onMessagesClick = (e) => {
     const copyBtn = e.target.closest?.('.copy-link-btn');
     if (copyBtn) {
       e.stopPropagation();
@@ -146,7 +147,15 @@ export function wireSessionContentRuntime({
       e.stopPropagation();
       labelEntry(labelBtn.dataset.entryId);
     }
-  });
+  };
+  messagesEl?.addEventListener('click', onMessagesClick);
 
-  return { sessionFormat };
+  return {
+    sessionFormat,
+    dispose: () => {
+      messagesEl?.removeEventListener('click', onMessagesClick);
+      if (previousDownloadSessionJson === undefined) delete target.downloadSessionJson;
+      else target.downloadSessionJson = previousDownloadSessionJson;
+    },
+  };
 }

--- a/web/src/session/session-content-runtime.test.js
+++ b/web/src/session/session-content-runtime.test.js
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { wireSessionContentRuntime } from './session-content-runtime.js';
+import { resetSessionModals } from './session-modals.svelte.js';
+import { resetSessionRuntime } from './session-runtime.js';
+
+describe('wireSessionContentRuntime', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    resetSessionModals();
+    resetSessionRuntime();
+    vi.restoreAllMocks();
+  });
+
+  it('removes delegated listeners and restores downloadSessionJson on dispose', () => {
+    document.body.innerHTML = '<div id="messages"><button class="label-btn" data-entry-id="e1"></button></div>';
+    const previousDownload = vi.fn();
+    const add = vi.spyOn(document.getElementById('messages'), 'addEventListener');
+    const remove = vi.spyOn(document.getElementById('messages'), 'removeEventListener');
+    window.downloadSessionJson = previousDownload;
+
+    const { dispose } = wireSessionContentRuntime({
+      windowImpl: window,
+      documentImpl: document,
+      model: {
+        entries: [],
+        header: {},
+        toolCallMap: new Map(),
+        labelMap: new Map(),
+      },
+      sessionId: 's.jsonl',
+      contentRuntime: { afterRender: null },
+      applyLazyHighlighting: vi.fn(),
+    });
+
+    expect(add).toHaveBeenCalledWith('click', expect.any(Function));
+    expect(window.downloadSessionJson).not.toBe(previousDownload);
+
+    dispose();
+
+    expect(remove).toHaveBeenCalledWith('click', add.mock.calls[0][1]);
+    expect(window.downloadSessionJson).toBe(previousDownload);
+  });
+});

--- a/web/src/session/session-runtime-context.js
+++ b/web/src/session/session-runtime-context.js
@@ -1,0 +1,54 @@
+// Explicit imperative runtime context for the live session page. This is the
+// page-owned counterpart to session-runtime.js (component handle registry):
+// SessionPage creates the model/navigator/reconcile hooks once, then live
+// components and page helpers read them here instead of reaching through window.
+//
+// The window aliases installed below are temporary compatibility shims for
+// older live glue and tests. New/refactored live code should prefer
+// getSessionRuntime().
+
+const emptyRuntime = Object.freeze({});
+let currentRuntime = emptyRuntime;
+
+export function setSessionRuntime(runtime = {}, { windowImpl = null, installWindowShims = true } = {}) {
+  currentRuntime = {
+    ...runtime,
+    navigateTo: runtime.navigateTo || runtime.navigator?.navigateTo || null,
+  };
+
+  if (installWindowShims && windowImpl) {
+    installSessionRuntimeWindowShims(currentRuntime, { windowImpl });
+  }
+
+  return currentRuntime;
+}
+
+export function getSessionRuntime() {
+  return currentRuntime;
+}
+
+export function resetSessionRuntimeContext({ windowImpl = null, clearWindowShims = true } = {}) {
+  currentRuntime = emptyRuntime;
+  if (clearWindowShims && windowImpl) clearSessionRuntimeWindowShims({ windowImpl });
+}
+
+export function installSessionRuntimeWindowShims(runtime = currentRuntime, { windowImpl = window } = {}) {
+  if (!windowImpl) return;
+
+  // Temporary compatibility shims. Keep these aliases until source search and
+  // tests prove every consumer has moved to getSessionRuntime().
+  windowImpl.__piSessionDataModel = runtime.model || null;
+  windowImpl.navigateTo = runtime.navigateTo || runtime.navigator?.navigateTo || null;
+  windowImpl.__piSessionNavigator = runtime.navigator || null;
+  windowImpl.__piReconcileEntries = runtime.reconcileEntries || null;
+  windowImpl.__piContentRuntime = runtime.contentRuntime || null;
+}
+
+export function clearSessionRuntimeWindowShims({ windowImpl = window } = {}) {
+  if (!windowImpl) return;
+  delete windowImpl.__piSessionDataModel;
+  delete windowImpl.navigateTo;
+  delete windowImpl.__piSessionNavigator;
+  delete windowImpl.__piReconcileEntries;
+  delete windowImpl.__piContentRuntime;
+}

--- a/web/src/session/session-runtime-context.test.js
+++ b/web/src/session/session-runtime-context.test.js
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getSessionRuntime,
+  resetSessionRuntimeContext,
+  setSessionRuntime,
+} from './session-runtime-context.js';
+
+describe('session runtime context', () => {
+  afterEach(() => {
+    resetSessionRuntimeContext({ windowImpl: window });
+  });
+
+  it('stores an explicit runtime and derives navigateTo from the navigator', () => {
+    const navigateTo = vi.fn();
+    const model = { entries: [] };
+    const runtime = setSessionRuntime({ model, navigator: { navigateTo } }, { windowImpl: null });
+
+    expect(runtime.navigateTo).toBe(navigateTo);
+    expect(getSessionRuntime().model).toBe(model);
+  });
+
+  it('installs and clears temporary window compatibility shims', () => {
+    const model = { entries: [] };
+    const navigateTo = vi.fn();
+    const reconcileEntries = vi.fn();
+    const contentRuntime = { afterRender: null };
+
+    setSessionRuntime({
+      model,
+      navigateTo,
+      navigator: { navigateTo },
+      reconcileEntries,
+      contentRuntime,
+    }, { windowImpl: window });
+
+    expect(window.__piSessionDataModel).toBe(model);
+    expect(window.navigateTo).toBe(navigateTo);
+    expect(window.__piReconcileEntries).toBe(reconcileEntries);
+    expect(window.__piContentRuntime).toBe(contentRuntime);
+
+    resetSessionRuntimeContext({ windowImpl: window });
+
+    expect(getSessionRuntime().model).toBeUndefined();
+    expect(window.__piSessionDataModel).toBeUndefined();
+    expect(window.navigateTo).toBeUndefined();
+    expect(window.__piReconcileEntries).toBeUndefined();
+    expect(window.__piContentRuntime).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Extracted the live session page shell and bootstrapping into focused helpers for model hydration, stored layout, annotations, and runtime startup so `SessionPage.svelte` stays mostly declarative.
- Added an explicit session runtime context for the live model, navigator, reconciliation hook, and content runtime while keeping documented window compatibility shims for remaining consumers.
- Updated chat, live reload, tree navigation, and palette helpers to prefer the runtime context, and made content runtime wiring disposable on unmount.
- Added Vitest coverage for the new helpers plus a source-level export boundary test to catch live-only imports earlier.

## Related issue

N/A

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `style` — formatting / UI styling, no behavior change
- [x] `test` — adding or updating tests
- [ ] `chore` — build, tooling, or maintenance

## Live vs. Export

- [ ] Not applicable — this PR doesn't touch session rendering
- [x] Considered both the live app and the export snapshot
- [ ] Kept `internal/ui/embedded/` in sync with `web/src/session/` changes — not needed; this changes live Svelte orchestration and tests only
- [x] No live-only chrome (Vite scripts, active composer, SSE/API) leaked into export

## Testing

- [ ] `make check` passes (test + build + vet) — not run
- [x] Frontend tests (`vitest`) cover the change: `cd web && npm test -- --run`
- [x] Go tests (`go test ./...`) cover the change
- [ ] UI changes verified in a browser — not run
