### PR TITLE
fix(docs): bump Burmese/SEA hero leading to 1.9

### DIFF
--- a/website/.vitepress/theme/custom.css
+++ b/website/.vitepress/theme/custom.css
@@ -123,7 +123,7 @@ html[data-theme='light'] {
 }
 :is(:lang(my), :lang(km), :lang(lo), :lang(th)) .VPHero .name,
 :is(:lang(my), :lang(km), :lang(lo), :lang(th)) .VPHero .text {
-  line-height: 1.75;
+  line-height: 1.9;
   padding-bottom: 0.2em;
 }
 :is(:lang(my), :lang(km), :lang(lo), :lang(th)) .VPHero .tagline {


### PR DESCRIPTION
Increase hero heading line-height to 1.9 for my/km/lo/th for more breathing room.