### PR TITLE
fix(web): restore settings tab on refresh and surface About version

### DIFF
--- a/internal/ui/embedded/styles/settings.css
+++ b/internal/ui/embedded/styles/settings.css
@@ -252,6 +252,7 @@
   border: 1px solid var(--dim);
   background: var(--input-bg, var(--surface-2));
   white-space: nowrap;
+  cursor: pointer;
 }
 
 .settings-link:hover {

--- a/web/src/components/settings/AboutSettings.svelte
+++ b/web/src/components/settings/AboutSettings.svelte
@@ -1,6 +1,10 @@
 <script>
+  import { onMount } from 'svelte';
   import { t } from '../../shared/i18n.js';
   import { REPO_URL, USER_DOCS_URL } from '../../shared/links.js';
+  import { applyVersionStatus } from '../../shared/version.js';
+
+  onMount(applyVersionStatus);
 </script>
 
 <section class="settings-section">

--- a/web/src/routes/SettingsPage.svelte
+++ b/web/src/routes/SettingsPage.svelte
@@ -28,6 +28,8 @@
     { id: 'catGatekeeper', labelKey: 'settings.catGatekeeper' },
     { id: 'about', labelKey: 'settings.about' },
   ];
+  const sectionIds = new Set(sections.map((s) => s.id));
+
   let activeSection = $state('appearance');
   let isMobile = $state(false);
   let mobileShowingPane = $state(false);
@@ -37,9 +39,25 @@
     t(sections.find((s) => s.id === activeSection)?.labelKey || 'settings.title'),
   );
 
+  function sectionFromUrl(win) {
+    try {
+      const id = new URLSearchParams(win.location.search).get('section');
+      return id && sectionIds.has(id) ? id : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function syncSectionUrl(win, id) {
+    try {
+      win.history.replaceState(win.history.state, '', `${win.location.pathname}?section=${id}`);
+    } catch {}
+  }
+
   function selectSection(id) {
     activeSection = id;
     if (isMobile) mobileShowingPane = true;
+    syncSectionUrl(window, id);
   }
 
   function backToList() {
@@ -93,6 +111,12 @@
     };
     updateMobile();
     mq?.addEventListener('change', updateMobile);
+
+    const initialSection = sectionFromUrl(window);
+    if (initialSection) {
+      activeSection = initialSection;
+      if (isMobile) mobileShowingPane = true;
+    }
 
     loadSettings({ windowImpl: window })
       .then((loaded) => {

--- a/web/src/routes/SettingsPage.test.js
+++ b/web/src/routes/SettingsPage.test.js
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { tick } from 'svelte';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import SettingsPage from './SettingsPage.svelte';
+
+beforeEach(() => {
+  localStorage.clear();
+  window.history.replaceState({}, '', '/settings');
+});
+afterEach(cleanup);
+
+function activeNav() {
+  return document.querySelector('.settings-sidebar-item.active')?.getAttribute('data-settings-nav');
+}
+
+describe('SettingsPage tab persistence', () => {
+  it('defaults to the appearance tab when no section is in the URL', async () => {
+    render(SettingsPage);
+    await tick();
+    expect(activeNav()).toBe('appearance');
+  });
+
+  it('restores the active tab from the ?section= query param on mount', async () => {
+    window.history.replaceState({}, '', '/settings?section=about');
+    render(SettingsPage);
+    await tick();
+    expect(activeNav()).toBe('about');
+  });
+
+  it('falls back to the default tab for an unknown section param', async () => {
+    window.history.replaceState({}, '', '/settings?section=bogus');
+    render(SettingsPage);
+    await tick();
+    expect(activeNav()).toBe('appearance');
+  });
+
+  it('writes the selected tab to the URL so a refresh restores it', async () => {
+    render(SettingsPage);
+    await tick();
+
+    await fireEvent.click(document.querySelector('[data-settings-nav="notifications"]'));
+    await tick();
+
+    expect(window.location.search).toBe('?section=notifications');
+    expect(activeNav()).toBe('notifications');
+  });
+
+  it('updates the URL without adding history entries when switching tabs', async () => {
+    render(SettingsPage);
+    await tick();
+    const lengthBefore = window.history.length;
+
+    await fireEvent.click(document.querySelector('[data-settings-nav="language"]'));
+    await tick();
+    await fireEvent.click(document.querySelector('[data-settings-nav="about"]'));
+    await tick();
+
+    expect(window.history.length).toBe(lengthBefore);
+    expect(window.location.search).toBe('?section=about');
+  });
+});

--- a/web/src/shared/version.js
+++ b/web/src/shared/version.js
@@ -14,6 +14,10 @@ export function openVersionModal() {
   active?.openModal?.();
 }
 
+export function applyVersionStatus() {
+  active?.applyStatus?.();
+}
+
 export function renderChangelog(markdown) {
   if (!markdown)
     return `<p class="version-changelog-empty">${escapeHtml(t('version.noReleaseNotes'))}</p>`;


### PR DESCRIPTION
## Summary

- Settings tabs now persist their active section as a `?section=<id>` query param via `window.history.replaceState`. Refreshing the page restores the same tab; the back button still exits to the app since no history entry is pushed.
- The About tab now displays the current version at the bottom of the settings pane by calling `applyVersionStatus()` on mount, reusing the existing version status UI.
- Added `cursor: pointer` to `.settings-link` so the version button row shows the hand cursor on hover, consistent with the anchor rows.

## Related issue

Closes #

## Type of change

- [x] `fix` — bug fix

## Live vs. Export

- [x] Not applicable — this PR doesn't touch session rendering

## Testing

- [x] `make check` passes (test + build + vet)
- [x] Frontend tests (`vitest`) cover the change
- [ ] Go tests (`go test ./...`) cover the change
- [ ] UI changes verified in a browser
