### PR TITLE
fix(docs): Burmese hero leading + clear Node 20 action warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,9 +28,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20'
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Assemble VitePress source
         run: python3 scripts/build_site.py
       - name: Install & build
@@ -38,8 +35,8 @@ jobs:
         run: |
           npm install
           npm run build
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: website/dist
 
@@ -51,4 +48,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/website/.vitepress/theme/custom.css
+++ b/website/.vitepress/theme/custom.css
@@ -123,11 +123,11 @@ html[data-theme='light'] {
 }
 :is(:lang(my), :lang(km), :lang(lo), :lang(th)) .VPHero .name,
 :is(:lang(my), :lang(km), :lang(lo), :lang(th)) .VPHero .text {
-  line-height: 1.5;
-  padding-bottom: 0.12em;
+  line-height: 1.75;
+  padding-bottom: 0.2em;
 }
 :is(:lang(my), :lang(km), :lang(lo), :lang(th)) .VPHero .tagline {
-  line-height: 1.7;
+  line-height: 1.8;
 }
 :is(:lang(my), :lang(km), :lang(lo), :lang(th)) .VPFeature .title {
   line-height: 1.5;


### PR DESCRIPTION
Follow-ups to the docs site:
- **Burmese/SEA hero overlap**: bump hero heading line-height to 1.75 for my/km/lo/th (the 56px stacked glyphs collided at 1.5).
- **Node 20 warnings**: drop `setup-python` (ubuntu runners have python3), bump `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`.