### PR TITLE
fix(web): WCO header alignment, session loading spinner, SPA back link

### DIFF
--- a/internal/ui/embedded/styles/index.css
+++ b/internal/ui/embedded/styles/index.css
@@ -58,7 +58,11 @@ a { color: inherit; }
     app-region: drag;
 }
 :root.wco .header-inner {
-    padding-left: calc(env(titlebar-area-x, 0px) + 28px);
+    /* The inner box is centered (max-width + margin: auto), so on wide windows
+       its left margin already clears the OS window controls and must stay aligned
+       with .content below. Only add the titlebar inset when the centered box would
+       otherwise slide under the controls (narrow windows). */
+    padding-left: max(28px, calc(env(titlebar-area-x, 0px) + 28px - max(0px, (100vw - 1040px) / 2)));
 }
 :root.wco .header a,
 :root.wco .header button,

--- a/internal/ui/embedded/styles/session.css
+++ b/internal/ui/embedded/styles/session.css
@@ -406,6 +406,44 @@
     @keyframes spin { to { transform: rotate(360deg); } }
     .spinner { animation: spin 1s linear infinite; }
 
+    .session-loading {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 14px;
+      min-height: var(--viewport-height, 100vh);
+      padding: 24px;
+      text-align: center;
+      color: var(--text-soft);
+      animation: session-loading-fade 0.25s ease both;
+    }
+    @keyframes session-loading-fade { from { opacity: 0; } to { opacity: 1; } }
+    .session-loading-spinner {
+      width: 26px;
+      height: 26px;
+      border-radius: 50%;
+      border: 2.5px solid var(--dim);
+      border-top-color: var(--accent);
+      animation: spin 0.8s linear infinite;
+    }
+    .session-loading-text {
+      font-size: 13px;
+      color: var(--muted);
+      letter-spacing: 0.01em;
+    }
+    .session-loading--error h1 {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--text);
+    }
+    .session-loading--error p { margin-top: 4px; }
+    .session-loading--error a { color: var(--accent); }
+    @media (prefers-reduced-motion: reduce) {
+      .session-loading { animation: none; }
+      .session-loading-spinner { animation-duration: 1.6s; }
+    }
+
     @media (prefers-reduced-motion: reduce) {
       ::view-transition-old(root),
       ::view-transition-new(root) {

--- a/web/src/components/session/SessionHeader.svelte
+++ b/web/src/components/session/SessionHeader.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { icon, PanelLeft, Plus, SquarePen, MoreHorizontal } from '../../shared/icons.js';
   import { t } from '../../shared/i18n.js';
-  import { navigate } from '../../shared/navigation.js';
+  import { navigate, handleNavClick } from '../../shared/navigation.js';
   import { showToast } from '../../shared/toast.js';
   import { copyToClipboard } from '../../shared/clipboard.js';
   import { sessionTitle, setSessionTitle } from '../../session/session-title.svelte.js';
@@ -95,7 +95,9 @@
 
 <div class="session-header-bar">
   <div class="session-header-left">
-    <a href="/" class="session-header-back"><span>←</span> {t('session.back')}</a>
+    <a href="/" class="session-header-back" onclick={(event) => handleNavClick(event, '/')}
+      ><span>←</span> {t('session.back')}</a
+    >
     <button
       id="tree-toggle"
       class="session-header-actions session-header-tree-toggle"

--- a/web/src/routes/SessionPage.svelte
+++ b/web/src/routes/SessionPage.svelte
@@ -120,9 +120,14 @@
 </script>
 
 {#if loading}
-  {#if showLoading}<div class="session-loading">{t('session.loading')}</div>{/if}
+  {#if showLoading}
+    <div class="session-loading" role="status" aria-live="polite">
+      <span class="session-loading-spinner" aria-hidden="true"></span>
+      <span class="session-loading-text">{t('session.loading')}</span>
+    </div>
+  {/if}
 {:else if error}
-  <div class="session-loading">
+  <div class="session-loading session-loading--error">
     <h1>{error}</h1>
     <p><a href="/">{t('session.backToSessions')}</a></p>
   </div>


### PR DESCRIPTION
## Summary
Three related web/PWA fixes:

- **WCO header alignment** — In Window Controls Overlay (installed PWA), the index header unconditionally added `env(titlebar-area-x)` to `.header-inner`'s left padding, pushing the logo ~90px right of the content cards on wide windows where the centered `max-width: 1040px` box already clears the OS controls. Now the inset is only applied when the centered box would actually slide under the window controls (narrow windows), keeping the logo aligned with the cards.
- **Session loading spinner** — `.session-loading` had no CSS, so "Loading session…" rendered as bare text in the top-left and flashed away. Replaced with a full-viewport centered layout: a spinner (reusing the existing `spin` keyframe), a muted label, and a gentle fade-in; the error fallback is styled too. Honors `prefers-reduced-motion`.
- **SPA back link** — The session "← Back" link was a plain `<a href="/">` triggering a full document reload; under the cross-document view transition that reload could stall in the installed PWA, leaving the homepage stuck on "Loading sessions…". It now routes through `handleNavClick` like the session cards, navigating client-side while still honoring modified clicks for open-in-new-tab.

## Test plan
- [ ] Install as PWA in WCO mode: index header logo aligns with the content cards below (wide window); logo still clears the OS window controls on a narrow window.
- [ ] Open a session that takes >200ms to load: a centered spinner + label appears (not top-left text), and resolves into the session.
- [ ] From a session, click "← Back": homepage loads without getting stuck on "Loading sessions…".
- [ ] Cmd/Ctrl-click "← Back" still opens the homepage in a new tab.
- [ ] `make check` passes.