### PR TITLE
test(e2e): make cat gatekeeper test time-independent

### DIFF
--- a/e2e/tests/cat.spec.ts
+++ b/e2e/tests/cat.spec.ts
@@ -22,6 +22,12 @@ test.describe("cat gatekeeper", () => {
     const { entries } = buildSession({ cwd });
     const id = writeSession(sessionsDir, uniqueSessionName(testInfo, "cat"), entries);
 
+    // Pin the browser clock to a non-bedtime hour. The gatekeeper's bedtime
+    // "sleep" overlay (default 23:00–07:00, read from the live Date.now()) would
+    // otherwise pre-empt skip-to-break whenever CI runs during that window. Use
+    // setFixedTime (not install) so the app's other timers keep running.
+    await page.clock.setFixedTime(new Date("2026-06-08T12:00:00"));
+
     await page.route("**/api/settings", async (route) => {
       if (route.request().method() === "GET") {
         await route.fulfill({


### PR DESCRIPTION
## Problem

`tests/cat.spec.ts` (`skip-to-break shows the enforced break overlay`) is flaky by **time of day**: the cat gatekeeper's bedtime "sleep" overlay (default window **23:00–07:00**) is computed from the live browser `Date.now()`. When CI runs inside that window, `skipToBreak()` shows the sleepy cat (`cat-overlay--sleep`) instead of the break, so the test fails:

```
expect(locator).toHaveClass(/cat-overlay--break/)
Received: "cat-overlay cat-overlay--sleep visible"
```

It passes during the day and fails at night (UTC), across all browser projects.

## Fix

Pin the browser clock to a fixed non-bedtime hour with Playwright's `page.clock.setFixedTime()` (set before navigation). Uses `setFixedTime` rather than `clock.install()` so the app's other timers (status polling, SSE) keep running normally.

```ts
await page.clock.setFixedTime(new Date("2026-06-08T12:00:00"));
```

## Verification

Run during the bedtime window (where it previously failed) — now green across Desktop Chrome / Mobile Safari / iPad:

```
✓ cat gatekeeper › skip-to-break shows the enforced break overlay with a countdown
```

One-line test-only change; no product code touched.