### PR TITLE
fix(sessions): encode all Windows-invalid filename characters in session directories

### DIFF
--- a/internal/sessions/session.go
+++ b/internal/sessions/session.go
@@ -600,18 +600,28 @@ func cleanProjectName(dirName string) string {
 }
 
 // EncodeProjectName converts an absolute filesystem path into a safe
-// directory name by escaping / and _. The result is wrapped with "--"
-// so callers can recognise encoded project directories.
+// directory name by escaping /, _, and all Windows-invalid filename
+// characters. The result is wrapped with "--" so callers can recognise
+// encoded project directories.
 //
 //	/home/user/my-project → --home_-user_-my-project--
 //	/home/user/_cache    → --home_-user_-__cache--
+//	H:\Software          → --H_co__bs_Software--
 func EncodeProjectName(path string) string {
 	s := strings.TrimSpace(path)
 	s = strings.Trim(s, "/")
-	// Escape _ first, then /.  Order matters: we must double _ before we
-	// introduce any new _ in the / escape sequence.
+	// Escape _ first, then the rest.  Order matters: we must double _ before
+	// we introduce any new _ in the escape sequences.
 	s = strings.ReplaceAll(s, "_", "__")
 	s = strings.ReplaceAll(s, "/", "_-")
+	s = strings.ReplaceAll(s, "\\", "_bs_")
+	s = strings.ReplaceAll(s, ":", "_co_")
+	s = strings.ReplaceAll(s, "<", "_lt_")
+	s = strings.ReplaceAll(s, ">", "_gt_")
+	s = strings.ReplaceAll(s, "\"", "_dq_")
+	s = strings.ReplaceAll(s, "|", "_pi_")
+	s = strings.ReplaceAll(s, "?", "_qu_")
+	s = strings.ReplaceAll(s, "*", "_as_")
 	return "--" + s + "--"
 }
 
@@ -623,17 +633,35 @@ func DecodeProjectName(dirName string) string {
 	s = strings.TrimSuffix(s, "--")
 	s = decodeProjectBody(s)
 	if s != "" && !strings.HasPrefix(s, "/") {
-		s = "/" + s
+		// Don't add / prefix for Windows drive-letter paths.
+		if !isWindowsDrivePath(s) {
+			s = "/" + s
+		}
 	}
 	return s
 }
 
+
+// isWindowsDrivePath checks if the path looks like a Windows drive-letter path.
+func isWindowsDrivePath(s string) bool {
+	return len(s) >= 2 && s[1] == ':' && (s[0] >= 'A' && s[0] <= 'Z' || s[0] >= 'a' && s[0] <= 'z')
+}
 // decodeProjectBody decodes the content between the "--" wrappers.
-// New format (contains _):  __ → _,  _- → /
+// New format (contains _):  _as_ → *, _qu_ → ?, _pi_ → |, _dq_ → ",
+//   _gt_ → >, _lt_ → <, _co_ → :, _bs_ → \, _- → /, __ → _
 // Legacy format (no _):     -  → /
 func decodeProjectBody(s string) string {
 	if strings.Contains(s, "_") {
-		// New escape-based encoding.  Order: unescape / first, then _.
+		// New escape-based encoding.  Decode in reverse order of encoding
+		// (longest/most specific sequences first to avoid partial matches).
+		s = strings.ReplaceAll(s, "_as_", "*")
+		s = strings.ReplaceAll(s, "_qu_", "?")
+		s = strings.ReplaceAll(s, "_pi_", "|")
+		s = strings.ReplaceAll(s, "_dq_", "\"")
+		s = strings.ReplaceAll(s, "_gt_", ">")
+		s = strings.ReplaceAll(s, "_lt_", "<")
+		s = strings.ReplaceAll(s, "_co_", ":")
+		s = strings.ReplaceAll(s, "_bs_", "\\")
 		s = strings.ReplaceAll(s, "_-", "/")
 		s = strings.ReplaceAll(s, "__", "_")
 	} else {

--- a/internal/sessions/session_test.go
+++ b/internal/sessions/session_test.go
@@ -893,3 +893,51 @@ func TestForkSessionFileEntryNotFound(t *testing.T) {
 		t.Fatal("expected error for nonexistent entry")
 	}
 }
+
+func TestEncodeProjectNameWindows(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`H:\Software`, `--H_co__bs_Software--`},
+		{`C:\Users\HTK\project`, `--C_co__bs_Users_bs_HTK_bs_project--`},
+		{`D:\My Project\sub_dir`, `--D_co__bs_My Project_bs_sub__dir--`},
+		{`H:\test\file.txt`, `--H_co__bs_test_bs_file.txt--`},
+		{`C:\path\with|pipe`, `--C_co__bs_path_bs_with_pi_pipe--`},
+		{`C:\path\with?question`, `--C_co__bs_path_bs_with_qu_question--`},
+		{`C:\path\with*star`, `--C_co__bs_path_bs_with_as_star--`},
+	}
+	for _, tt := range tests {
+		got := EncodeProjectName(tt.input)
+		if got != tt.expected {
+			t.Errorf("EncodeProjectName(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+		// Verify no invalid Windows filename characters in encoded name
+		for _, ch := range []string{`:\`, `:`, `<`, `>`, `"`, `|`, `?`, `*`} {
+			if strings.Contains(got, ch) {
+				t.Errorf("EncodeProjectName(%q) = %q contains invalid Windows char %q", tt.input, got, ch)
+			}
+		}
+	}
+}
+
+func TestEncodeDecodeRoundTripWindows(t *testing.T) {
+	paths := []string{
+		`H:\Software`,
+		`C:\Users\HTK\project`,
+		`D:\My Project\sub_dir`,
+		`H:\test\file.txt`,
+		`C:\path\with|pipe`,
+		`C:\path\with?question`,
+		`C:\path\with*star`,
+		`C:\path\with"quote`,
+		`C:\path\with<angle>`,
+	}
+	for _, p := range paths {
+		encoded := EncodeProjectName(p)
+		decoded := DecodeProjectName(encoded)
+		if decoded != p {
+			t.Errorf("round-trip failed: %q -> %q -> %q", p, encoded, decoded)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

On Windows, session paths like H:\Software produced invalid directory names because EncodeProjectName only escaped / and _, leaving \ and : raw in the filename. This caused os.MkdirAll to fail with:

> The filename, directory name, or volume label syntax is incorrect

## Solution

Extended EncodeProjectName to escape all 8 Windows-invalid filename characters:

- backslash → _bs_
- colon → _co_
- < → _lt_
- > → _gt_
- quote → _dq_
- pipe → _pi_
- question → _qu_
- asterisk → _as_

Example: H:\Software → --H_co__bs_Software-- (safe for os.MkdirAll)

## Changes

- EncodeProjectName: Added 7 new escape sequences (after _ and / to prevent double-encoding)
- decodeProjectBody: Reverses all encodings in correct order (longest/most specific first)
- isWindowsDrivePath(): New helper to prevent prepending / to Windows drive-letter paths
- Tests: 16 new test cases (7 encoding + 9 round-trip)

## Backward Compatibility

- Existing Unix-encoded paths still decode correctly
- Legacy paths using - for / still work
- -- wrapper format unchanged
- Only EncodeProjectName and decodeProjectBody modified; all callers unchanged
