### PR TITLE
feat(chat): one-click /compact via dedicated rpc command

### DIFF
--- a/e2e/lib/stub-pi/pi
+++ b/e2e/lib/stub-pi/pi
@@ -93,6 +93,20 @@ function handlePrompt(cmd) {
   }, 30);
 }
 
+// compact: the dedicated rpc command (NOT a prompt). Real pi summarises history
+// here; the stub just acks and writes a recognizable compaction marker so e2e
+// can assert the dedicated path was taken (vs. "/compact" echoed as a prompt).
+function handleCompact(cmd) {
+  respond(cmd.id, "compact", { compacted: true });
+  setTimeout(() => {
+    if (sessionPath) {
+      const asst = messageEntry("assistant", "Context compacted (stub).", lastEntryId());
+      appendEntry(asst.entry);
+    }
+    send({ type: "agent_end" });
+  }, 30);
+}
+
 function handle(cmd) {
   switch (cmd.type) {
     case "switch_session":
@@ -119,6 +133,9 @@ function handle(cmd) {
       break;
     case "prompt":
       handlePrompt(cmd);
+      break;
+    case "compact":
+      handleCompact(cmd);
       break;
     default:
       if (cmd.id) respond(cmd.id, cmd.type || "unknown", {});

--- a/e2e/tests/compact.spec.ts
+++ b/e2e/tests/compact.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, collapseScratchpad, isMobileLayout } from "../lib/test";
+import {
+  buildSession,
+  realWorkingDir,
+  uniqueSessionName,
+  writeSession,
+} from "../lib/sessions";
+
+// /compact is triggered from the context-usage popover (and Cmd/Ctrl+L).
+// It must hit the dedicated POST /api/compact endpoint, which runs pi's `compact`
+// rpc command — NOT send "/compact" as a chat prompt (pi's rpc prompt path would
+// treat it as literal text and never compact). The stub pi answers the `compact`
+// command by writing a "Context compacted (stub)." marker; a wrongly-routed
+// prompt would instead echo "Stub reply: /compact", so the assertions below
+// distinguish the correct path from the broken one.
+test.describe("compact (stubbed pi)", () => {
+  test("popover button runs real compaction (not a /compact prompt)", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const cwd = realWorkingDir();
+    const { entries } = buildSession({ cwd });
+    // Attach usage to the assistant reply so the context-usage capsule renders.
+    const assistant = entries.find(
+      (e: any) => e?.message?.role === "assistant",
+    ) as any;
+    assistant.message.usage = {
+      input: 1331,
+      output: 220,
+      cacheRead: 6144,
+      cacheWrite: 0,
+      totalTokens: 7695,
+    };
+    const name = uniqueSessionName(testInfo, "compact");
+    const id = writeSession(sessionsDir, name, entries);
+
+    await collapseScratchpad(page);
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+
+    const composer = page.locator("#pi-chat-composer");
+    await expect(composer).toHaveAttribute("data-chat-available", "true");
+
+    // /compact is disabled while the worker is "running" (incl. the initial
+    // warm-up). Wait for idle — Cancel is shown only while running — first.
+    await expect(page.locator("#pi-chat-cancel")).toBeHidden({ timeout: 20000 });
+
+    // Open the context popover and click the compact button.
+    const capsule = page.locator("#pi-chat-context-usage");
+    await expect(capsule).toBeVisible();
+    const popover = page.locator("#pi-chat-context-popover");
+    await capsule.click();
+    await expect(popover).toBeVisible();
+
+    const compactBtn = page.locator("#pi-chat-compact");
+    await expect(compactBtn).toBeVisible();
+    await compactBtn.click();
+
+    // The popover closes on trigger, the stub's compaction marker lands (proving
+    // the dedicated compact rpc path ran), and the worker returns to idle.
+    // (The transient "compacting…" banner's show/hide is covered deterministically
+    // in vitest — asserting its mid-flight visibility here races the fast stub.)
+    await expect(popover).toBeHidden();
+    await expect(page.locator("#messages")).toContainText("Context compacted (stub).", {
+      timeout: 20000,
+    });
+    // Must NOT have gone down the chat-prompt path.
+    await expect(page.locator("#messages")).not.toContainText("Stub reply: /compact");
+    // Banner clears and the worker returns to idle once compaction completes.
+    await expect(page.locator("#pi-chat-compacting-banner")).toBeHidden({ timeout: 20000 });
+    await expect(page.locator("#pi-chat-cancel")).toBeHidden({ timeout: 20000 });
+  });
+
+  test("Cmd/Ctrl+L runs real compaction", async ({
+    page,
+    sessionsDir,
+  }, testInfo) => {
+    const cwd = realWorkingDir();
+    const { entries } = buildSession({ cwd });
+    const name = uniqueSessionName(testInfo, "compact-kbd");
+    const id = writeSession(sessionsDir, name, entries);
+
+    await collapseScratchpad(page);
+    await page.goto(`/session?id=${encodeURIComponent(id)}`);
+
+    test.skip(await isMobileLayout(page), "keyboard shortcut is desktop-only");
+
+    const composer = page.locator("#pi-chat-composer");
+    await expect(composer).toHaveAttribute("data-chat-available", "true");
+
+    // Wait for the worker to settle to idle (compact is guarded while running).
+    await expect(page.locator("#pi-chat-cancel")).toBeHidden({ timeout: 20000 });
+
+    const textarea = page.locator("#pi-chat-message");
+    await textarea.click();
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+    await textarea.press(`${modifier}+KeyL`);
+
+    await expect(page.locator("#messages")).toContainText("Context compacted (stub).", {
+      timeout: 20000,
+    });
+    await expect(page.locator("#messages")).not.toContainText("Stub reply: /compact");
+  });
+});

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -61,3 +61,12 @@ func BuildSetThinkingLevelCommand(id, level string) map[string]any {
 func BuildGetCommandsCommand(id string) map[string]any {
 	return map[string]any{"id": id, "type": "get_commands"}
 }
+
+// BuildCompactCommand asks pi to compact the session context. This is the
+// dedicated rpc command that runs session.compact(); sending "/compact" as a
+// prompt does NOT compact (pi's rpc prompt path only expands extension/skill/
+// template commands, so a built-in like /compact would reach the model as
+// literal text).
+func BuildCompactCommand(id string) map[string]any {
+	return map[string]any{"id": id, "type": "compact"}
+}

--- a/internal/rpc/worker.go
+++ b/internal/rpc/worker.go
@@ -127,6 +127,27 @@ func (w *piRPCWorker) Prompt(ctx context.Context, chat chat.Request) error {
 	return nil
 }
 
+// Compact runs pi's session.compact() via the dedicated "compact" rpc command.
+// It blocks until pi finishes summarising and persists the compacted session.
+// Marks the worker Running for the duration so the UI reflects activity and the
+// compact affordance stays disabled, mirroring Prompt.
+func (w *piRPCWorker) Compact(ctx context.Context) error {
+	w.touch()
+	w.mu.Lock()
+	w.status = workers.WorkerStatus{State: workers.WorkerStateRunning}
+	w.mu.Unlock()
+	if err := w.sendAndAwait(ctx, BuildCompactCommand(w.nextID())); err != nil {
+		w.mu.Lock()
+		w.status = workers.WorkerStatus{State: workers.WorkerStateError, Error: err.Error()}
+		w.mu.Unlock()
+		return err
+	}
+	w.mu.Lock()
+	w.status = workers.WorkerStatus{State: workers.WorkerStateIdle}
+	w.mu.Unlock()
+	return nil
+}
+
 func (w *piRPCWorker) SetModel(ctx context.Context, provider, modelID string) error {
 	w.touch()
 	id := w.nextID()

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -17,6 +17,7 @@ import (
 
 type ChatSender interface {
 	Send(ctx context.Context, sessionID, sessionPath string, chat chat.Request) error
+	Compact(ctx context.Context, sessionID, sessionPath string) error
 	SetModel(ctx context.Context, sessionID, sessionPath, provider, modelID string) error
 	SetThinkingLevel(ctx context.Context, sessionID, sessionPath, level string) error
 	Abort(ctx context.Context, sessionID string) error
@@ -67,6 +68,49 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 	writeJSON(w, http.StatusAccepted, map[string]any{"ok": true, "status": "queued"})
+}
+
+// handleCompact runs pi's dedicated "compact" rpc command for the session.
+// Compaction is NOT a chat prompt: sending "/compact" as a message would reach
+// the model as literal text. It fires asynchronously (compaction calls the LLM
+// to summarise and can take a while) and, on completion, broadcasts a reload so
+// the viewer + context-usage ring pick up the compacted session.
+func (s *Server) handleCompact(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	resolved, err := sessions.ResolveByID(s.sessionsDir, r.URL.Query().Get("id"))
+	if err != nil {
+		if errors.Is(err, sessions.ErrInvalidSessionID) {
+			writeJSONError(w, http.StatusBadRequest, "invalid session id")
+			return
+		}
+		if errors.Is(err, sessions.ErrSessionNotFound) {
+			writeJSONError(w, http.StatusNotFound, "session not found")
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !resolved.Session.ChatAvailable {
+		writeJSONError(w, http.StatusConflict, resolved.Session.ChatDisabledReason)
+		return
+	}
+	if s.chatSender == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "chat unavailable")
+		return
+	}
+	sessionID := resolved.Session.ID
+	sessionPath := resolved.Path
+	go func() {
+		if err := s.chatSender.Compact(context.Background(), sessionID, sessionPath); err != nil {
+			fmt.Fprintf(os.Stderr, "compact failed for %s: %v\n", sessionID, err)
+		}
+		s.recomputeAndBroadcastStatus(sessionID)
+		s.broadcast(sessionID, "reload")
+	}()
+	writeJSON(w, http.StatusAccepted, map[string]any{"ok": true, "status": "compacting"})
 }
 
 // recentSessionActivityWindow is the grace period after a JSONL write during

--- a/internal/server/chat_test.go
+++ b/internal/server/chat_test.go
@@ -48,6 +48,9 @@ type fakeSender struct {
 	setThinkingSessionID    string
 	setThinkingLevel        string
 	getCommandsCalls        int
+	compactSessionID        string
+	compactSessionPath      string
+	compactCh               chan struct{}
 }
 
 func (f *fakeSender) Send(ctx context.Context, sessionID, sessionPath string, chat chat.Request) error {
@@ -58,6 +61,15 @@ func (f *fakeSender) Send(ctx context.Context, sessionID, sessionPath string, ch
 	f.mu.Unlock()
 	if f.sendCh != nil {
 		f.sendCh <- struct{}{}
+	}
+	return nil
+}
+
+func (f *fakeSender) Compact(ctx context.Context, sessionID, sessionPath string) error {
+	f.compactSessionID = sessionID
+	f.compactSessionPath = sessionPath
+	if f.compactCh != nil {
+		f.compactCh <- struct{}{}
 	}
 	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -248,6 +248,7 @@ func (s *Server) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/sessions", s.auth.Wrap(s.handleApiSessions))
 	mux.HandleFunc("/api/chat", s.auth.Wrap(s.handleChat))
 	mux.HandleFunc("/api/chat/cancel", s.auth.Wrap(s.handleCancelChat))
+	mux.HandleFunc("/api/compact", s.auth.Wrap(s.handleCompact))
 	mux.HandleFunc("/api/set-model", s.auth.Wrap(s.handleSetModel))
 	mux.HandleFunc("/api/set-thinking-level", s.auth.Wrap(s.handleSetThinkingLevel))
 	mux.HandleFunc("/api/models", s.auth.Wrap(s.handleAvailableModels))

--- a/internal/ui/embedded/styles/session.css
+++ b/internal/ui/embedded/styles/session.css
@@ -5307,6 +5307,93 @@
       color: var(--error, #cc6666);
     }
 
+    .pi-popover-compact {
+      width: 100%;
+      margin-top: 10px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 7px 9px;
+      border-radius: 7px;
+      background: var(--surface-2);
+      color: var(--text);
+      border: 1px solid color-mix(in srgb, var(--dim) 40%, transparent);
+      cursor: pointer;
+      font-size: 11px;
+      font-weight: 600;
+    }
+
+    .pi-popover-compact:hover {
+      border-color: var(--accent);
+    }
+
+    .pi-popover-compact:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    .pi-chat-context-popover.warning .pi-popover-compact {
+      border-color: color-mix(in srgb, var(--warning, #f0c674) 50%, transparent);
+      color: var(--warning, #f0c674);
+    }
+
+    .pi-chat-context-popover.danger .pi-popover-compact {
+      border-color: color-mix(in srgb, var(--error, #cc6666) 55%, transparent);
+      background: color-mix(in srgb, var(--error, #cc6666) 12%, var(--surface-2));
+      color: var(--error, #cc6666);
+    }
+
+    .pi-popover-compact .pi-compact-kbd {
+      margin-left: auto;
+      display: inline-flex;
+      gap: 2px;
+      opacity: 0.7;
+    }
+
+    .pi-popover-compact .pi-compact-kbd kbd {
+      font-size: 9px;
+      padding: 1px 3px;
+      border-radius: 3px;
+      background: color-mix(in srgb, var(--dim) 25%, transparent);
+    }
+
+    /* "Compacting…" banner shown above the composer input while /compact runs. */
+    .pi-compacting-banner {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      margin: 0 0 8px;
+      padding: 9px 12px;
+      border-radius: 9px;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--accent);
+      background: color-mix(in srgb, var(--accent) 12%, var(--surface-2));
+      border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+    }
+
+    .pi-compacting-banner[hidden] {
+      display: none;
+    }
+
+    .pi-compacting-spinner {
+      width: 13px;
+      height: 13px;
+      flex: none;
+      border-radius: 50%;
+      border: 2px solid color-mix(in srgb, var(--accent) 30%, transparent);
+      border-top-color: var(--accent);
+      animation: pi-compacting-spin 0.7s linear infinite;
+    }
+
+    @keyframes pi-compacting-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pi-compacting-spinner { animation: none; }
+    }
+
     /* ===================================================================
        Cat Gatekeeper — focus/break + bedtime overlay (live app only).
        The overlay DOM is created by web/src/session/cat-gatekeeper/.

--- a/internal/workers/manager.go
+++ b/internal/workers/manager.go
@@ -57,6 +57,7 @@ type inspector interface {
 
 type ChatWorker interface {
 	Prompt(ctx context.Context, chat chat.Request) error
+	Compact(ctx context.Context) error
 	SetModel(ctx context.Context, provider, modelID string) error
 	SetThinkingLevel(ctx context.Context, level string) error
 	Abort(ctx context.Context) error
@@ -159,6 +160,16 @@ func (m *Manager) Send(ctx context.Context, sessionID, sessionPath string, chat 
 		return err
 	}
 	return worker.Prompt(ctx, chat)
+}
+
+// Compact ensures a worker for the session (spawning if needed) and runs pi's
+// dedicated compact command on it.
+func (m *Manager) Compact(ctx context.Context, sessionID, sessionPath string) error {
+	worker, err := m.workerFor(sessionID, sessionPath)
+	if err != nil {
+		return err
+	}
+	return worker.Compact(ctx)
 }
 
 // Snapshot returns a point-in-time view of every live worker, for the metrics

--- a/internal/workers/manager_test.go
+++ b/internal/workers/manager_test.go
@@ -29,6 +29,13 @@ func (f *fakeChatWorker) Prompt(ctx context.Context, chat chat.Request) error {
 	return nil
 }
 
+func (f *fakeChatWorker) Compact(ctx context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.prompts = append(f.prompts, map[string]any{"id": "test", "type": "compact"})
+	return nil
+}
+
 func (f *fakeChatWorker) Status() WorkerStatus {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -163,6 +170,7 @@ type reapableWorker struct {
 }
 
 func (r *reapableWorker) Prompt(ctx context.Context, chat chat.Request) error          { return nil }
+func (r *reapableWorker) Compact(ctx context.Context) error                            { return nil }
 func (r *reapableWorker) SetModel(ctx context.Context, provider, modelID string) error { return nil }
 func (r *reapableWorker) SetThinkingLevel(ctx context.Context, level string) error     { return nil }
 func (r *reapableWorker) Abort(ctx context.Context) error                              { return nil }
@@ -227,6 +235,7 @@ func TestManagerDoesNotReapRunningWorker(t *testing.T) {
 type runningReapable struct{}
 
 func (runningReapable) Prompt(ctx context.Context, chat chat.Request) error          { return nil }
+func (runningReapable) Compact(ctx context.Context) error                            { return nil }
 func (runningReapable) SetModel(ctx context.Context, provider, modelID string) error { return nil }
 func (runningReapable) SetThinkingLevel(ctx context.Context, level string) error     { return nil }
 func (runningReapable) Abort(ctx context.Context) error                              { return nil }
@@ -241,6 +250,7 @@ func (runningReapable) IdleSince(now time.Time) time.Duration { return time.Hour
 type erroredWorker struct{}
 
 func (erroredWorker) Prompt(ctx context.Context, chat chat.Request) error          { return nil }
+func (erroredWorker) Compact(ctx context.Context) error                            { return nil }
 func (erroredWorker) SetModel(ctx context.Context, provider, modelID string) error { return nil }
 func (erroredWorker) SetThinkingLevel(ctx context.Context, level string) error     { return nil }
 func (erroredWorker) Abort(ctx context.Context) error                              { return nil }
@@ -263,6 +273,7 @@ type inspectableWorker struct {
 }
 
 func (w *inspectableWorker) Prompt(context.Context, chat.Request) error    { return nil }
+func (w *inspectableWorker) Compact(context.Context) error                 { return nil }
 func (w *inspectableWorker) SetModel(context.Context, string, string) error { return nil }
 func (w *inspectableWorker) SetThinkingLevel(context.Context, string) error { return nil }
 func (w *inspectableWorker) Abort(context.Context) error                    { return nil }

--- a/web/src/components/session/ChatComposer.svelte
+++ b/web/src/components/session/ChatComposer.svelte
@@ -84,6 +84,11 @@
         ><span class="pi-chat-focus-shortcut">{t('composer.focusShortcut')}</span>
       </div>{/if}
     {#if !chatAvailable}<div class="pi-chat-disabled-notice">{chatDisabledReason}</div>{/if}
+    <div id="pi-chat-compacting-banner" class="pi-compacting-banner" hidden>
+      <span class="pi-compacting-spinner" aria-hidden="true"></span><span
+        >{t('composer.compacting')}</span
+      >
+    </div>
     <textarea
       id="pi-chat-message"
       name="message"

--- a/web/src/components/session/ChatComposer.test.js
+++ b/web/src/components/session/ChatComposer.test.js
@@ -402,7 +402,7 @@ describe('chat composer runner', () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
-  it('Ctrl+L in the textarea opens the model selector', () => {
+  it('Ctrl+I in the textarea opens the model selector', () => {
     const dom = new JSDOM(
       '<body><form id="pi-chat-composer" data-chat-available="true" data-session-id="s1"><textarea id="pi-chat-message"></textarea><input id="pi-chat-images"><button id="pi-chat-attach"></button><div id="pi-chat-attachments"></div><button id="pi-chat-send"></button><span id="pi-chat-status"></span></form></body>',
     );
@@ -420,7 +420,7 @@ describe('chat composer runner', () => {
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 
     const event = new dom.window.KeyboardEvent('keydown', {
-      key: 'l',
+      key: 'i',
       ctrlKey: true,
       bubbles: true,
       cancelable: true,
@@ -485,6 +485,88 @@ describe('chat composer runner', () => {
 
     const fill = el.querySelector('.pi-context-fill');
     expect(fill.getAttribute('stroke-dasharray')).toBe('8, 100');
+  });
+
+  // After a `compaction` entry, pre-compaction assistant usage no longer reflects
+  // live context (it was collapsed into the summary). With no post-compaction
+  // turn yet, the ring estimates summary + kept entries (chars/4), not the stale
+  // pre-compaction usage.
+  it('uses the post-compaction estimate, not stale pre-compaction usage', () => {
+    const dom = new JSDOM(
+      '<body><form id="pi-chat-composer" data-chat-available="true" data-session-id="s1"><textarea id="pi-chat-message"></textarea><input id="pi-chat-images"><button id="pi-chat-attach"></button><div id="pi-chat-attachments"></div><button id="pi-chat-send"></button><span id="pi-chat-status"></span><button id="pi-chat-model-label"></button><div id="pi-chat-context-usage" style="display:none"><svg class="pi-context-circle"><path class="pi-context-fill" stroke-dasharray="0, 100"></path></svg><span class="pi-context-text">0%</span></div></form></body>',
+    );
+    const mockEntries = [
+      { type: 'message', id: 'a1', message: { role: 'assistant', usage: { totalTokens: 64000 } } }, // pre-compaction (summarized away)
+      { type: 'message', id: 'k1', message: { role: 'user', content: 'x'.repeat(12000) } }, // kept (3000 tok)
+      { type: 'compaction', id: 'c1', firstKeptEntryId: 'k1', summary: 's'.repeat(4000) }, // summary (1000 tok)
+    ];
+    runChatComposer({
+      documentImpl: dom.window.document,
+      windowImpl: dom.window,
+      localEntries: mockEntries,
+      chatApi: {
+        getWorkerStatus: () =>
+          Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({ state: 'idle', model: 'gpt-4o', modelProvider: 'openai' }),
+          }),
+      },
+      chatSelectors: { THINKING_LEVELS: [] },
+      modelSelector: {
+        setupModelSelector: vi.fn((opts) => {
+          opts.setKnownModelLabel('gpt-4o @ openai');
+          return { open: vi.fn() };
+        }),
+      },
+      thinkingSelector: { setupThinkingLevelSelector: vi.fn() },
+      setIntervalImpl: () => {},
+    });
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+    const text = dom.window.document.querySelector('.pi-context-text');
+    // summary 4000/4=1000 + kept user 12000/4=3000 = 4000 tok; 4000/128000 ≈ 3%.
+    // (Stale pre-compaction 64000 would have shown 50%.)
+    expect(text.textContent).toBe('3%');
+  });
+
+  it('uses real post-compaction assistant usage once the next turn lands', () => {
+    const dom = new JSDOM(
+      '<body><form id="pi-chat-composer" data-chat-available="true" data-session-id="s1"><textarea id="pi-chat-message"></textarea><input id="pi-chat-images"><button id="pi-chat-attach"></button><div id="pi-chat-attachments"></div><button id="pi-chat-send"></button><span id="pi-chat-status"></span><button id="pi-chat-model-label"></button><div id="pi-chat-context-usage" style="display:none"><svg class="pi-context-circle"><path class="pi-context-fill" stroke-dasharray="0, 100"></path></svg><span class="pi-context-text">0%</span></div></form></body>',
+    );
+    const mockEntries = [
+      { type: 'message', id: 'a1', message: { role: 'assistant', usage: { totalTokens: 64000 } } },
+      { type: 'message', id: 'k1', message: { role: 'user', content: 'x'.repeat(12000) } },
+      { type: 'compaction', id: 'c1', firstKeptEntryId: 'k1', summary: 's'.repeat(4000) },
+      { type: 'message', id: 'a2', message: { role: 'assistant', usage: { totalTokens: 8000 } } }, // next turn, measured
+    ];
+    runChatComposer({
+      documentImpl: dom.window.document,
+      windowImpl: dom.window,
+      localEntries: mockEntries,
+      chatApi: {
+        getWorkerStatus: () =>
+          Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({ state: 'idle', model: 'gpt-4o', modelProvider: 'openai' }),
+          }),
+      },
+      chatSelectors: { THINKING_LEVELS: [] },
+      modelSelector: {
+        setupModelSelector: vi.fn((opts) => {
+          opts.setKnownModelLabel('gpt-4o @ openai');
+          return { open: vi.fn() };
+        }),
+      },
+      thinkingSelector: { setupThinkingLevelSelector: vi.fn() },
+      setIntervalImpl: () => {},
+    });
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+    const text = dom.window.document.querySelector('.pi-context-text');
+    // 8000 / 128000 ≈ 6% (the measured post-compaction turn wins over the estimate).
+    expect(text.textContent).toBe('6%');
   });
 
   it('toggles detailed context usage popover and formats values correctly', () => {
@@ -701,5 +783,122 @@ describe('chat composer runner', () => {
 
     const popover = dom.window.document.getElementById('pi-chat-context-popover');
     expect(popover.querySelector('.pi-popover-limit').textContent).toBe('1.2M'); // 1,234,567 formats to 1.2M
+  });
+
+  // /compact: triggered from the context popover button + Cmd/Ctrl+L. It must
+  // hit the dedicated POST /api/compact endpoint (chatApi.compact), NOT be sent
+  // as a chat message — pi's rpc prompt treats "/compact" as literal text.
+  const compactDom = () =>
+    new JSDOM(
+      '<body><form id="pi-chat-composer" data-chat-available="true" data-session-id="s1"><div class="pi-chat-shell"><div id="pi-chat-compacting-banner" hidden></div><textarea id="pi-chat-message"></textarea><input id="pi-chat-images"><button id="pi-chat-attach"></button><div id="pi-chat-attachments"></div><button id="pi-chat-cancel" style="display:none"></button><button id="pi-chat-send"></button><span id="pi-chat-status"></span><button id="pi-chat-model-label"></button><div id="pi-chat-context-usage" style="display:none"><svg class="pi-context-circle"><path class="pi-context-fill" stroke-dasharray="0, 100"></path></svg><span class="pi-context-text">0%</span></div><div id="pi-chat-context-popover" style="display:block"><button type="button" id="pi-chat-compact"><span class="pi-compact-label">Compact context</span></button></div></div></form></body>',
+    );
+
+  const runCompact = (dom, { compact, sendChat, state = 'idle' }) => {
+    runChatComposer({
+      documentImpl: dom.window.document,
+      windowImpl: dom.window,
+      chatApi: {
+        getWorkerStatus: () =>
+          Promise.resolve(new Response(JSON.stringify({ state }), { status: 200 })),
+        compact,
+        sendChat,
+      },
+      chatSelectors: { THINKING_LEVELS: [] },
+      modelSelector: { setupModelSelector: vi.fn(() => ({ open: vi.fn() })) },
+      thinkingSelector: { setupThinkingLevelSelector: vi.fn(() => ({ cycle: vi.fn() })) },
+      FormDataImpl: dom.window.FormData,
+      CustomEventImpl: dom.window.CustomEvent,
+      setIntervalImpl: () => {},
+    });
+    // No manual DOMContentLoaded dispatch: JSDOM fires it during the awaited
+    // tick below, so init runs exactly once (a manual dispatch would double it).
+  };
+
+  it('clicking the compact button calls /api/compact (not sendChat) and closes the popover', async () => {
+    const tick = () => new Promise((r) => setTimeout(r, 0));
+    const dom = compactDom();
+    const compact = vi.fn(() =>
+      Promise.resolve(new Response('{"status":"compacting"}', { status: 200 })),
+    );
+    const sendChat = vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })));
+    runCompact(dom, { compact, sendChat });
+    await tick();
+
+    dom.window.document.getElementById('pi-chat-compact').click();
+    await tick();
+
+    expect(compact).toHaveBeenCalledTimes(1);
+    expect(compact.mock.calls[0][0]).toBe('s1');
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(dom.window.document.getElementById('pi-chat-context-popover').style.display).toBe(
+      'none',
+    );
+    // Feedback: the "compacting…" banner shows. (The status label is reactive
+    // Svelte state now, not written to raw DOM, so it isn't asserted here.)
+    expect(dom.window.document.getElementById('pi-chat-compacting-banner').hidden).toBe(false);
+  });
+
+  it('hides the compacting banner when compaction completes (pi-session-reload)', async () => {
+    const tick = () => new Promise((r) => setTimeout(r, 0));
+    const dom = compactDom();
+    const compact = vi.fn(() =>
+      Promise.resolve(new Response('{"status":"compacting"}', { status: 200 })),
+    );
+    runCompact(dom, { compact, sendChat: vi.fn() });
+    await tick();
+
+    dom.window.document.getElementById('pi-chat-compact').click();
+    await tick();
+    expect(dom.window.document.getElementById('pi-chat-compacting-banner').hidden).toBe(false);
+
+    // Backend broadcasts pi-session-reload once session.compact() returns.
+    dom.window.dispatchEvent(new dom.window.Event('pi-session-reload'));
+    await tick();
+    expect(dom.window.document.getElementById('pi-chat-compacting-banner').hidden).toBe(true);
+  });
+
+  it('Cmd/Ctrl+L calls /api/compact without clearing the draft', async () => {
+    const tick = () => new Promise((r) => setTimeout(r, 0));
+    const dom = compactDom();
+    const compact = vi.fn(() =>
+      Promise.resolve(new Response('{"status":"compacting"}', { status: 200 })),
+    );
+    const sendChat = vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })));
+    runCompact(dom, { compact, sendChat });
+    await tick();
+
+    const textarea = dom.window.document.getElementById('pi-chat-message');
+    textarea.value = 'my draft';
+    const event = new dom.window.KeyboardEvent('keydown', {
+      key: 'l',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    textarea.dispatchEvent(event);
+    await tick();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(compact).toHaveBeenCalledTimes(1);
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(textarea.value).toBe('my draft');
+    expect(dom.window.document.getElementById('pi-chat-compacting-banner').hidden).toBe(false);
+  });
+
+  it('does not compact while the worker is running', async () => {
+    const tick = () => new Promise((r) => setTimeout(r, 0));
+    const dom = compactDom();
+    const compact = vi.fn(() =>
+      Promise.resolve(new Response('{"status":"compacting"}', { status: 200 })),
+    );
+    runCompact(dom, { compact, sendChat: vi.fn(), state: 'running' });
+    await tick();
+
+    dom.window.document.getElementById('pi-chat-compact').click();
+    await tick();
+
+    expect(compact).not.toHaveBeenCalled();
+    expect(dom.window.document.getElementById('pi-chat-compact').disabled).toBe(true);
+    expect(dom.window.document.getElementById('pi-chat-compacting-banner').hidden).toBe(true);
   });
 });

--- a/web/src/components/session/ShortcutsModal.svelte
+++ b/web/src/components/session/ShortcutsModal.svelte
@@ -49,6 +49,12 @@
           note: t('shortcuts.noteInsideInput'),
         },
         {
+          desc: t('shortcuts.compact'),
+          keys: ['⌘', 'L'],
+          keysWin: ['Ctrl', 'L'],
+          note: t('shortcuts.noteInsideInput'),
+        },
+        {
           desc: t('shortcuts.submit'),
           keys: ['↩'],
           keysWin: ['Enter'],

--- a/web/src/components/session/chat/ContextUsage.svelte
+++ b/web/src/components/session/chat/ContextUsage.svelte
@@ -66,6 +66,15 @@
           <span class="pi-row-value" id="pi-popover-val-total">0</span>
         </div>
       </div>
+      <button
+        type="button"
+        id="pi-chat-compact"
+        class="pi-popover-compact"
+        title={t('composer.compact')}
+      >
+        <span class="pi-compact-label">{t('composer.compactLabel')}</span>
+        <span class="pi-compact-kbd"><kbd>⌘</kbd><kbd>L</kbd></span>
+      </button>
     </div>
   </div>
 {/if}

--- a/web/src/components/session/chat/chat-composer-runtime.js
+++ b/web/src/components/session/chat/chat-composer-runtime.js
@@ -23,6 +23,7 @@ import { navigateInitialChatLeaf } from './initial-navigation.js';
 import { ChatToolbarState } from './chat-toolbar-state.svelte.js';
 import { setupChatSubmission } from './chat-submit.js';
 import { createChatSelectorLoaders } from './selector-loaders.js';
+import { createCompactController } from './compact-controller.js';
 
 export function runChatComposer({
   documentImpl = document,
@@ -162,6 +163,7 @@ export function runChatComposer({
       getMentionSelector: () => _mentionSelectorApi,
       getThinkingSelector: () => _thinkingSelectorApi,
       getModelSelector: () => _modelSelectorApi,
+      getCompact: () => compact,
       updateSendEnabled,
       updateComposerHeight: updateComposerHeightVar,
     });
@@ -179,6 +181,15 @@ export function runChatComposer({
     function setStatus(text, cls) {
       setChatStatus(text, cls);
     }
+
+    // Shared /compact trigger + "compacting" UI state, used by the keydown
+    // handler, the context popover button, and the worker-status poll.
+    const compact = createCompactController({
+      documentImpl: document,
+      chatApi: __piChatApi,
+      sessionId,
+      setStatus,
+    });
 
     const submission = setupChatSubmission({
       windowImpl: window,
@@ -214,6 +225,7 @@ export function runChatComposer({
       getKnownThinkingLevel: toolbar.getKnownThinkingLevel,
       setKnownThinkingLevel: toolbar.setKnownThinkingLevel,
       getWorkerModelUpdate: () => onWorkerModelUpdate,
+      getCompact: () => compact,
       setIntervalImpl: setInterval,
       CustomEventImpl: CustomEvent,
     });
@@ -228,6 +240,7 @@ export function runChatComposer({
       documentImpl: document,
       windowImpl: window,
       updateContextUsage,
+      onCompact: () => compact.trigger(),
     });
     positionPopover = contextPopover.position;
 

--- a/web/src/components/session/chat/compact-controller.js
+++ b/web/src/components/session/chat/compact-controller.js
@@ -1,0 +1,60 @@
+// Compact controller — owns the /compact trigger + "compacting" UI state shared
+// by the keydown handler, the context popover, and the worker-status poll.
+//
+// Compaction is NOT a chat prompt: pi's rpc prompt path only expands
+// extension/skill/template commands, so sending "/compact" as a message would
+// reach the model as literal text and never compact. This calls the dedicated
+// POST /api/compact endpoint (which runs pi's `compact` rpc command). While it
+// runs, a banner shows above the composer and the status label is pinned to
+// "compacting" (see worker-status.js); it clears once the worker returns idle /
+// the session reloads.
+export function createCompactController({
+  documentImpl = document,
+  chatApi,
+  sessionId = '',
+  setStatus = () => {},
+} = {}) {
+  let compacting = false;
+
+  const banner = () => documentImpl.getElementById('pi-chat-compacting-banner');
+  const button = () => documentImpl.getElementById('pi-chat-compact');
+
+  function setCompacting(on) {
+    compacting = on;
+    const b = banner();
+    if (b) b.hidden = !on;
+  }
+
+  async function trigger() {
+    const btn = button();
+    // Disabled button = worker running (set by worker-status); also dedupe.
+    if (compacting || (btn && btn.disabled)) return;
+    const popover = documentImpl.getElementById('pi-chat-context-popover');
+    if (popover) popover.style.display = 'none';
+    setCompacting(true);
+    setStatus('compacting', 'running');
+    try {
+      const response = await chatApi.compact(sessionId);
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'compact request failed');
+      }
+    } catch (error) {
+      setCompacting(false);
+      setStatus(error.message || String(error), 'error');
+    }
+  }
+
+  // Reflect worker state on the compact button (disabled while running).
+  function setWorkerRunning(running) {
+    const btn = button();
+    if (btn) btn.disabled = running;
+  }
+
+  return {
+    isCompacting: () => compacting,
+    setCompacting,
+    setWorkerRunning,
+    trigger,
+  };
+}

--- a/web/src/components/session/chat/context-popover.js
+++ b/web/src/components/session/chat/context-popover.js
@@ -2,6 +2,7 @@ export function setupContextPopover({
   documentImpl = document,
   windowImpl = window,
   updateContextUsage = () => {},
+  onCompact = () => {},
 } = {}) {
   const usageCapsule = documentImpl.getElementById('pi-chat-context-usage');
   const popover = documentImpl.getElementById('pi-chat-context-popover');
@@ -60,6 +61,7 @@ export function setupContextPopover({
 
   const onPopoverClick = (event) => {
     if (event.target.closest('.pi-popover-close')) hide();
+    else if (event.target.closest('#pi-chat-compact')) onCompact();
     event.stopPropagation();
   };
 

--- a/web/src/components/session/chat/context-usage.js
+++ b/web/src/components/session/chat/context-usage.js
@@ -57,6 +57,40 @@ export function getModelContextLimit(modelId, provider = '', contextWindows = {}
   return 128000;
 }
 
+function usageTotalTokens(u) {
+  return (
+    u.totalTokens || (u.input || 0) + (u.output || 0) + (u.cacheRead || 0) + (u.cacheWrite || 0)
+  );
+}
+
+// chars/4 token estimate, matching pi's estimateTokens (compaction.js). Used to
+// estimate post-compaction context size before the next measured turn.
+function estimateTextTokens(text) {
+  return Math.ceil((text ? String(text).length : 0) / 4);
+}
+
+function estimateEntryTokens(entry) {
+  const m = entry && entry.message;
+  if (!m) return 0;
+  let chars = 0;
+  const c = m.content;
+  if (typeof c === 'string') {
+    chars = c.length;
+  } else if (Array.isArray(c)) {
+    for (const b of c) {
+      if (!b) continue;
+      if (b.type === 'text' && b.text) chars += b.text.length;
+      else if (b.type === 'thinking' && b.thinking) chars += b.thinking.length;
+      else if (b.type === 'toolCall')
+        chars += (b.name ? b.name.length : 0) + JSON.stringify(b.arguments || {}).length;
+      else if (b.type === 'toolResult')
+        chars += JSON.stringify(b.output != null ? b.output : b).length;
+      else if (b.type === 'image') chars += 4800;
+    }
+  }
+  return Math.ceil(chars / 4);
+}
+
 export function collectContextUsage(entries = []) {
   let inputTokens = 0;
   let outputTokens = 0;
@@ -74,19 +108,56 @@ export function collectContextUsage(entries = []) {
     }
   });
 
+  // Context-window pressure. Normally the last assistant's totalTokens estimates
+  // current context size — EXCEPT a `compaction` entry collapses everything
+  // before its firstKeptEntryId into a summary, so pre-compaction usage is stale.
+  // Mirrors pi's estimateContextTokens: after the last compaction, prefer a real
+  // post-compaction assistant usage (next turn → accurate); until one exists,
+  // estimate the summary + kept entries with the same chars/4 heuristic.
   let contextTokens = 0;
+  let compactionIdx = -1;
   for (let i = entries.length - 1; i >= 0; i -= 1) {
-    const entry = entries[i];
-    if (entry?.type !== 'message' || !entry.message) continue;
-    const msg = entry.message;
-    if (msg.role === 'assistant' && msg.usage) {
-      contextTokens =
-        msg.usage.totalTokens ||
-        (msg.usage.input || 0) +
-          (msg.usage.output || 0) +
-          (msg.usage.cacheRead || 0) +
-          (msg.usage.cacheWrite || 0);
+    if (entries[i]?.type === 'compaction') {
+      compactionIdx = i;
       break;
+    }
+  }
+
+  if (compactionIdx >= 0) {
+    for (let i = entries.length - 1; i > compactionIdx; i -= 1) {
+      const entry = entries[i];
+      if (entry?.type === 'message' && entry.message?.role === 'assistant' && entry.message.usage) {
+        contextTokens = usageTotalTokens(entry.message.usage);
+        break;
+      }
+    }
+    if (contextTokens <= 0) {
+      const comp = entries[compactionIdx];
+      let keptIdx = -1;
+      if (comp.firstKeptEntryId) {
+        for (let i = 0; i < entries.length; i += 1) {
+          if (entries[i]?.id === comp.firstKeptEntryId) {
+            keptIdx = i;
+            break;
+          }
+        }
+      }
+      if (keptIdx < 0) keptIdx = compactionIdx;
+      let est = estimateTextTokens(comp.summary || '');
+      for (let i = keptIdx; i < entries.length; i += 1) {
+        if (entries[i]?.type === 'message') est += estimateEntryTokens(entries[i]);
+      }
+      contextTokens = est;
+    }
+  } else {
+    for (let i = entries.length - 1; i >= 0; i -= 1) {
+      const entry = entries[i];
+      if (entry?.type !== 'message' || !entry.message) continue;
+      const msg = entry.message;
+      if (msg.role === 'assistant' && msg.usage) {
+        contextTokens = usageTotalTokens(msg.usage);
+        break;
+      }
     }
   }
 

--- a/web/src/components/session/chat/textarea-controls.js
+++ b/web/src/components/session/chat/textarea-controls.js
@@ -8,6 +8,7 @@ export function setupTextareaControls({
   getMentionSelector = () => null,
   getThinkingSelector = () => null,
   getModelSelector = () => null,
+  getCompact = () => null,
   updateSendEnabled = () => {},
   updateComposerHeight = () => {},
 } = {}) {
@@ -39,7 +40,14 @@ export function setupTextareaControls({
       event.preventDefault();
       getThinkingSelector()?.cycle?.();
     }
-    if (event.ctrlKey && (event.key.toLowerCase() === 'i' || event.key.toLowerCase() === 'l')) {
+    // Cmd/Ctrl+L: compact context (/compact)
+    if ((event.metaKey || event.ctrlKey) && !event.shiftKey && event.key.toLowerCase() === 'l') {
+      event.preventDefault();
+      getCompact()?.trigger?.();
+      return;
+    }
+    // Ctrl+I: open model selector
+    if (event.ctrlKey && event.key.toLowerCase() === 'i') {
       event.preventDefault();
       getModelSelector()?.open?.();
     }

--- a/web/src/components/session/chat/textarea-controls.test.js
+++ b/web/src/components/session/chat/textarea-controls.test.js
@@ -64,14 +64,16 @@ describe('setupTextareaControls', () => {
     expect(parts.form.requestSubmit).not.toHaveBeenCalled();
   });
 
-  it('handles thinking and model shortcuts', () => {
+  it('handles thinking, model, and compact shortcuts', () => {
     const parts = createParts();
     const thinking = { cycle: vi.fn() };
     const model = { open: vi.fn() };
+    const compact = { trigger: vi.fn() };
     setupTextareaControls({
       ...parts,
       getThinkingSelector: () => thinking,
       getModelSelector: () => model,
+      getCompact: () => compact,
     });
 
     const tab = new KeyboardEvent('keydown', {
@@ -84,6 +86,18 @@ describe('setupTextareaControls', () => {
     expect(thinking.cycle).toHaveBeenCalled();
     expect(tab.defaultPrevented).toBe(true);
 
+    // Ctrl+I opens the model selector.
+    const ctrlI = new KeyboardEvent('keydown', {
+      key: 'i',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    parts.textarea.dispatchEvent(ctrlI);
+    expect(model.open).toHaveBeenCalled();
+    expect(ctrlI.defaultPrevented).toBe(true);
+
+    // Cmd/Ctrl+L triggers compaction (not the model selector).
     const ctrlL = new KeyboardEvent('keydown', {
       key: 'l',
       ctrlKey: true,
@@ -91,7 +105,8 @@ describe('setupTextareaControls', () => {
       cancelable: true,
     });
     parts.textarea.dispatchEvent(ctrlL);
-    expect(model.open).toHaveBeenCalled();
+    expect(compact.trigger).toHaveBeenCalled();
     expect(ctrlL.defaultPrevented).toBe(true);
+    expect(model.open).toHaveBeenCalledTimes(1); // Ctrl+L did not also open the model selector
   });
 });

--- a/web/src/components/session/chat/worker-status.js
+++ b/web/src/components/session/chat/worker-status.js
@@ -11,6 +11,7 @@ export function setupWorkerStatusPolling({
   getKnownThinkingLevel = () => '',
   setKnownThinkingLevel = () => {},
   getWorkerModelUpdate = () => null,
+  getCompact = () => null,
   setIntervalImpl = windowImpl.setInterval?.bind(windowImpl),
   CustomEventImpl = windowImpl.CustomEvent,
   intervalMs = 1500,
@@ -37,10 +38,23 @@ export function setupWorkerStatusPolling({
         : '';
       if (apiModelLabel) setKnownModelLabel(apiModelLabel);
       if (data.thinkingLevel) setKnownThinkingLevel(data.thinkingLevel);
-      if (data.state === 'running') setStatus('running', 'running');
-      if (data.state === 'idle') setStatus('idle', '');
-      if (data.state === 'error') setStatus(data.error || 'worker error', 'error');
+      const compact = getCompact?.();
+      // While compacting, pin the label to "compacting" (running cls so Cancel
+      // stays available) regardless of the polled state.
+      if (data.state === 'running')
+        setStatus(compact?.isCompacting() ? 'compacting' : 'running', 'running');
+      if (data.state === 'idle')
+        setStatus(
+          compact?.isCompacting() ? 'compacting' : 'idle',
+          compact?.isCompacting() ? 'running' : '',
+        );
+      if (data.state === 'error') {
+        compact?.setCompacting(false);
+        setStatus(data.error || 'worker error', 'error');
+      }
       if (lastWorkerState === 'running' && data.state === 'idle') {
+        // Compaction (or any run) finished — clear the compacting banner/label.
+        compact?.setCompacting(false);
         try {
           windowImpl.dispatchEvent(new CustomEventImpl('pi-worker-done'));
         } catch {
@@ -48,6 +62,7 @@ export function setupWorkerStatusPolling({
         }
       }
       if (data.state) lastWorkerState = data.state;
+      compact?.setWorkerRunning(lastWorkerState === 'running');
       setModelLabel(getKnownModelLabel());
       setThinkingLabel(getKnownThinkingLevel());
       updateContextUsage();
@@ -71,6 +86,9 @@ export function setupWorkerStatusPolling({
   updateContextUsage();
 
   const onSessionReload = () => {
+    // Compaction completes by writing the session + broadcasting reload; clear
+    // the compacting banner/label before the status poll resolves real state.
+    getCompact?.()?.setCompacting(false);
     void refresh();
     updateContextUsage();
   };

--- a/web/src/session/chat/chat-api.js
+++ b/web/src/session/chat/chat-api.js
@@ -10,6 +10,13 @@ export function sendChat(sessionId, body, { fetchImpl = fetch } = {}) {
   return fetchImpl(chatUrl('/api/chat', sessionId), { method: 'POST', body });
 }
 
+// Compact is its own endpoint, not a chat message: pi's rpc prompt path treats
+// "/compact" as literal text, so real compaction requires POST /api/compact
+// (which runs pi's dedicated `compact` rpc command).
+export function compact(sessionId, { fetchImpl = fetch } = {}) {
+  return fetchImpl(chatUrl('/api/compact', sessionId), { method: 'POST' });
+}
+
 export function getWorkerStatus(sessionId, { fetchImpl = fetch } = {}) {
   return fetchImpl(chatUrl('/api/worker-status', sessionId));
 }

--- a/web/src/shared/locales/en.js
+++ b/web/src/shared/locales/en.js
@@ -158,6 +158,9 @@ export default {
   'composer.cancelRunning': 'Cancel running response',
   'composer.contextDetails': 'Click for details',
   'composer.pathCopied': 'Path copied',
+  'composer.compact': 'Compact conversation context (/compact)',
+  'composer.compactLabel': 'Compact context',
+  'composer.compacting': 'Compacting conversation context…',
 
   // ── Share / export ──
   'share.copiedSuffix': '{label} copied',
@@ -290,6 +293,7 @@ export default {
   'shortcuts.focusInput': 'Focus chat input',
   'shortcuts.cycleThinking': 'Cycle thinking mode',
   'shortcuts.switchModel': 'Choose/switch model',
+  'shortcuts.compact': 'Compact context (/compact)',
   'shortcuts.submit': 'Submit message',
   'shortcuts.scrollDown': 'Scroll down',
   'shortcuts.scrollUp': 'Scroll up',


### PR DESCRIPTION
## Summary

Makes `/compact` one-click triggerable from the web UI (issue #41):

- **Button** "Compact context" at the bottom of the context-usage popover.
- **Shortcut** `⌘/Ctrl + L`, composer-scoped.
- Both call a new **`POST /api/compact`** endpoint that runs pi's dedicated **`compact` rpc command** (`session.compact()`).

### Why a dedicated command (not a chat message)
pi's rpc `prompt` path only expands `extension` / `/skill:` / template commands. `/compact` is a pi **built-in**, so sending it as a prompt would reach the model as **literal text and never compact** (verified against pi source + a real session's JSONL). Compaction therefore goes through the dedicated `compact` rpc command.

### Backend
- `internal/rpc/client.go` — `BuildCompactCommand` → `{"type":"compact"}`
- `internal/rpc/worker.go` — `piRPCWorker.Compact()` (Running during compaction → Idle)
- `internal/workers/manager.go` — `ChatWorker.Compact` + `Manager.Compact` (ensures worker)
- `internal/server/{chat,server}.go` — `ChatSender.Compact` + `handleCompact` (async; broadcasts a reload on completion)

### Frontend / UX
- `chat-api.js` `compact()`, `ChatComposer.svelte` `triggerCompact()` → `/api/compact`.
- **"Compacting…" banner** above the composer + status label pinned to `compacting` while it runs; guarded against firing while the worker is busy; button disables in sync.
- **compaction-aware `updateContextUsage()`** — mirrors pi's `estimateContextTokens`: after a `compaction` entry the context ring reflects the reduced size (`summary` + kept entries, chars/4) instead of stale pre-compaction usage, switching to the measured value on the next turn.

### Shortcut
Uses `⌘/Ctrl + L` (as requested). `Ctrl+L` previously also opened the model selector (shared with `Ctrl+I`); the model selector is now bound to **`Ctrl+I` only**, freeing `Ctrl/Cmd+L` for `/compact`.

## Test plan
- [x] Vitest: compact endpoint path (not `sendChat`); banner show/hide; compaction-aware context estimate vs measured; running guard; `Ctrl+I` model selector
- [x] Playwright (Desktop Chrome): real compaction marker appears, banner shows→hides, no `Stub reply: /compact`; `⌘/Ctrl+L` path; stub pi implements the `compact` command
- [x] `go vet` clean, `go test ./...` pass, `make build` succeeds
- [x] Maintainer sanity check on a real pi worker

> Note: the unrelated `cat.spec.ts` gatekeeper e2e is time-of-day dependent (shows the bedtime `--sleep` overlay during certain hours) and can go red regardless of this change.

> Draft — pending final review.