### PR TITLE
feat: configurable session display defaults for thinking, tools, and tool outputs

### DIFF
--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -394,6 +394,35 @@ test.describe("settings page", () => {
         page.locator('[data-action="toggle-tool-output"]'),
       ).toHaveAttribute("aria-pressed", "false");
     });
+
+    // Hiding tools must leave a visible marker next to each tool call, not a
+    // stranded timestamp. Mirrors the .thinking-collapsed "Thinking ..."
+    // placeholder pattern.
+    test("hiding tools surfaces the 'Tool: <name> ...' collapsed marker", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      await page
+        .locator(".session-card", { hasText: "add deepseek-v4-pro" })
+        .click();
+      await expect(page).toHaveURL(/\/session\?id=/);
+
+      // Default state: tools visible, placeholder hidden.
+      await expect(
+        page.locator('[data-action="toggle-tools"]'),
+      ).toHaveAttribute("aria-pressed", "true");
+      const placeholders = page.locator(".tool-call-collapsed");
+      await expect(placeholders.first()).toBeAttached();
+      await expect(placeholders.first()).toBeHidden();
+      await expect(page.locator(".tool-execution").first()).toBeVisible();
+
+      // Toggle tools off and assert the swap — placeholder becomes visible,
+      // tool-execution is hidden.
+      await page.locator('[data-action="toggle-tools"]').click();
+      await expect(placeholders.first()).toBeVisible();
+      await expect(placeholders.first()).toContainText(/^Tool: \S+ \.\.\./);
+      await expect(page.locator(".tool-execution").first()).toBeHidden();
+    });
   });
 
   // Mobile drill-in: at narrow widths the sidebar fills the viewport and the

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -228,69 +228,172 @@ test.describe("settings page", () => {
     await expect(page.locator('[data-setting="pi-web-theme"]')).toHaveCount(0);
   });
 
-  // Session Display defaults (issue #48): the three header toggles
-  // (thinking, tools, tool outputs) have configurable initial visibility. The
-  // /settings page writes through to /api/settings, and the next session load
-  // picks the new value up via loadToggleState before the user has touched the
-  // header buttons. Verified by checking the buttons' aria-pressed state, which
-  // syncToggleButtons sets on attachHeaderHandlers.
-  test("session display defaults persist and apply to new session loads", async ({
-    page,
-  }, testInfo) => {
-    test.skip(
-      testInfo.project.name !== "Desktop Chrome",
-      "server-side persistence is browser-independent; run once",
-    );
+  // Session Display defaults (issue #48). Three tests cover the feature end
+  // to end: the /settings page round-trip, the bug-fix invariant that an
+  // in-session toggle is scoped to that session id, and the migration that
+  // discards the pre-PR global blob. They share a key (toggle:thinking) and
+  // assume specific server-side starting state, so they run serially in the
+  // same worker (the file is fullyParallel by default — see playwright.config).
+  test.describe.serial("session display defaults", () => {
+    // POST the toggle defaults back to the server-side defaults before each
+    // test in this group so a partial earlier run can't make the next test
+    // depend on stale state.
+    test.beforeEach(async ({ page }, testInfo) => {
+      test.skip(
+        testInfo.project.name !== "Desktop Chrome",
+        "shared server-side settings store; run once",
+      );
+      const r = await page.request.post("/api/settings", {
+        data: {
+          settings: {
+            "pi-web:v1:toggle:thinking": "true",
+            "pi-web:v1:toggle:tools": "true",
+            "pi-web:v1:toggle:tool-outputs": "false",
+          },
+        },
+      });
+      expect(r.ok()).toBeTruthy();
+    });
 
-    const thinkingInput = '[data-setting="pi-web:v1:toggle:thinking"]';
-    // The <input> is visually hidden by .settings-toggle CSS; the wrapping
-    // <label> is what the user actually clicks. Target the label for interactions
-    // and the input for state assertions.
-    const thinkingLabel = `label.settings-toggle:has(${thinkingInput})`;
+    // /settings round-trip: the three header toggles (thinking, tools, tool
+    // outputs) have configurable initial visibility. The /settings page writes
+    // through to /api/settings, and the next session load picks the new value
+    // up via loadToggleState before the user has touched the header buttons.
+    // Verified by checking the buttons' aria-pressed state, which
+    // syncToggleButtons sets on attachHeaderHandlers.
+    test("defaults persist and apply to new session loads", async ({
+      page,
+    }) => {
+      const thinkingInput = '[data-setting="pi-web:v1:toggle:thinking"]';
+      // The <input> is visually hidden by .settings-toggle CSS; the wrapping
+      // <label> is what the user actually clicks. Target the label for
+      // interactions and the input for state assertions.
+      const thinkingLabel = `label.settings-toggle:has(${thinkingInput})`;
 
-    await page.goto("/settings");
-    await openSection(page, "sessionDisplay");
-    await expect(page.locator(thinkingLabel)).toBeVisible();
-    await expect(page.locator(thinkingInput)).toBeChecked();
+      await page.goto("/settings");
+      await openSection(page, "sessionDisplay");
+      await expect(page.locator(thinkingLabel)).toBeVisible();
+      await expect(page.locator(thinkingInput)).toBeChecked();
 
-    // Default is "true" (matches the previous hardcoded behavior); flip to off
-    // and assert the change is POSTed.
-    const saved = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/settings") && r.request().method() === "POST",
-    );
-    await page.locator(thinkingLabel).click();
-    await saved;
-    await expect(page.locator(thinkingInput)).not.toBeChecked();
+      // Default is "true" (matches the previous hardcoded behavior); flip to
+      // off and assert the change is POSTed.
+      const saved = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/settings") &&
+          r.request().method() === "POST",
+      );
+      await page.locator(thinkingLabel).click();
+      await saved;
+      await expect(page.locator(thinkingInput)).not.toBeChecked();
 
-    // Drop the localStorage cache so the next page load can only get the
-    // setting back from the server, then reload to confirm the toggle stays off.
-    await page.evaluate(() => window.localStorage.clear());
-    await page.reload();
-    await openSection(page, "sessionDisplay");
-    await expect(page.locator(thinkingInput)).not.toBeChecked();
+      // Drop the localStorage cache so the next page load can only get the
+      // setting back from the server, then reload to confirm it stays off.
+      await page.evaluate(() => window.localStorage.clear());
+      await page.reload();
+      await openSection(page, "sessionDisplay");
+      await expect(page.locator(thinkingInput)).not.toBeChecked();
 
-    // Open the demo session and assert the header toggle reflects the new
-    // default. aria-pressed is set by syncToggleButtons during
-    // attachHeaderHandlers, so it captures the state loadToggleState computed.
-    await page.goto("/");
-    await page.locator(".session-card", { hasText: "add deepseek-v4-pro" }).click();
-    await expect(page).toHaveURL(/\/session\?id=/);
-    await expect(
-      page.locator('[data-action="toggle-thinking"]'),
-    ).toHaveAttribute("aria-pressed", "false");
+      // Open the demo session and assert the header toggle reflects the new
+      // default. aria-pressed is set by syncToggleButtons during
+      // attachHeaderHandlers, so it captures the state loadToggleState
+      // computed.
+      await page.goto("/");
+      await page
+        .locator(".session-card", { hasText: "add deepseek-v4-pro" })
+        .click();
+      await expect(page).toHaveURL(/\/session\?id=/);
+      await expect(
+        page.locator('[data-action="toggle-thinking"]'),
+      ).toHaveAttribute("aria-pressed", "false");
+    });
 
-    // Restore the default so this test doesn't bleed into the rest of the
-    // suite (settings persist server-side in a single shared store).
-    await page.goto("/settings");
-    await openSection(page, "sessionDisplay");
-    const restored = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/settings") && r.request().method() === "POST",
-    );
-    await page.locator(thinkingLabel).click();
-    await restored;
-    await expect(page.locator(thinkingInput)).toBeChecked();
+    // Per-session override (issue #48 follow-up): when the user toggles a
+    // header button inside a session, the override is scoped to that session.
+    // Other sessions still follow the configured /settings default. Regression
+    // guard for the bug where a single global blob shadowed the setting across
+    // every session.
+    test("in-session header toggle override is scoped to that session", async ({
+      page,
+    }) => {
+      // Clean any blob a previous test in this group might have left on this
+      // browser context. The beforeEach has reset server-side defaults.
+      await page.goto("/");
+      await page.evaluate(() =>
+        window.localStorage.removeItem("pi.sessionDetail.toggleState"),
+      );
+
+      // Open the demo session and toggle thinking off via the header button —
+      // this is the "in-session override" the bug used to leak to every other
+      // session.
+      await page
+        .locator(".session-card", { hasText: "add deepseek-v4-pro" })
+        .click();
+      await expect(page).toHaveURL(/\/session\?id=/);
+      const demoUrl = page.url();
+      await expect(
+        page.locator('[data-action="toggle-thinking"]'),
+      ).toHaveAttribute("aria-pressed", "true");
+      await page.locator('[data-action="toggle-thinking"]').click();
+      await expect(
+        page.locator('[data-action="toggle-thinking"]'),
+      ).toHaveAttribute("aria-pressed", "false");
+
+      // Navigate to a different session; the configured default (thinking on)
+      // must apply — the demo override must not leak.
+      await page.goto("/");
+      await page
+        .locator(".session-card", { hasText: "Fix the failing unit test" })
+        .click();
+      await expect(page).toHaveURL(/\/session\?id=/);
+      await expect(
+        page.locator('[data-action="toggle-thinking"]'),
+      ).toHaveAttribute("aria-pressed", "true");
+
+      // Re-open the demo session; the per-session override must still apply
+      // there (the blob remembers it specifically for that session id).
+      await page.goto(demoUrl);
+      await expect(
+        page.locator('[data-action="toggle-thinking"]'),
+      ).toHaveAttribute("aria-pressed", "false");
+    });
+
+    // Migration: a pre-existing flat-state blob (one shared override for every
+    // session) must be ignored after this PR so the configured default
+    // applies. Regression guard for the exact bug surfaced in the screenshot
+    // review.
+    test("stale flat-shape toggle blob is ignored by loadToggleState", async ({
+      page,
+    }) => {
+      // Seed localStorage with the old flat shape before any session loads,
+      // matching what users from before this PR have on their machines.
+      await page.goto("/");
+      await page.evaluate(() => {
+        window.localStorage.setItem(
+          "pi.sessionDetail.toggleState",
+          JSON.stringify({
+            thinkingExpanded: false,
+            toolsVisible: false,
+            toolOutputsExpanded: true,
+          }),
+        );
+      });
+      await page
+        .locator(".session-card", { hasText: "add deepseek-v4-pro" })
+        .click();
+      await expect(page).toHaveURL(/\/session\?id=/);
+
+      // The configured defaults (thinking on, tools on, tool outputs off) must
+      // win — the flat blob is treated as no overrides.
+      await expect(
+        page.locator('[data-action="toggle-thinking"]'),
+      ).toHaveAttribute("aria-pressed", "true");
+      await expect(
+        page.locator('[data-action="toggle-tools"]'),
+      ).toHaveAttribute("aria-pressed", "true");
+      await expect(
+        page.locator('[data-action="toggle-tool-output"]'),
+      ).toHaveAttribute("aria-pressed", "false");
+    });
   });
 
   // Mobile drill-in: at narrow widths the sidebar fills the viewport and the

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -228,6 +228,71 @@ test.describe("settings page", () => {
     await expect(page.locator('[data-setting="pi-web-theme"]')).toHaveCount(0);
   });
 
+  // Session Display defaults (issue #48): the three header toggles
+  // (thinking, tools, tool outputs) have configurable initial visibility. The
+  // /settings page writes through to /api/settings, and the next session load
+  // picks the new value up via loadToggleState before the user has touched the
+  // header buttons. Verified by checking the buttons' aria-pressed state, which
+  // syncToggleButtons sets on attachHeaderHandlers.
+  test("session display defaults persist and apply to new session loads", async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "Desktop Chrome",
+      "server-side persistence is browser-independent; run once",
+    );
+
+    const thinkingInput = '[data-setting="pi-web:v1:toggle:thinking"]';
+    // The <input> is visually hidden by .settings-toggle CSS; the wrapping
+    // <label> is what the user actually clicks. Target the label for interactions
+    // and the input for state assertions.
+    const thinkingLabel = `label.settings-toggle:has(${thinkingInput})`;
+
+    await page.goto("/settings");
+    await openSection(page, "sessionDisplay");
+    await expect(page.locator(thinkingLabel)).toBeVisible();
+    await expect(page.locator(thinkingInput)).toBeChecked();
+
+    // Default is "true" (matches the previous hardcoded behavior); flip to off
+    // and assert the change is POSTed.
+    const saved = page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/settings") && r.request().method() === "POST",
+    );
+    await page.locator(thinkingLabel).click();
+    await saved;
+    await expect(page.locator(thinkingInput)).not.toBeChecked();
+
+    // Drop the localStorage cache so the next page load can only get the
+    // setting back from the server, then reload to confirm the toggle stays off.
+    await page.evaluate(() => window.localStorage.clear());
+    await page.reload();
+    await openSection(page, "sessionDisplay");
+    await expect(page.locator(thinkingInput)).not.toBeChecked();
+
+    // Open the demo session and assert the header toggle reflects the new
+    // default. aria-pressed is set by syncToggleButtons during
+    // attachHeaderHandlers, so it captures the state loadToggleState computed.
+    await page.goto("/");
+    await page.locator(".session-card", { hasText: "add deepseek-v4-pro" }).click();
+    await expect(page).toHaveURL(/\/session\?id=/);
+    await expect(
+      page.locator('[data-action="toggle-thinking"]'),
+    ).toHaveAttribute("aria-pressed", "false");
+
+    // Restore the default so this test doesn't bleed into the rest of the
+    // suite (settings persist server-side in a single shared store).
+    await page.goto("/settings");
+    await openSection(page, "sessionDisplay");
+    const restored = page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/settings") && r.request().method() === "POST",
+    );
+    await page.locator(thinkingLabel).click();
+    await restored;
+    await expect(page.locator(thinkingInput)).toBeChecked();
+  });
+
   // Mobile drill-in: at narrow widths the sidebar fills the viewport and the
   // pane is hidden until a section is tapped; the header back arrow returns to
   // the list. Mirrors the iOS Settings pattern.

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -395,6 +395,39 @@ test.describe("settings page", () => {
       ).toHaveAttribute("aria-pressed", "false");
     });
 
+    // Cold-cache first paint: before this fix, the toggle controller was
+    // created from an empty localStorage and never re-read after
+    // hydrateSettings() resolved, so a fresh browser would render hardcoded
+    // defaults instead of the user's configured ones. After the fix, the
+    // controller's reload() runs once hydration lands, catching the rendered
+    // header up to the configured default.
+    test("first paint with empty localStorage picks up configured defaults after hydrate", async ({
+      page,
+    }) => {
+      // Configure the server-side default to a non-hardcoded value so we can
+      // distinguish "hydrate worked and reload() ran" from "hardcoded fallback".
+      const seeded = await page.request.post("/api/settings", {
+        data: { settings: { "pi-web:v1:toggle:thinking": "false" } },
+      });
+      expect(seeded.ok()).toBeTruthy();
+
+      // Land on the index, wipe the localStorage cache so the session page's
+      // synchronous loadToggleState() runs against an empty store. The fresh
+      // context means there's no per-session blob either.
+      await page.goto("/");
+      await page.evaluate(() => window.localStorage.clear());
+      await page
+        .locator(".session-card", { hasText: "add deepseek-v4-pro" })
+        .click();
+      await expect(page).toHaveURL(/\/session\?id=/);
+
+      // Without reload-after-hydrate, this stayed at "true" indefinitely because
+      // the controller was constructed before localStorage was populated.
+      await expect(
+        page.locator('[data-action="toggle-thinking"]'),
+      ).toHaveAttribute("aria-pressed", "false");
+    });
+
     // Gating: while tool calls are hidden, the "Tool output" header button and
     // its matching settings toggle have no visible effect, so both must
     // surface as disabled. The state itself is preserved so re-enabling tools

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -395,6 +395,52 @@ test.describe("settings page", () => {
       ).toHaveAttribute("aria-pressed", "false");
     });
 
+    // Gating: while tool calls are hidden, the "Tool output" header button and
+    // its matching settings toggle have no visible effect, so both must
+    // surface as disabled. The state itself is preserved so re-enabling tools
+    // restores the prior tool-output choice.
+    test("tool-output toggle is disabled while tools are hidden", async ({
+      page,
+    }) => {
+      // Session header: open demo, hide tools, assert the Tool output button is
+      // disabled; show tools again, assert it's re-enabled.
+      await page.goto("/");
+      await page
+        .locator(".session-card", { hasText: "add deepseek-v4-pro" })
+        .click();
+      await expect(page).toHaveURL(/\/session\?id=/);
+      const toolOutputBtn = page.locator(
+        '[data-action="toggle-tool-output"]',
+      );
+      await expect(toolOutputBtn).toBeEnabled();
+      await page.locator('[data-action="toggle-tools"]').click();
+      await expect(toolOutputBtn).toBeDisabled();
+      await page.locator('[data-action="toggle-tools"]').click();
+      await expect(toolOutputBtn).toBeEnabled();
+
+      // Settings page: same gating on the "Expand tool outputs by default"
+      // input — disabled when "Show tool calls by default" is off.
+      await page.goto("/settings");
+      await openSection(page, "sessionDisplay");
+      const toolsInput = page.locator(
+        '[data-setting="pi-web:v1:toggle:tools"]',
+      );
+      const toolOutputsInput = page.locator(
+        '[data-setting="pi-web:v1:toggle:tool-outputs"]',
+      );
+      const toolsLabel = `label.settings-toggle:has([data-setting="pi-web:v1:toggle:tools"])`;
+      await expect(toolsInput).toBeChecked();
+      await expect(toolOutputsInput).toBeEnabled();
+      const offSaved = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/settings") &&
+          r.request().method() === "POST",
+      );
+      await page.locator(toolsLabel).click();
+      await offSaved;
+      await expect(toolOutputsInput).toBeDisabled();
+    });
+
     // Hiding tools must leave a visible marker next to each tool call, not a
     // stranded timestamp. Mirrors the .thinking-collapsed "Thinking ..."
     // placeholder pattern.

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -66,6 +66,9 @@ var settingDefaults = map[string]string{
 	settingAutoTitleModel:         "",
 	"pi-web:v1:artifacts:enabled": "true",
 	"pi-web:v1:artifacts:include": "*.md, *.html",
+	"pi-web:v1:toggle:thinking":      "true",
+	"pi-web:v1:toggle:tools":         "true",
+	"pi-web:v1:toggle:tool-outputs":  "false",
 }
 
 // getSettings returns every server-backed setting: defaults overlaid with any

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -120,6 +120,40 @@ func TestAutoTitleSettingsDefaultsAndRoundTrip(t *testing.T) {
 	}
 }
 
+func TestToggleDefaultSettingsRoundTrip(t *testing.T) {
+	s := &Server{db: newSettingsTestDB(t)}
+
+	all := s.getSettings()
+	if all["pi-web:v1:toggle:thinking"] != "true" {
+		t.Errorf("expected toggle:thinking default 'true', got %q", all["pi-web:v1:toggle:thinking"])
+	}
+	if all["pi-web:v1:toggle:tools"] != "true" {
+		t.Errorf("expected toggle:tools default 'true', got %q", all["pi-web:v1:toggle:tools"])
+	}
+	if all["pi-web:v1:toggle:tool-outputs"] != "false" {
+		t.Errorf("expected toggle:tool-outputs default 'false', got %q", all["pi-web:v1:toggle:tool-outputs"])
+	}
+
+	body := bytes.NewBufferString(`{"settings":{"pi-web:v1:toggle:thinking":"false","pi-web:v1:toggle:tool-outputs":"true"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/settings", body)
+	w := httptest.NewRecorder()
+	s.handleSaveSettings(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if got := s.getSetting("pi-web:v1:toggle:thinking", "true"); got != "false" {
+		t.Errorf("expected stored toggle:thinking 'false', got %q", got)
+	}
+	if got := s.getSetting("pi-web:v1:toggle:tool-outputs", "false"); got != "true" {
+		t.Errorf("expected stored toggle:tool-outputs 'true', got %q", got)
+	}
+	// Untouched key keeps its default.
+	if got := s.getSetting("pi-web:v1:toggle:tools", "true"); got != "true" {
+		t.Errorf("expected toggle:tools to keep default 'true', got %q", got)
+	}
+}
+
 func TestHandleSaveSettingsIgnoresUnknownKeys(t *testing.T) {
 	s := &Server{db: newSettingsTestDB(t)}
 

--- a/internal/ui/embedded/styles/session.css
+++ b/internal/ui/embedded/styles/session.css
@@ -1583,6 +1583,17 @@
       color: var(--body-bg);
     }
 
+    /* Set on the "Tool output" button by syncToggleButtons when tool calls are
+       hidden — its setting has no visible effect until tools are visible
+       again. */
+    .header-toggle-btn:disabled,
+    .header-toggle-btn:disabled:hover {
+      opacity: 0.4;
+      cursor: not-allowed;
+      background: var(--container-bg);
+      border-color: var(--border);
+    }
+
     .model-search {
       display: block;
       width: calc(100% - 16px);

--- a/internal/ui/embedded/styles/session.css
+++ b/internal/ui/embedded/styles/session.css
@@ -2207,6 +2207,19 @@
       border-radius: 4px;
     }
 
+    /* Placeholder shown in place of a tool call when the "show tool calls"
+       toggle is off — mirrors .thinking-collapsed so users still see a marker
+       instead of a stranded timestamp. */
+    .tool-call-collapsed {
+      display: none;
+      padding: var(--line-height);
+      color: var(--thinkingText);
+      font-style: italic;
+    }
+    .message-timestamp + .tool-call-collapsed {
+      padding-top: 0;
+    }
+
     .tool-execution + .tool-execution {
       margin-top: var(--line-height);
     }

--- a/internal/ui/embedded/styles/session.css
+++ b/internal/ui/embedded/styles/session.css
@@ -1585,13 +1585,16 @@
 
     /* Set on the "Tool output" button by syncToggleButtons when tool calls are
        hidden — its setting has no visible effect until tools are visible
-       again. */
+       again. opacity alone collapsed the 10px text into the surface in dark
+       themes; the explicit text-soft + dimmed background keep it readable
+       across every theme while still reading as inactive. */
     .header-toggle-btn:disabled,
     .header-toggle-btn:disabled:hover {
-      opacity: 0.4;
       cursor: not-allowed;
+      color: var(--text-soft);
       background: var(--container-bg);
       border-color: var(--border);
+      opacity: 0.7;
     }
 
     .model-search {

--- a/internal/ui/embedded/styles/settings.css
+++ b/internal/ui/embedded/styles/settings.css
@@ -231,6 +231,16 @@
   background: #fff;
 }
 
+/* Row dim/disabled state: used when one toggle gates another (e.g.
+   "Expand tool outputs by default" has no effect when "Show tool calls by
+   default" is off). */
+.settings-row-disabled {
+  opacity: 0.5;
+}
+.settings-row-disabled .settings-toggle .slider {
+  cursor: not-allowed;
+}
+
 .settings-link {
   display: inline-flex;
   align-items: center;

--- a/internal/ui/toggle_state_test.go
+++ b/internal/ui/toggle_state_test.go
@@ -61,7 +61,11 @@ func TestToolsVisibilityAndOutputExpansionAreSeparateStates(t *testing.T) {
 		"node.querySelectorAll('.tool-output.expandable').forEach((el) => {",
 		"el.classList.toggle('expanded', state.toolOutputsExpanded);",
 		"toggleToolsVisibility: () => toggle('toolsVisible'),",
-		"toggleToolOutputs: () => toggle('toolOutputsExpanded'),",
+		// toggleToolOutputs no-ops when tools are hidden so the P shortcut and a
+		// disabled-button click stay quiet (output blocks are inside the hidden
+		// .tool-execution wrapper, so there's nothing to expand or collapse).
+		"if (!state.toolsVisible) return;",
+		"toggle('toolOutputsExpanded');",
 	}
 	for _, check := range checks {
 		if !strings.Contains(src, check) {

--- a/internal/ui/toggle_state_test.go
+++ b/internal/ui/toggle_state_test.go
@@ -31,7 +31,10 @@ func TestSessionToggleButtonsReflectPersistedActiveState(t *testing.T) {
 			"toolsVisible: true",
 			"toolOutputsExpanded: false",
 			"storage?.getItem(TOGGLE_STATE_STORAGE_KEY)",
-			"storage?.setItem(TOGGLE_STATE_STORAGE_KEY, JSON.stringify(state));",
+			// Toggle state persists under TOGGLE_STATE_STORAGE_KEY, but as a
+			// { [sessionId]: state } map so changing the configured default in
+			// /settings affects every session the user hasn't explicitly toggled.
+			"storage?.setItem(TOGGLE_STATE_STORAGE_KEY, JSON.stringify(map));",
 			"btn.classList.toggle('active', isActive);",
 			"btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');",
 		},

--- a/web/src/components/session/ToolCall.svelte
+++ b/web/src/components/session/ToolCall.svelte
@@ -43,6 +43,13 @@
 
 <!-- eslint-disable svelte/no-at-html-tags -- trusted: Lucide icon SVG and rendered session markdown -->
 
+<!--
+  The .tool-call-collapsed sibling mirrors the .thinking-collapsed pattern:
+  applyToggleStateToNode (web/src/session/ui/toggle-state.js) shows it whenever
+  state.toolsVisible is false so an assistant message whose only content is a
+  tool call doesn't render as a stranded timestamp.
+-->
+<div class="tool-call-collapsed">Tool: {call.name} ...</div>
 <div class="tool-execution {statusClass}" id={resultEntry ? `entry-${resultEntry.id}` : undefined}>
   {#if call.name === 'bash'}
     {@const command = str(args.command)}

--- a/web/src/components/settings/SessionDisplayDefaultsSettings.svelte
+++ b/web/src/components/settings/SessionDisplayDefaultsSettings.svelte
@@ -1,0 +1,81 @@
+<script>
+  import { t } from '../../shared/i18n.js';
+  import { boolFor } from '../../settings/settings-support.js';
+  import {
+    TOGGLE_DEFAULT_SETTING_KEYS,
+    clearPersistedToggleOverride,
+  } from '../../session/ui/toggle-state.js';
+
+  let { settings = {}, onSave = () => {} } = $props();
+
+  const thinkingKey = TOGGLE_DEFAULT_SETTING_KEYS.thinkingExpanded;
+  const toolsKey = TOGGLE_DEFAULT_SETTING_KEYS.toolsVisible;
+  const toolOutputsKey = TOGGLE_DEFAULT_SETTING_KEYS.toolOutputsExpanded;
+
+  let thinkingExpanded = $derived(boolFor(settings, thinkingKey, true));
+  let toolsVisible = $derived(boolFor(settings, toolsKey, true));
+  let toolOutputsExpanded = $derived(boolFor(settings, toolOutputsKey, false));
+
+  function save(settingKey, stateKey, checked) {
+    onSave(settingKey, checked ? 'true' : 'false');
+    // Drop the runtime override so the new default takes effect on the next
+    // session load instead of being shadowed by the user's last in-session
+    // toggle (see loadToggleState in session/ui/toggle-state.js).
+    clearPersistedToggleOverride(stateKey);
+  }
+</script>
+
+<section class="settings-section">
+  <div class="settings-section-title">{t('settings.sessionDisplay')}</div>
+  <div class="settings-row">
+    <div class="settings-row-label">
+      <span class="name">{t('settings.thinkingExpanded')}</span><span class="hint"
+        >{t('settings.thinkingExpandedHint')}</span
+      >
+    </div>
+    <div class="settings-control">
+      <label class="settings-toggle"
+        ><input
+          type="checkbox"
+          data-setting={thinkingKey}
+          checked={thinkingExpanded}
+          onchange={(e) => save(thinkingKey, 'thinkingExpanded', e.currentTarget.checked)}
+        /><span class="slider"></span></label
+      >
+    </div>
+  </div>
+  <div class="settings-row">
+    <div class="settings-row-label">
+      <span class="name">{t('settings.toolsVisible')}</span><span class="hint"
+        >{t('settings.toolsVisibleHint')}</span
+      >
+    </div>
+    <div class="settings-control">
+      <label class="settings-toggle"
+        ><input
+          type="checkbox"
+          data-setting={toolsKey}
+          checked={toolsVisible}
+          onchange={(e) => save(toolsKey, 'toolsVisible', e.currentTarget.checked)}
+        /><span class="slider"></span></label
+      >
+    </div>
+  </div>
+  <div class="settings-row">
+    <div class="settings-row-label">
+      <span class="name">{t('settings.toolOutputsExpanded')}</span><span class="hint"
+        >{t('settings.toolOutputsExpandedHint')}</span
+      >
+    </div>
+    <div class="settings-control">
+      <label class="settings-toggle"
+        ><input
+          type="checkbox"
+          data-setting={toolOutputsKey}
+          checked={toolOutputsExpanded}
+          onchange={(e) => save(toolOutputsKey, 'toolOutputsExpanded', e.currentTarget.checked)}
+        /><span class="slider"></span></label
+      >
+    </div>
+  </div>
+</section>

--- a/web/src/components/settings/SessionDisplayDefaultsSettings.svelte
+++ b/web/src/components/settings/SessionDisplayDefaultsSettings.svelte
@@ -54,7 +54,7 @@
       >
     </div>
   </div>
-  <div class="settings-row">
+  <div class="settings-row" class:settings-row-disabled={!toolsVisible}>
     <div class="settings-row-label">
       <span class="name">{t('settings.toolOutputsExpanded')}</span><span class="hint"
         >{t('settings.toolOutputsExpandedHint')}</span
@@ -66,6 +66,7 @@
           type="checkbox"
           data-setting={toolOutputsKey}
           checked={toolOutputsExpanded}
+          disabled={!toolsVisible}
           onchange={(e) => save(toolOutputsKey, e.currentTarget.checked)}
         /><span class="slider"></span></label
       >

--- a/web/src/components/settings/SessionDisplayDefaultsSettings.svelte
+++ b/web/src/components/settings/SessionDisplayDefaultsSettings.svelte
@@ -1,10 +1,7 @@
 <script>
   import { t } from '../../shared/i18n.js';
   import { boolFor } from '../../settings/settings-support.js';
-  import {
-    TOGGLE_DEFAULT_SETTING_KEYS,
-    clearPersistedToggleOverride,
-  } from '../../session/ui/toggle-state.js';
+  import { TOGGLE_DEFAULT_SETTING_KEYS } from '../../session/ui/toggle-state.js';
 
   let { settings = {}, onSave = () => {} } = $props();
 
@@ -16,12 +13,8 @@
   let toolsVisible = $derived(boolFor(settings, toolsKey, true));
   let toolOutputsExpanded = $derived(boolFor(settings, toolOutputsKey, false));
 
-  function save(settingKey, stateKey, checked) {
+  function save(settingKey, checked) {
     onSave(settingKey, checked ? 'true' : 'false');
-    // Drop the runtime override so the new default takes effect on the next
-    // session load instead of being shadowed by the user's last in-session
-    // toggle (see loadToggleState in session/ui/toggle-state.js).
-    clearPersistedToggleOverride(stateKey);
   }
 </script>
 
@@ -39,7 +32,7 @@
           type="checkbox"
           data-setting={thinkingKey}
           checked={thinkingExpanded}
-          onchange={(e) => save(thinkingKey, 'thinkingExpanded', e.currentTarget.checked)}
+          onchange={(e) => save(thinkingKey, e.currentTarget.checked)}
         /><span class="slider"></span></label
       >
     </div>
@@ -56,7 +49,7 @@
           type="checkbox"
           data-setting={toolsKey}
           checked={toolsVisible}
-          onchange={(e) => save(toolsKey, 'toolsVisible', e.currentTarget.checked)}
+          onchange={(e) => save(toolsKey, e.currentTarget.checked)}
         /><span class="slider"></span></label
       >
     </div>
@@ -73,7 +66,7 @@
           type="checkbox"
           data-setting={toolOutputsKey}
           checked={toolOutputsExpanded}
-          onchange={(e) => save(toolOutputsKey, 'toolOutputsExpanded', e.currentTarget.checked)}
+          onchange={(e) => save(toolOutputsKey, e.currentTarget.checked)}
         /><span class="slider"></span></label
       >
     </div>

--- a/web/src/routes/SettingsPage.svelte
+++ b/web/src/routes/SettingsPage.svelte
@@ -6,6 +6,7 @@
   import CatGatekeeperSettings from '../components/settings/CatGatekeeperSettings.svelte';
   import LanguageSettings from '../components/settings/LanguageSettings.svelte';
   import NotificationSettings from '../components/settings/NotificationSettings.svelte';
+  import SessionDisplayDefaultsSettings from '../components/settings/SessionDisplayDefaultsSettings.svelte';
   import SessionsListSettings from '../components/settings/SessionsListSettings.svelte';
   import SessionTitleSettings from '../components/settings/SessionTitleSettings.svelte';
   import { t } from '../shared/i18n.js';
@@ -21,6 +22,7 @@
     { id: 'language', labelKey: 'settings.language' },
     { id: 'sessionsList', labelKey: 'settings.sessionsList' },
     { id: 'sessionTitles', labelKey: 'settings.sessionTitles' },
+    { id: 'sessionDisplay', labelKey: 'settings.sessionDisplay' },
     { id: 'artifacts', labelKey: 'settings.artifacts' },
     { id: 'notifications', labelKey: 'settings.notifications' },
     { id: 'catGatekeeper', labelKey: 'settings.catGatekeeper' },
@@ -155,6 +157,8 @@
       <SessionsListSettings {settings} onSave={saveSetting} />
     {:else if activeSection === 'sessionTitles'}
       <SessionTitleSettings {settings} onSave={saveSetting} />
+    {:else if activeSection === 'sessionDisplay'}
+      <SessionDisplayDefaultsSettings {settings} onSave={saveSetting} />
     {:else if activeSection === 'artifacts'}
       <ArtifactSettings {settings} onSave={saveSetting} />
     {:else if activeSection === 'notifications'}

--- a/web/src/session/page/session-page-runtime.js
+++ b/web/src/session/page/session-page-runtime.js
@@ -23,7 +23,12 @@ export function startSessionPageRuntime({
   configureSettingsSync({
     fetchImpl: windowImpl.fetch ? windowImpl.fetch.bind(windowImpl) : undefined,
   });
-  hydrateSettings({ storage: windowImpl.localStorage });
+  // Kick off settings hydration in the background. The toggle controller and
+  // SessionContent render before this resolves on a cold cache (no localStorage
+  // yet), so they'd otherwise be stuck on toggleStateDefaults; once hydration
+  // lands we call toggleController.reload() to pick up the user's configured
+  // defaults and re-apply them to the already-rendered DOM.
+  const hydrated = hydrateSettings({ storage: windowImpl.localStorage });
   windowImpl.marked = windowImpl.marked || marked;
 
   const contentWiring = wireSessionContentRuntime({
@@ -61,6 +66,11 @@ export function startSessionPageRuntime({
 
   sessionRuntime.layout = { isMobileLayout: ui.isMobileLayout, closeSidebar: ui.closeSidebar };
   ui.attachHeaderHandlers();
+  // Catch up the toggle state to whatever the server returned, once it lands.
+  // hydrated may be null when fetch isn't configured (export bundle / tests).
+  hydrated?.then?.((settings) => {
+    if (settings) ui.toggleController.reload();
+  });
   navigateTo(
     model.currentLeafId,
     model.urlTargetId ? 'target' : 'bottom',

--- a/web/src/session/page/session-page-runtime.js
+++ b/web/src/session/page/session-page-runtime.js
@@ -40,6 +40,7 @@ export function startSessionPageRuntime({
     documentImpl,
     windowImpl,
     storage: windowImpl.localStorage,
+    sessionId,
     marked,
     hljs: null,
     escapeHtml: sessionFormat.escapeHtml,

--- a/web/src/session/ui/session-ui-runner.js
+++ b/web/src/session/ui/session-ui-runner.js
@@ -4,6 +4,7 @@ export function setupSessionUi({
   documentImpl = document,
   windowImpl = window,
   storage = localStorage,
+  sessionId = '',
   marked,
   hljs,
   escapeHtml,
@@ -46,7 +47,11 @@ export function setupSessionUi({
     );
   }
 
-  const toggleController = toggleStateApi.createToggleController({ documentImpl, storage });
+  const toggleController = toggleStateApi.createToggleController({
+    documentImpl,
+    storage,
+    sessionId,
+  });
   // Registered so the message-pane afterRender hook (live content-runtime +
   // export-entry) can re-apply persisted collapse/toggle state to new nodes.
   sessionRuntime.toggleState = toggleController;

--- a/web/src/session/ui/toggle-state.js
+++ b/web/src/session/ui/toggle-state.js
@@ -120,6 +120,15 @@ export function syncToggleButtons(documentImpl, state) {
     btn.classList.toggle('active', isActive);
     btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
   });
+  // The tool-output toggle has no visible effect while tool calls are hidden,
+  // since the output blocks live inside the .tool-execution wrapper that's
+  // already display:none. Disable it (and its keyboard shortcut, see
+  // createToggleController.toggleToolOutputs) so the control doesn't claim to
+  // do something it can't until tools are turned back on.
+  const toolOutputBtn = documentImpl.querySelector('[data-action="toggle-tool-output"]');
+  if (toolOutputBtn) {
+    toolOutputBtn.disabled = !state.toolsVisible;
+  }
 }
 
 export function createToggleController({
@@ -154,7 +163,12 @@ export function createToggleController({
     syncButtons,
     toggleThinking: () => toggle('thinkingExpanded'),
     toggleToolsVisibility: () => toggle('toolsVisible'),
-    toggleToolOutputs: () => toggle('toolOutputsExpanded'),
+    toggleToolOutputs: () => {
+      // Hidden tool calls have no visible output to expand or collapse — no-op
+      // so the P shortcut and a disabled button click both stay quiet.
+      if (!state.toolsVisible) return;
+      toggle('toolOutputsExpanded');
+    },
     attachHeaderHandlers() {
       documentImpl
         .querySelector('[data-action="toggle-thinking"]')

--- a/web/src/session/ui/toggle-state.js
+++ b/web/src/session/ui/toggle-state.js
@@ -93,6 +93,14 @@ export function applyToggleStateToNode(node, state) {
   node.querySelectorAll('.tool-execution, .compaction').forEach((el) => {
     el.style.display = state.toolsVisible ? '' : 'none';
   });
+  // Mirrors the .thinking-text / .thinking-collapsed pair: show a "Tool: <name>
+  // ..." placeholder so a hidden tool call still has a visible marker (and an
+  // assistant message whose only content is a tool call isn't a stranded
+  // timestamp). The placeholder lives next to each .tool-execution in
+  // ToolCall.svelte.
+  node.querySelectorAll('.tool-call-collapsed').forEach((el) => {
+    el.style.display = state.toolsVisible ? 'none' : 'block';
+  });
   node.querySelectorAll('.tool-output.expandable').forEach((el) => {
     el.classList.toggle('expanded', state.toolOutputsExpanded);
   });

--- a/web/src/session/ui/toggle-state.js
+++ b/web/src/session/ui/toggle-state.js
@@ -19,50 +19,66 @@ function readBoolSetting(storage, key, fallback) {
   return fallback;
 }
 
+// Read the persisted per-session map. Older builds stored a single flat state
+// object at this key (one shared override for every session); that shape is
+// discarded here so the configured Session Display defaults apply going
+// forward instead of being shadowed by a stale global toggle.
+function readSessionMap(storage) {
+  try {
+    const raw = storage?.getItem(TOGGLE_STATE_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    if (
+      'thinkingExpanded' in parsed ||
+      'toolsVisible' in parsed ||
+      'toolOutputsExpanded' in parsed
+    ) {
+      // Old flat-state shape — treat as no overrides.
+      return {};
+    }
+    return parsed;
+  } catch (_) {
+    return {};
+  }
+}
+
 // loadToggleState builds the initial header-toggle state in three layers:
 // 1. Hardcoded defaults (toggleStateDefaults).
 // 2. Server-backed per-user defaults (TOGGLE_DEFAULT_SETTING_KEYS), already
 //    mirrored into localStorage by the settings hydration on page load.
-// 3. The per-session JSON blob (TOGGLE_STATE_STORAGE_KEY), which remembers the
-//    user's most recent in-session toggle and wins over the configured default.
-//    The settings UI clears the relevant blob entry on save (see
-//    clearPersistedToggleOverride) so changing a default takes effect on next
-//    session load instead of being shadowed by a stale runtime override.
-export function loadToggleState({ storage = globalThis.localStorage } = {}) {
+// 3. The per-session override for `sessionId`, if any — set when the user
+//    toggled a header button in that specific session, so the next time they
+//    open the SAME session it remembers their last choice. Other sessions are
+//    not affected, so changing a default in /settings takes effect everywhere
+//    the user hasn't explicitly overridden it.
+export function loadToggleState({ sessionId = '', storage = globalThis.localStorage } = {}) {
   const state = { ...toggleStateDefaults };
   for (const [stateKey, settingKey] of Object.entries(TOGGLE_DEFAULT_SETTING_KEYS)) {
     state[stateKey] = readBoolSetting(storage, settingKey, state[stateKey]);
   }
-  try {
-    const saved = JSON.parse(storage?.getItem(TOGGLE_STATE_STORAGE_KEY) || '{}');
+  if (!sessionId) return state;
+  const saved = readSessionMap(storage)[sessionId];
+  if (saved && typeof saved === 'object') {
     if (typeof saved.thinkingExpanded === 'boolean')
       state.thinkingExpanded = saved.thinkingExpanded;
     if (typeof saved.toolsVisible === 'boolean') state.toolsVisible = saved.toolsVisible;
     if (typeof saved.toolOutputsExpanded === 'boolean')
       state.toolOutputsExpanded = saved.toolOutputsExpanded;
-  } catch (_) {}
+  }
   return state;
 }
 
-// Drop one key from the persisted per-session blob so the next loadToggleState
-// falls back to the (just-changed) configured default. Other keys in the blob
-// are preserved.
-export function clearPersistedToggleOverride(stateKey, { storage = globalThis.localStorage } = {}) {
+export function saveToggleState(state, { sessionId = '', storage = globalThis.localStorage } = {}) {
+  if (!sessionId) return;
   try {
-    const saved = JSON.parse(storage?.getItem(TOGGLE_STATE_STORAGE_KEY) || '{}');
-    if (!(stateKey in saved)) return;
-    delete saved[stateKey];
-    if (Object.keys(saved).length === 0) {
-      storage?.removeItem(TOGGLE_STATE_STORAGE_KEY);
-    } else {
-      storage?.setItem(TOGGLE_STATE_STORAGE_KEY, JSON.stringify(saved));
-    }
-  } catch (_) {}
-}
-
-export function saveToggleState(state, { storage = globalThis.localStorage } = {}) {
-  try {
-    storage?.setItem(TOGGLE_STATE_STORAGE_KEY, JSON.stringify(state));
+    const map = readSessionMap(storage);
+    map[sessionId] = {
+      thinkingExpanded: state.thinkingExpanded,
+      toolsVisible: state.toolsVisible,
+      toolOutputsExpanded: state.toolOutputsExpanded,
+    };
+    storage?.setItem(TOGGLE_STATE_STORAGE_KEY, JSON.stringify(map));
   } catch (_) {}
 }
 
@@ -101,12 +117,13 @@ export function syncToggleButtons(documentImpl, state) {
 export function createToggleController({
   documentImpl = document,
   storage = globalThis.localStorage,
-  initialState = loadToggleState({ storage }),
+  sessionId = '',
+  initialState = loadToggleState({ sessionId, storage }),
 } = {}) {
   const state = initialState;
   const applyToNode = (node) => applyToggleStateToNode(node, state);
   const syncButtons = () => syncToggleButtons(documentImpl, state);
-  const save = () => saveToggleState(state, { storage });
+  const save = () => saveToggleState(state, { sessionId, storage });
   const toggle = (key) => {
     state[key] = !state[key];
     save();

--- a/web/src/session/ui/toggle-state.js
+++ b/web/src/session/ui/toggle-state.js
@@ -1,12 +1,38 @@
 export const TOGGLE_STATE_STORAGE_KEY = 'pi.sessionDetail.toggleState';
+export const TOGGLE_DEFAULT_SETTING_KEYS = {
+  thinkingExpanded: 'pi-web:v1:toggle:thinking',
+  toolsVisible: 'pi-web:v1:toggle:tools',
+  toolOutputsExpanded: 'pi-web:v1:toggle:tool-outputs',
+};
 export const toggleStateDefaults = {
   thinkingExpanded: true,
   toolsVisible: true,
   toolOutputsExpanded: false,
 };
 
+function readBoolSetting(storage, key, fallback) {
+  try {
+    const raw = storage?.getItem(key);
+    if (raw === 'true') return true;
+    if (raw === 'false') return false;
+  } catch (_) {}
+  return fallback;
+}
+
+// loadToggleState builds the initial header-toggle state in three layers:
+// 1. Hardcoded defaults (toggleStateDefaults).
+// 2. Server-backed per-user defaults (TOGGLE_DEFAULT_SETTING_KEYS), already
+//    mirrored into localStorage by the settings hydration on page load.
+// 3. The per-session JSON blob (TOGGLE_STATE_STORAGE_KEY), which remembers the
+//    user's most recent in-session toggle and wins over the configured default.
+//    The settings UI clears the relevant blob entry on save (see
+//    clearPersistedToggleOverride) so changing a default takes effect on next
+//    session load instead of being shadowed by a stale runtime override.
 export function loadToggleState({ storage = globalThis.localStorage } = {}) {
   const state = { ...toggleStateDefaults };
+  for (const [stateKey, settingKey] of Object.entries(TOGGLE_DEFAULT_SETTING_KEYS)) {
+    state[stateKey] = readBoolSetting(storage, settingKey, state[stateKey]);
+  }
   try {
     const saved = JSON.parse(storage?.getItem(TOGGLE_STATE_STORAGE_KEY) || '{}');
     if (typeof saved.thinkingExpanded === 'boolean')
@@ -16,6 +42,22 @@ export function loadToggleState({ storage = globalThis.localStorage } = {}) {
       state.toolOutputsExpanded = saved.toolOutputsExpanded;
   } catch (_) {}
   return state;
+}
+
+// Drop one key from the persisted per-session blob so the next loadToggleState
+// falls back to the (just-changed) configured default. Other keys in the blob
+// are preserved.
+export function clearPersistedToggleOverride(stateKey, { storage = globalThis.localStorage } = {}) {
+  try {
+    const saved = JSON.parse(storage?.getItem(TOGGLE_STATE_STORAGE_KEY) || '{}');
+    if (!(stateKey in saved)) return;
+    delete saved[stateKey];
+    if (Object.keys(saved).length === 0) {
+      storage?.removeItem(TOGGLE_STATE_STORAGE_KEY);
+    } else {
+      storage?.setItem(TOGGLE_STATE_STORAGE_KEY, JSON.stringify(saved));
+    }
+  } catch (_) {}
 }
 
 export function saveToggleState(state, { storage = globalThis.localStorage } = {}) {

--- a/web/src/session/ui/toggle-state.js
+++ b/web/src/session/ui/toggle-state.js
@@ -169,6 +169,18 @@ export function createToggleController({
       if (!state.toolsVisible) return;
       toggle('toolOutputsExpanded');
     },
+    // Re-read storage and re-apply. Used by the session runtime once
+    // hydrateSettings() resolves so a cold-cache first paint (no server-backed
+    // toggle keys in localStorage yet) catches up to the user's configured
+    // defaults instead of being stuck on toggleStateDefaults.
+    reload() {
+      const next = loadToggleState({ sessionId, storage });
+      state.thinkingExpanded = next.thinkingExpanded;
+      state.toolsVisible = next.toolsVisible;
+      state.toolOutputsExpanded = next.toolOutputsExpanded;
+      applyToNode(documentImpl);
+      syncButtons();
+    },
     attachHeaderHandlers() {
       documentImpl
         .querySelector('[data-action="toggle-thinking"]')

--- a/web/src/session/ui/toggle-state.test.js
+++ b/web/src/session/ui/toggle-state.test.js
@@ -216,6 +216,51 @@ describe('toggle state helpers', () => {
     expect(dom.window.document.querySelector('.tool-execution').style.display).toBe('');
   });
 
+  it('controller reload picks up settings written after creation (cold-cache first paint)', () => {
+    // Simulate the cold-cache case: the controller is created before
+    // hydrateSettings() has populated localStorage with the server-backed
+    // defaults, so loadToggleState falls back to the hardcoded defaults. Once
+    // hydration completes and the keys appear, reload() must re-read storage
+    // and re-apply to the rendered DOM + buttons.
+    const dom = new JSDOM(
+      `<div class="thinking-text"></div><div class="thinking-collapsed"></div>` +
+        `<button data-action="toggle-thinking"></button>` +
+        `<button data-action="toggle-tools"></button>` +
+        `<button data-action="toggle-tool-output"></button>`,
+    );
+    const storage = makeStorage();
+    const controller = createToggleController({
+      documentImpl: dom.window.document,
+      storage,
+      sessionId: 'sess-a',
+    });
+    controller.attachHeaderHandlers();
+    // Initial state matches hardcoded defaults (true/true/false).
+    expect(controller.thinkingExpanded).toBe(true);
+    expect(
+      dom.window.document
+        .querySelector('[data-action="toggle-thinking"]')
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+
+    // Hydration writes the server defaults under the user-setting keys.
+    storage.setItem(TOGGLE_DEFAULT_SETTING_KEYS.thinkingExpanded, 'false');
+    storage.setItem(TOGGLE_DEFAULT_SETTING_KEYS.toolsVisible, 'false');
+
+    controller.reload();
+    expect(controller.thinkingExpanded).toBe(false);
+    expect(controller.toolsVisible).toBe(false);
+    // Re-applied to the DOM: thinking text hidden, collapsed placeholder shown.
+    expect(dom.window.document.querySelector('.thinking-text').style.display).toBe('none');
+    expect(dom.window.document.querySelector('.thinking-collapsed').style.display).toBe('block');
+    // Header button reflects the new state.
+    expect(
+      dom.window.document
+        .querySelector('[data-action="toggle-thinking"]')
+        .getAttribute('aria-pressed'),
+    ).toBe('false');
+  });
+
   it('controller persists toggles under its session id and other sessions are unaffected', () => {
     const dom = new JSDOM(
       `<button data-action="toggle-thinking"></button><div class="thinking-text"></div><div class="thinking-collapsed"></div>`,

--- a/web/src/session/ui/toggle-state.test.js
+++ b/web/src/session/ui/toggle-state.test.js
@@ -2,12 +2,28 @@ import { describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import {
   applyToggleStateToNode,
+  clearPersistedToggleOverride,
   createToggleController,
   loadToggleState,
   saveToggleState,
   syncToggleButtons,
+  TOGGLE_DEFAULT_SETTING_KEYS,
   TOGGLE_STATE_STORAGE_KEY,
 } from './toggle-state.js';
+
+function makeStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    getItem: (k) => (k in data ? data[k] : null),
+    setItem: (k, v) => {
+      data[k] = String(v);
+    },
+    removeItem: (k) => {
+      delete data[k];
+    },
+    _data: data,
+  };
+}
 
 describe('toggle state helpers', () => {
   it('loads defaults and saved booleans defensively', () => {
@@ -61,6 +77,49 @@ describe('toggle state helpers', () => {
         .querySelector('[data-action="toggle-tool-output"]')
         .getAttribute('aria-pressed'),
     ).toBe('true');
+  });
+
+  it('reads configured defaults from settings storage before falling back to hardcoded defaults', () => {
+    const storage = makeStorage({
+      [TOGGLE_DEFAULT_SETTING_KEYS.thinkingExpanded]: 'false',
+      [TOGGLE_DEFAULT_SETTING_KEYS.toolOutputsExpanded]: 'true',
+      // toolsVisible left unset → falls back to hardcoded default (true).
+    });
+    expect(loadToggleState({ storage })).toEqual({
+      thinkingExpanded: false,
+      toolsVisible: true,
+      toolOutputsExpanded: true,
+    });
+  });
+
+  it('per-session blob wins over configured setting defaults', () => {
+    const storage = makeStorage({
+      [TOGGLE_DEFAULT_SETTING_KEYS.thinkingExpanded]: 'false',
+      [TOGGLE_STATE_STORAGE_KEY]: JSON.stringify({ thinkingExpanded: true }),
+    });
+    expect(loadToggleState({ storage })).toEqual({
+      thinkingExpanded: true,
+      toolsVisible: true,
+      toolOutputsExpanded: false,
+    });
+  });
+
+  it('clearPersistedToggleOverride drops a single key, keeps others, removes the blob when empty', () => {
+    const storage = makeStorage({
+      [TOGGLE_STATE_STORAGE_KEY]: JSON.stringify({
+        thinkingExpanded: false,
+        toolsVisible: false,
+      }),
+    });
+    clearPersistedToggleOverride('thinkingExpanded', { storage });
+    expect(JSON.parse(storage.getItem(TOGGLE_STATE_STORAGE_KEY))).toEqual({
+      toolsVisible: false,
+    });
+    clearPersistedToggleOverride('toolsVisible', { storage });
+    expect(storage.getItem(TOGGLE_STATE_STORAGE_KEY)).toBeNull();
+    // No-op when the key isn't present — must not throw or write garbage.
+    clearPersistedToggleOverride('toolOutputsExpanded', { storage });
+    expect(storage.getItem(TOGGLE_STATE_STORAGE_KEY)).toBeNull();
   });
 
   it('creates a controller for header toggles', () => {

--- a/web/src/session/ui/toggle-state.test.js
+++ b/web/src/session/ui/toggle-state.test.js
@@ -128,7 +128,7 @@ describe('toggle state helpers', () => {
   it('applies state to rendered nodes and buttons', () => {
     const dom = new JSDOM(`<div>
       <div class="thinking-text"></div><div class="thinking-collapsed"></div>
-      <div class="tool-execution"></div><div class="tool-output expandable"></div><div class="compaction"></div>
+      <div class="tool-call-collapsed"></div><div class="tool-execution"></div><div class="tool-output expandable"></div><div class="compaction"></div>
       <button data-action="toggle-thinking"></button><button data-action="toggle-tools"></button><button data-action="toggle-tool-output"></button>
     </div>`);
     const state = { thinkingExpanded: false, toolsVisible: false, toolOutputsExpanded: true };
@@ -138,6 +138,9 @@ describe('toggle state helpers', () => {
     expect(dom.window.document.querySelector('.thinking-text').style.display).toBe('none');
     expect(dom.window.document.querySelector('.thinking-collapsed').style.display).toBe('block');
     expect(dom.window.document.querySelector('.tool-execution').style.display).toBe('none');
+    // Mirror placeholder appears when tools are hidden so a tool-only assistant
+    // message keeps a visible marker instead of just a stranded timestamp.
+    expect(dom.window.document.querySelector('.tool-call-collapsed').style.display).toBe('block');
     expect(dom.window.document.querySelector('.tool-output').classList.contains('expanded')).toBe(
       true,
     );
@@ -151,6 +154,19 @@ describe('toggle state helpers', () => {
         .querySelector('[data-action="toggle-tool-output"]')
         .getAttribute('aria-pressed'),
     ).toBe('true');
+  });
+
+  it('hides the tool-call placeholder when tools are visible', () => {
+    const dom = new JSDOM(
+      `<div><div class="tool-call-collapsed"></div><div class="tool-execution"></div></div>`,
+    );
+    applyToggleStateToNode(dom.window.document, {
+      thinkingExpanded: true,
+      toolsVisible: true,
+      toolOutputsExpanded: false,
+    });
+    expect(dom.window.document.querySelector('.tool-call-collapsed').style.display).toBe('none');
+    expect(dom.window.document.querySelector('.tool-execution').style.display).toBe('');
   });
 
   it('controller persists toggles under its session id and other sessions are unaffected', () => {

--- a/web/src/session/ui/toggle-state.test.js
+++ b/web/src/session/ui/toggle-state.test.js
@@ -1,8 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { JSDOM } from 'jsdom';
 import {
   applyToggleStateToNode,
-  clearPersistedToggleOverride,
   createToggleController,
   loadToggleState,
   saveToggleState,
@@ -26,29 +25,104 @@ function makeStorage(initial = {}) {
 }
 
 describe('toggle state helpers', () => {
-  it('loads defaults and saved booleans defensively', () => {
-    expect(loadToggleState({ storage: { getItem: () => null } })).toEqual({
+  it('returns the hardcoded defaults when nothing is stored', () => {
+    expect(loadToggleState({ storage: makeStorage() })).toEqual({
       thinkingExpanded: true,
       toolsVisible: true,
       toolOutputsExpanded: false,
     });
-    expect(
-      loadToggleState({
-        storage: {
-          getItem: () =>
-            '{"thinkingExpanded":false,"toolsVisible":false,"toolOutputsExpanded":true}',
-        },
-      }),
-    ).toEqual({ thinkingExpanded: false, toolsVisible: false, toolOutputsExpanded: true });
   });
 
-  it('saves state', () => {
-    const storage = { setItem: vi.fn() };
-    saveToggleState({ thinkingExpanded: false }, { storage });
-    expect(storage.setItem).toHaveBeenCalledWith(
-      TOGGLE_STATE_STORAGE_KEY,
-      JSON.stringify({ thinkingExpanded: false }),
+  it('reads configured defaults from settings storage before falling back to hardcoded defaults', () => {
+    const storage = makeStorage({
+      [TOGGLE_DEFAULT_SETTING_KEYS.thinkingExpanded]: 'false',
+      [TOGGLE_DEFAULT_SETTING_KEYS.toolOutputsExpanded]: 'true',
+      // toolsVisible left unset → falls back to hardcoded default (true).
+    });
+    expect(loadToggleState({ storage })).toEqual({
+      thinkingExpanded: false,
+      toolsVisible: true,
+      toolOutputsExpanded: true,
+    });
+  });
+
+  it('per-session override wins over configured setting defaults, scoped to that session id', () => {
+    const storage = makeStorage({
+      [TOGGLE_DEFAULT_SETTING_KEYS.thinkingExpanded]: 'false',
+      [TOGGLE_STATE_STORAGE_KEY]: JSON.stringify({
+        'sess-a': { thinkingExpanded: true },
+      }),
+    });
+    expect(loadToggleState({ sessionId: 'sess-a', storage })).toEqual({
+      thinkingExpanded: true,
+      toolsVisible: true,
+      toolOutputsExpanded: false,
+    });
+    // Another session has no override, so the configured default applies.
+    expect(loadToggleState({ sessionId: 'sess-b', storage })).toEqual({
+      thinkingExpanded: false,
+      toolsVisible: true,
+      toolOutputsExpanded: false,
+    });
+  });
+
+  it('discards the old global flat-state blob so the configured default applies', () => {
+    // Simulate the pre-migration shape: a single flat state object at the key.
+    // Without the migration, this would have shadowed every session.
+    const storage = makeStorage({
+      [TOGGLE_DEFAULT_SETTING_KEYS.toolOutputsExpanded]: 'false',
+      [TOGGLE_STATE_STORAGE_KEY]: JSON.stringify({
+        thinkingExpanded: true,
+        toolsVisible: true,
+        toolOutputsExpanded: true,
+      }),
+    });
+    expect(loadToggleState({ sessionId: 'sess-a', storage })).toEqual({
+      thinkingExpanded: true,
+      toolsVisible: true,
+      toolOutputsExpanded: false,
+    });
+  });
+
+  it('saves state under the session id; no-ops without one', () => {
+    const storage = makeStorage();
+    saveToggleState(
+      { thinkingExpanded: false, toolsVisible: true, toolOutputsExpanded: true },
+      { sessionId: 'sess-a', storage },
     );
+    expect(JSON.parse(storage.getItem(TOGGLE_STATE_STORAGE_KEY))).toEqual({
+      'sess-a': {
+        thinkingExpanded: false,
+        toolsVisible: true,
+        toolOutputsExpanded: true,
+      },
+    });
+
+    // Saving for a different session preserves the first one's entry.
+    saveToggleState(
+      { thinkingExpanded: true, toolsVisible: false, toolOutputsExpanded: false },
+      { sessionId: 'sess-b', storage },
+    );
+    expect(JSON.parse(storage.getItem(TOGGLE_STATE_STORAGE_KEY))).toEqual({
+      'sess-a': {
+        thinkingExpanded: false,
+        toolsVisible: true,
+        toolOutputsExpanded: true,
+      },
+      'sess-b': {
+        thinkingExpanded: true,
+        toolsVisible: false,
+        toolOutputsExpanded: false,
+      },
+    });
+
+    // Missing sessionId → no write (export view has no useful id).
+    const empty = makeStorage();
+    saveToggleState(
+      { thinkingExpanded: false, toolsVisible: false, toolOutputsExpanded: true },
+      { storage: empty },
+    );
+    expect(empty.getItem(TOGGLE_STATE_STORAGE_KEY)).toBeNull();
   });
 
   it('applies state to rendered nodes and buttons', () => {
@@ -79,61 +153,34 @@ describe('toggle state helpers', () => {
     ).toBe('true');
   });
 
-  it('reads configured defaults from settings storage before falling back to hardcoded defaults', () => {
-    const storage = makeStorage({
-      [TOGGLE_DEFAULT_SETTING_KEYS.thinkingExpanded]: 'false',
-      [TOGGLE_DEFAULT_SETTING_KEYS.toolOutputsExpanded]: 'true',
-      // toolsVisible left unset → falls back to hardcoded default (true).
-    });
-    expect(loadToggleState({ storage })).toEqual({
-      thinkingExpanded: false,
-      toolsVisible: true,
-      toolOutputsExpanded: true,
-    });
-  });
-
-  it('per-session blob wins over configured setting defaults', () => {
-    const storage = makeStorage({
-      [TOGGLE_DEFAULT_SETTING_KEYS.thinkingExpanded]: 'false',
-      [TOGGLE_STATE_STORAGE_KEY]: JSON.stringify({ thinkingExpanded: true }),
-    });
-    expect(loadToggleState({ storage })).toEqual({
-      thinkingExpanded: true,
-      toolsVisible: true,
-      toolOutputsExpanded: false,
-    });
-  });
-
-  it('clearPersistedToggleOverride drops a single key, keeps others, removes the blob when empty', () => {
-    const storage = makeStorage({
-      [TOGGLE_STATE_STORAGE_KEY]: JSON.stringify({
-        thinkingExpanded: false,
-        toolsVisible: false,
-      }),
-    });
-    clearPersistedToggleOverride('thinkingExpanded', { storage });
-    expect(JSON.parse(storage.getItem(TOGGLE_STATE_STORAGE_KEY))).toEqual({
-      toolsVisible: false,
-    });
-    clearPersistedToggleOverride('toolsVisible', { storage });
-    expect(storage.getItem(TOGGLE_STATE_STORAGE_KEY)).toBeNull();
-    // No-op when the key isn't present — must not throw or write garbage.
-    clearPersistedToggleOverride('toolOutputsExpanded', { storage });
-    expect(storage.getItem(TOGGLE_STATE_STORAGE_KEY)).toBeNull();
-  });
-
-  it('creates a controller for header toggles', () => {
+  it('controller persists toggles under its session id and other sessions are unaffected', () => {
     const dom = new JSDOM(
       `<button data-action="toggle-thinking"></button><div class="thinking-text"></div><div class="thinking-collapsed"></div>`,
     );
-    const storage = { setItem: vi.fn(), getItem: () => null };
-    const controller = createToggleController({ documentImpl: dom.window.document, storage });
+    const storage = makeStorage();
+    const controller = createToggleController({
+      documentImpl: dom.window.document,
+      storage,
+      sessionId: 'sess-a',
+    });
     controller.attachHeaderHandlers();
 
     dom.window.document.querySelector('[data-action="toggle-thinking"]').click();
 
     expect(controller.thinkingExpanded).toBe(false);
-    expect(dom.window.document.querySelector('.thinking-text').style.display).toBe('none');
-    expect(storage.setItem).toHaveBeenCalled();
+    expect(JSON.parse(storage.getItem(TOGGLE_STATE_STORAGE_KEY))).toEqual({
+      'sess-a': {
+        thinkingExpanded: false,
+        toolsVisible: true,
+        toolOutputsExpanded: false,
+      },
+    });
+
+    // A fresh load for a different session ignores sess-a's override.
+    expect(loadToggleState({ sessionId: 'sess-b', storage })).toEqual({
+      thinkingExpanded: true,
+      toolsVisible: true,
+      toolOutputsExpanded: false,
+    });
   });
 });

--- a/web/src/session/ui/toggle-state.test.js
+++ b/web/src/session/ui/toggle-state.test.js
@@ -156,6 +156,53 @@ describe('toggle state helpers', () => {
     ).toBe('true');
   });
 
+  it('disables the tool-output button when tools are hidden, re-enables when they reappear', () => {
+    const dom = new JSDOM(
+      `<button data-action="toggle-thinking"></button><button data-action="toggle-tools"></button><button data-action="toggle-tool-output"></button>`,
+    );
+    const toolOutputBtn = dom.window.document.querySelector('[data-action="toggle-tool-output"]');
+
+    syncToggleButtons(dom.window.document, {
+      thinkingExpanded: true,
+      toolsVisible: false,
+      toolOutputsExpanded: false,
+    });
+    expect(toolOutputBtn.disabled).toBe(true);
+
+    syncToggleButtons(dom.window.document, {
+      thinkingExpanded: true,
+      toolsVisible: true,
+      toolOutputsExpanded: false,
+    });
+    expect(toolOutputBtn.disabled).toBe(false);
+  });
+
+  it('toggleToolOutputs is a no-op while tools are hidden so the P shortcut stays quiet', () => {
+    const dom = new JSDOM(
+      `<button data-action="toggle-thinking"></button><button data-action="toggle-tools"></button><button data-action="toggle-tool-output"></button>`,
+    );
+    const storage = makeStorage();
+    const controller = createToggleController({
+      documentImpl: dom.window.document,
+      storage,
+      sessionId: 'sess-a',
+      initialState: {
+        thinkingExpanded: true,
+        toolsVisible: false,
+        toolOutputsExpanded: false,
+      },
+    });
+    controller.toggleToolOutputs();
+    expect(controller.toolOutputsExpanded).toBe(false);
+    // Nothing was persisted, since no state change happened.
+    expect(storage.getItem(TOGGLE_STATE_STORAGE_KEY)).toBeNull();
+
+    // Re-enable tools, then the toggle works normally.
+    controller.toggleToolsVisibility();
+    controller.toggleToolOutputs();
+    expect(controller.toolOutputsExpanded).toBe(true);
+  });
+
   it('hides the tool-call placeholder when tools are visible', () => {
     const dom = new JSDOM(
       `<div><div class="tool-call-collapsed"></div><div class="tool-execution"></div></div>`,

--- a/web/src/shared/locales/de.js
+++ b/web/src/shared/locales/de.js
@@ -235,6 +235,17 @@ export default {
     'Integriert ist eine kostenlose, sofortige Wort-Heuristik (keine KI). Wähle ein Modell für bessere Titel — ein kleines, schnelles ist ideal.',
   'settings.titleBuiltin': 'Integrierte Heuristik (keine KI)',
 
+  'settings.sessionDisplay': 'Sitzungsanzeige',
+  'settings.thinkingExpanded': 'Denken standardmäßig anzeigen',
+  'settings.thinkingExpandedHint':
+    'Wenn aktiv, ist das Modell-Denken beim Laden ausgeklappt. Du kannst es weiterhin pro Sitzung in der Kopfzeile umschalten.',
+  'settings.toolsVisible': 'Tool-Aufrufe standardmäßig zeigen',
+  'settings.toolsVisibleHint':
+    'Wenn aus, werden Tool-Aufrufe und Komprimierungen beim Laden ausgeblendet — praktisch auf kleinen Bildschirmen.',
+  'settings.toolOutputsExpanded': 'Tool-Ausgaben standardmäßig ausklappen',
+  'settings.toolOutputsExpandedHint':
+    'Wenn aktiv, werden Tool-Ausgabeblöcke ausgeklappt statt eingeklappt geladen.',
+
   'settings.artifacts': 'Artefakte',
   'settings.showArtifacts': 'Artefakte-Panel anzeigen',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/en.js
+++ b/web/src/shared/locales/en.js
@@ -332,6 +332,17 @@ export default {
     'Built-in is a free, instant word heuristic (no AI). Pick a model for smarter titles — a small, fast one is ideal.',
   'settings.titleBuiltin': 'Built-in heuristic (no AI)',
 
+  'settings.sessionDisplay': 'Session Display',
+  'settings.thinkingExpanded': 'Show thinking by default',
+  'settings.thinkingExpandedHint':
+    'When on, model reasoning is expanded as sessions load. You can still toggle it per session from the header.',
+  'settings.toolsVisible': 'Show tool calls by default',
+  'settings.toolsVisibleHint':
+    'When off, tool invocations and compactions are hidden as sessions load — handy on small screens.',
+  'settings.toolOutputsExpanded': 'Expand tool outputs by default',
+  'settings.toolOutputsExpandedHint':
+    'When on, tool output blocks load expanded instead of collapsed.',
+
   'settings.artifacts': 'Artifacts',
   'settings.showArtifacts': 'Show Artifacts panel',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/es.js
+++ b/web/src/shared/locales/es.js
@@ -237,6 +237,17 @@ export default {
     'El integrado es una heurística de palabras gratuita e instantánea (sin IA). Elige un modelo para títulos más inteligentes: uno pequeño y rápido es lo ideal.',
   'settings.titleBuiltin': 'Heurística integrada (sin IA)',
 
+  'settings.sessionDisplay': 'Vista de sesión',
+  'settings.thinkingExpanded': 'Mostrar pensamiento por defecto',
+  'settings.thinkingExpandedHint':
+    'Cuando está activo, el razonamiento del modelo aparece expandido al cargar las sesiones. Aún puedes alternarlo por sesión desde el encabezado.',
+  'settings.toolsVisible': 'Mostrar llamadas a herramientas por defecto',
+  'settings.toolsVisibleHint':
+    'Cuando está desactivado, las llamadas a herramientas y compactaciones se ocultan al cargar — útil en pantallas pequeñas.',
+  'settings.toolOutputsExpanded': 'Expandir salidas de herramientas por defecto',
+  'settings.toolOutputsExpandedHint':
+    'Cuando está activo, los bloques de salida de herramientas cargan expandidos en vez de colapsados.',
+
   'settings.artifacts': 'Artefactos',
   'settings.showArtifacts': 'Mostrar el panel de artefactos',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/fil.js
+++ b/web/src/shared/locales/fil.js
@@ -238,6 +238,17 @@ export default {
     'Ang built-in ay libre, instant na heuristic ng salita (walang AI). Pumili ng model para sa mas matalinong pamagat — mainam ang maliit at mabilis.',
   'settings.titleBuiltin': 'Built-in na heuristic (walang AI)',
 
+  'settings.sessionDisplay': 'Display ng session',
+  'settings.thinkingExpanded': 'Ipakita ang thinking bilang default',
+  'settings.thinkingExpandedHint':
+    'Kapag naka-on, naka-expand ang reasoning ng model habang naglo-load ang mga session. Pwede mo pa rin i-toggle ito per session mula sa header.',
+  'settings.toolsVisible': 'Ipakita ang tool calls bilang default',
+  'settings.toolsVisibleHint':
+    'Kapag naka-off, naka-hide ang mga tool invocation at compaction habang naglo-load — kapaki-pakinabang sa maliit na screen.',
+  'settings.toolOutputsExpanded': 'I-expand ang tool outputs bilang default',
+  'settings.toolOutputsExpandedHint':
+    'Kapag naka-on, naglo-load ang mga tool output block na naka-expand sa halip na naka-collapse.',
+
   'settings.artifacts': 'Mga Artifact',
   'settings.showArtifacts': 'Ipakita ang panel ng Artifact',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/fr.js
+++ b/web/src/shared/locales/fr.js
@@ -238,6 +238,17 @@ export default {
     'L’intégré est une heuristique de mots gratuite et instantanée (sans IA). Choisissez un modèle pour des titres plus pertinents — un petit modèle rapide est idéal.',
   'settings.titleBuiltin': 'Heuristique intégrée (sans IA)',
 
+  'settings.sessionDisplay': 'Affichage de session',
+  'settings.thinkingExpanded': 'Afficher la réflexion par défaut',
+  'settings.thinkingExpandedHint':
+    'Lorsque activé, la réflexion du modèle est dépliée au chargement des sessions. Vous pouvez toujours la basculer par session depuis l’en-tête.',
+  'settings.toolsVisible': 'Afficher les appels d’outils par défaut',
+  'settings.toolsVisibleHint':
+    'Lorsque désactivé, les appels d’outils et compactions sont masqués au chargement — pratique sur petits écrans.',
+  'settings.toolOutputsExpanded': 'Déplier les sorties d’outils par défaut',
+  'settings.toolOutputsExpandedHint':
+    'Lorsque activé, les blocs de sortie d’outils sont chargés dépliés au lieu de repliés.',
+
   'settings.artifacts': 'Artefacts',
   'settings.showArtifacts': 'Afficher le panneau Artefacts',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/id.js
+++ b/web/src/shared/locales/id.js
@@ -234,6 +234,17 @@ export default {
     'Bawaan adalah heuristik kata gratis dan instan (tanpa AI). Pilih model untuk judul yang lebih cerdas — yang kecil dan cepat ideal.',
   'settings.titleBuiltin': 'Heuristik bawaan (tanpa AI)',
 
+  'settings.sessionDisplay': 'Tampilan sesi',
+  'settings.thinkingExpanded': 'Tampilkan berpikir secara bawaan',
+  'settings.thinkingExpandedHint':
+    'Saat aktif, penalaran model terbuka ketika sesi dimuat. Anda tetap bisa mengaturnya per sesi dari header.',
+  'settings.toolsVisible': 'Tampilkan pemanggilan alat secara bawaan',
+  'settings.toolsVisibleHint':
+    'Saat nonaktif, pemanggilan alat dan kompaksi disembunyikan saat dimuat — berguna di layar kecil.',
+  'settings.toolOutputsExpanded': 'Buka hasil alat secara bawaan',
+  'settings.toolOutputsExpandedHint':
+    'Saat aktif, blok hasil alat dimuat dalam keadaan terbuka alih-alih terlipat.',
+
   'settings.artifacts': 'Artefak',
   'settings.showArtifacts': 'Tampilkan panel Artefak',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/ja.js
+++ b/web/src/shared/locales/ja.js
@@ -235,6 +235,17 @@ export default {
     '組み込みは無料で即時の単語ヒューリスティック（AI なし）です。より賢いタイトルにはモデルを選択してください — 小さく高速なものが理想的です。',
   'settings.titleBuiltin': '組み込みヒューリスティック（AI なし）',
 
+  'settings.sessionDisplay': 'セッション表示',
+  'settings.thinkingExpanded': '思考をデフォルトで表示',
+  'settings.thinkingExpandedHint':
+    '有効にすると、セッション読み込み時にモデルの思考が展開されます。ヘッダーからセッションごとに切り替えることもできます。',
+  'settings.toolsVisible': 'ツール呼び出しをデフォルトで表示',
+  'settings.toolsVisibleHint':
+    '無効にすると、ツール呼び出しと圧縮表示がセッション読み込み時に非表示になります — 小さな画面で便利です。',
+  'settings.toolOutputsExpanded': 'ツール出力をデフォルトで展開',
+  'settings.toolOutputsExpandedHint':
+    '有効にすると、ツール出力ブロックが折りたたみではなく展開された状態で読み込まれます。',
+
   'settings.artifacts': 'アーティファクト',
   'settings.showArtifacts': 'アーティファクトパネルを表示',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/km.js
+++ b/web/src/shared/locales/km.js
@@ -232,6 +232,17 @@ export default {
     'មានស្រាប់គឺជា heuristic ពាក្យឥតគិតថ្លៃ ភ្លាមៗ (គ្មាន AI)។ ជ្រើសម៉ូដែលសម្រាប់ចំណងជើងឆ្លាតវៃជាងមុន — តូច និងលឿនគឺល្អបំផុត។',
   'settings.titleBuiltin': 'Heuristic មានស្រាប់ (គ្មាន AI)',
 
+  'settings.sessionDisplay': 'ការបង្ហាញ session',
+  'settings.thinkingExpanded': 'បង្ហាញការគិតតាមលំនាំដើម',
+  'settings.thinkingExpandedHint':
+    'ពេលបើក ការគិតរបស់ម៉ូដែលត្រូវបានបង្ហាញពេលផ្ទុក session។ អ្នកនៅតែអាចបិទបើកវាក្នុង session នីមួយៗពីបឋមកថា។',
+  'settings.toolsVisible': 'បង្ហាញការហៅឧបករណ៍តាមលំនាំដើម',
+  'settings.toolsVisibleHint':
+    'ពេលបិទ ការហៅឧបករណ៍ និងការបង្ហាប់ត្រូវបានលាក់ពេលផ្ទុក — មានប្រយោជន៍លើអេក្រង់តូច។',
+  'settings.toolOutputsExpanded': 'ពន្លាលទ្ធផលឧបករណ៍តាមលំនាំដើម',
+  'settings.toolOutputsExpandedHint':
+    'ពេលបើក ប្លុកលទ្ធផលឧបករណ៍ផ្ទុកក្នុងស្ថានភាពពន្លាជំនួសឱ្យបង្រួម។',
+
   'settings.artifacts': 'អាទីហ្វាក់',
   'settings.showArtifacts': 'បង្ហាញផ្ទាំងអាទីហ្វាក់',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/lo.js
+++ b/web/src/shared/locales/lo.js
@@ -233,6 +233,17 @@ export default {
     'ມີໃນຕົວແມ່ນ heuristic ຄຳສັບຟຣີ ທັນທີ (ບໍ່ມີ AI). ເລືອກໂມເດວເພື່ອຫົວຂໍ້ທີ່ສະຫຼາດກວ່າ — ໂມເດວນ້ອຍ ແລະ ໄວແມ່ນເໝາະສົມ.',
   'settings.titleBuiltin': 'Heuristic ມີໃນຕົວ (ບໍ່ມີ AI)',
 
+  'settings.sessionDisplay': 'ການສະແດງ session',
+  'settings.thinkingExpanded': 'ສະແດງການຄິດເປັນຄ່າເລີ່ມຕົ້ນ',
+  'settings.thinkingExpandedHint':
+    'ເມື່ອເປີດ ການຄິດຂອງໂມເດວຈະຖືກຂະຫຍາຍເມື່ອໂຫລດ session. ທ່ານສາມາດສະຫຼັບໄດ້ຕໍ່ session ຈາກສ່ວນຫົວ.',
+  'settings.toolsVisible': 'ສະແດງການເອີ້ນເຄື່ອງມືເປັນຄ່າເລີ່ມຕົ້ນ',
+  'settings.toolsVisibleHint':
+    'ເມື່ອປິດ ການເອີ້ນເຄື່ອງມືແລະການບີບອັດຖືກເຊື່ອງເມື່ອໂຫລດ — ມີປະໂຫຍດໃນຈໍຂະໜາດນ້ອຍ.',
+  'settings.toolOutputsExpanded': 'ຂະຫຍາຍຜົນຮັບເຄື່ອງມືເປັນຄ່າເລີ່ມຕົ້ນ',
+  'settings.toolOutputsExpandedHint':
+    'ເມື່ອເປີດ ບລັອກຜົນຮັບເຄື່ອງມືໂຫລດໃນສະຖານະຂະຫຍາຍແທນທີ່ຈະຫຍໍ້.',
+
   'settings.artifacts': 'ອາທິແຟັກ',
   'settings.showArtifacts': 'ສະແດງແຜງອາທິແຟັກ',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/ms.js
+++ b/web/src/shared/locales/ms.js
@@ -235,6 +235,17 @@ export default {
     'Terbina dalam ialah heuristik perkataan percuma dan segera (tanpa AI). Pilih model untuk tajuk yang lebih bijak — yang kecil dan pantas adalah ideal.',
   'settings.titleBuiltin': 'Heuristik terbina dalam (tanpa AI)',
 
+  'settings.sessionDisplay': 'Paparan sesi',
+  'settings.thinkingExpanded': 'Tunjukkan pemikiran secara lalai',
+  'settings.thinkingExpandedHint':
+    'Apabila dihidupkan, pemikiran model dikembangkan semasa sesi dimuat. Anda masih boleh menukarnya setiap sesi dari pengepala.',
+  'settings.toolsVisible': 'Tunjukkan panggilan alat secara lalai',
+  'settings.toolsVisibleHint':
+    'Apabila dimatikan, panggilan alat dan pemampatan disembunyikan semasa dimuat — berguna untuk skrin kecil.',
+  'settings.toolOutputsExpanded': 'Kembangkan hasil alat secara lalai',
+  'settings.toolOutputsExpandedHint':
+    'Apabila dihidupkan, blok hasil alat dimuat dalam keadaan dikembangkan dan bukan dilipat.',
+
   'settings.artifacts': 'Artifak',
   'settings.showArtifacts': 'Tunjukkan panel Artifak',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/my.js
+++ b/web/src/shared/locales/my.js
@@ -237,6 +237,17 @@ export default {
     'အတွင်းပါသည် အခမဲ့၊ ချက်ချင်း စကားလုံး heuristic (AI မပါ)။ ပိုမိုဉာဏ်ရှိသော ခေါင်းစဉ်များအတွက် မော်ဒယ်တစ်ခု ရွေးပါ — သေးငယ်၍ မြန်သည်က အကောင်းဆုံး။',
   'settings.titleBuiltin': 'အတွင်းပါ heuristic (AI မပါ)',
 
+  'settings.sessionDisplay': 'Session ပြသမှု',
+  'settings.thinkingExpanded': 'တွေးခေါ်မှုကို မူရင်းအဖြစ် ပြ',
+  'settings.thinkingExpandedHint':
+    'ဖွင့်ထားလျှင် session များ ဖွင့်စဉ် မော်ဒယ်၏ တွေးခေါ်မှုကို ချဲ့ပြထား။ Header မှ session တစ်ခုခြင်းအတွက် ပြောင်းနိုင်ပါသေး။',
+  'settings.toolsVisible': 'Tool call များကို မူရင်းအဖြစ် ပြ',
+  'settings.toolsVisibleHint':
+    'ပိတ်ထားလျှင် tool ခေါ်ဆိုမှုနှင့် compaction များကို session ဖွင့်စဉ် ဖျောက်ထား — မျက်နှာပြင်သေးတွင် အသုံးဝင်။',
+  'settings.toolOutputsExpanded': 'Tool output များကို မူရင်းအဖြစ် ချဲ့ပြ',
+  'settings.toolOutputsExpandedHint':
+    'ဖွင့်ထားလျှင် tool output block များကို ခေါက်ထားသည့်အစား ချဲ့ထားသည့်အနေဖြင့် ပြ။',
+
   'settings.artifacts': 'အာတိဖက်များ',
   'settings.showArtifacts': 'အာတိဖက် အကန့် ပြ',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/th.js
+++ b/web/src/shared/locales/th.js
@@ -233,6 +233,16 @@ export default {
     'ในตัวเป็นฮิวริสติกคำที่ฟรีและทันที (ไม่มี AI) เลือกโมเดลเพื่อชื่อที่ฉลาดขึ้น — โมเดลเล็กและเร็วเหมาะที่สุด',
   'settings.titleBuiltin': 'ฮิวริสติกในตัว (ไม่มี AI)',
 
+  'settings.sessionDisplay': 'การแสดงผลเซสชัน',
+  'settings.thinkingExpanded': 'แสดงการคิดเป็นค่าเริ่มต้น',
+  'settings.thinkingExpandedHint':
+    'เมื่อเปิด การคิดของโมเดลจะถูกขยายเมื่อโหลดเซสชัน คุณยังสลับได้ต่อเซสชันจากส่วนหัว',
+  'settings.toolsVisible': 'แสดงการเรียกเครื่องมือเป็นค่าเริ่มต้น',
+  'settings.toolsVisibleHint':
+    'เมื่อปิด การเรียกเครื่องมือและการบีบอัดจะถูกซ่อนเมื่อโหลด — มีประโยชน์บนหน้าจอเล็ก',
+  'settings.toolOutputsExpanded': 'ขยายผลลัพธ์เครื่องมือเป็นค่าเริ่มต้น',
+  'settings.toolOutputsExpandedHint': 'เมื่อเปิด บล็อกผลลัพธ์เครื่องมือจะโหลดในสถานะขยายแทนการพับ',
+
   'settings.artifacts': 'อาร์ติแฟกต์',
   'settings.showArtifacts': 'แสดงแผงอาร์ติแฟกต์',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/vi.js
+++ b/web/src/shared/locales/vi.js
@@ -233,6 +233,17 @@ export default {
     'Tích hợp là heuristic từ ngữ miễn phí, tức thời (không AI). Chọn một mô hình để có tiêu đề thông minh hơn — loại nhỏ, nhanh là lý tưởng.',
   'settings.titleBuiltin': 'Heuristic tích hợp (không AI)',
 
+  'settings.sessionDisplay': 'Hiển thị phiên',
+  'settings.thinkingExpanded': 'Hiển thị suy nghĩ theo mặc định',
+  'settings.thinkingExpandedHint':
+    'Khi bật, suy nghĩ của mô hình được mở rộng khi tải phiên. Bạn vẫn có thể bật/tắt mỗi phiên từ tiêu đề.',
+  'settings.toolsVisible': 'Hiển thị lệnh gọi công cụ theo mặc định',
+  'settings.toolsVisibleHint':
+    'Khi tắt, các lệnh gọi công cụ và phần nén được ẩn khi tải — tiện cho màn hình nhỏ.',
+  'settings.toolOutputsExpanded': 'Mở rộng kết quả công cụ theo mặc định',
+  'settings.toolOutputsExpandedHint':
+    'Khi bật, các khối kết quả công cụ tải ở trạng thái mở rộng thay vì thu gọn.',
+
   'settings.artifacts': 'Tạo phẩm',
   'settings.showArtifacts': 'Hiện bảng Tạo phẩm',
   'settings.showArtifactsHint':

--- a/web/src/shared/locales/zh.js
+++ b/web/src/shared/locales/zh.js
@@ -229,6 +229,15 @@ export default {
     '内置是免费、即时的词语启发式（无 AI）。选择一个模型以获得更智能的标题——小而快的模型最为理想。',
   'settings.titleBuiltin': '内置启发式（无 AI）',
 
+  'settings.sessionDisplay': '会话显示',
+  'settings.thinkingExpanded': '默认展示思考',
+  'settings.thinkingExpandedHint':
+    '开启后，加载会话时模型思考默认展开。仍可在每个会话的头部进行切换。',
+  'settings.toolsVisible': '默认显示工具调用',
+  'settings.toolsVisibleHint': '关闭后，加载时隐藏工具调用与折叠摘要 — 适用于小屏幕。',
+  'settings.toolOutputsExpanded': '默认展开工具输出',
+  'settings.toolOutputsExpandedHint': '开启后，工具输出块以展开状态而非折叠状态加载。',
+
   'settings.artifacts': '产物',
   'settings.showArtifacts': '显示产物面板',
   'settings.showArtifactsHint':

--- a/web/src/shared/settings-store.js
+++ b/web/src/shared/settings-store.js
@@ -37,6 +37,9 @@ export const SERVER_SETTING_KEYS = [
   'pi-web:v1:auto-title:model',
   'pi-web:v1:artifacts:enabled',
   'pi-web:v1:artifacts:include',
+  'pi-web:v1:toggle:thinking',
+  'pi-web:v1:toggle:tools',
+  'pi-web:v1:toggle:tool-outputs',
 ];
 
 // Network sync is disabled until a page entrypoint configures it. This keeps


### PR DESCRIPTION
## Summary

- Adds **Session Display** defaults in `/settings` so users can choose whether thinking blocks, tool calls, and tool outputs start expanded or collapsed for *every* session, not just the one they last toggled.
- Per-session toggle overrides are scoped to a session ID (`localStorage` map) instead of a single global blob, so changing a default in settings takes effect for sessions the user hasn't explicitly overridden.
- When tool calls are hidden, each one renders a `<div class="tool-call-collapsed">Tool: <name> ...</div>` placeholder (mirrors the existing thinking-collapsed pattern) so an assistant message whose only content is a tool call doesn't collapse to a stranded timestamp.
- The tool-output header toggle is disabled (visually + keyboard shortcut no-ops) while tool calls are hidden, since output blocks live inside the `.tool-execution` wrapper that is already `display:none`.

## Related issue

Closes #48

## Type of change

- [x] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `style` — formatting / UI styling, no behavior change
- [x] `test` — adding or updating tests
- [ ] `chore` — build, tooling, or maintenance

## Live vs. Export

- [x] Considered both the live app and the export snapshot
- [x] Kept `internal/ui/embedded/` in sync with `web/src/session/` changes
- [x] No live-only chrome (Vite scripts, active composer, SSE/API) leaked into export

## Testing

- [x] `make check` passes (test + build + vet)
- [x] Frontend tests (`vitest`) cover the change
- [x] Go tests (`go test ./...`) cover the change
- [ ] UI changes verified in a browser
