### PR TITLE
fix: prevent Enter key from sending message during IME composition

### DIFF
--- a/web/src/components/session/chat/textarea-controls.js
+++ b/web/src/components/session/chat/textarea-controls.js
@@ -30,7 +30,7 @@ export function setupTextareaControls({
   const onKeydown = (event) => {
     if (getSlashSelector()?.handleKeydown?.(event)) return;
     if (getMentionSelector()?.handleKeydown?.(event)) return;
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
       if (isMobileTextInputMode()) return;
       event.preventDefault();
       form?.requestSubmit?.();


### PR DESCRIPTION
## Problem

When using an IME (Input Method Editor) — such as Chinese, Japanese, or Korean input methods — pressing Enter to confirm the current composition would incorrectly submit the chat message instead.

This happens because the `keydown` handler in `textarea-controls.js` doesn't check `event.isComposing`. During IME composition, the browser fires keyboard events with `isComposing: true`, and Enter should confirm the composition, not send the message.

## Fix

Added `!event.isComposing` to the Enter key condition in `web/src/components/session/chat/textarea-controls.js`:

```javascript
// Before
if (event.key === 'Enter' && !event.shiftKey) {

// After
if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
```

This is the standard [Web API approach](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing) for handling IME composition correctly in web applications.

## Testing

- All 629 existing tests pass
- Manually verified with Chinese IME on macOS:
  - Typing English letters with IME active → Enter confirms composition ✓
  - Typing without IME → Enter sends message as before ✓
  - Shift+Enter → newline (unchanged) ✓
