### PR TITLE
feat(windows): real state-file locking, self-update restart, Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,40 @@ jobs:
       - name: Run checks
         run: make check
 
+  test-windows:
+    name: Test (Windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'web/package-lock.json'
+
+      # `make` isn't available on the Windows runner and the full check suite
+      # already runs on ubuntu; this job covers the Go code on a real Windows
+      # toolchain. The frontend build only exists to satisfy //go:embed.
+      - name: Build frontend (go:embed assets)
+        working-directory: web
+        run: |
+          npm ci
+          npm run build
+
+      - name: Go tests
+        run: go test ./...
+
+      - name: Go vet
+        run: go vet ./...
+
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
             goarch: arm64
           - goos: windows
             goarch: amd64
+          - goos: windows
+            goarch: arm64
 
     steps:
       - name: Checkout

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,10 @@ go 1.25.5
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/google/uuid v1.6.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/shirou/gopsutil/v4 v4.26.5
+	golang.org/x/sys v0.42.0
 	modernc.org/sqlite v1.51.0
 )
 
@@ -14,18 +17,15 @@ require (
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/app/state_file_test.go
+++ b/internal/app/state_file_test.go
@@ -1,15 +1,12 @@
-//go:build !windows
-
 package app
 
 import (
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 )
 
-func TestStateFileFlockBlocksSecondAcquire(t *testing.T) {
+func TestStateFileLockBlocksSecondAcquire(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "state.json")
 
@@ -18,17 +15,18 @@ func TestStateFileFlockBlocksSecondAcquire(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f1.Close()
-	if err := syscall.Flock(int(f1.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		t.Fatalf("first flock should succeed: %v", err)
+	if err := lockStateFile(f1); err != nil {
+		t.Fatalf("first lock should succeed: %v", err)
 	}
 
+	// flock (Unix) and LockFileEx (Windows) both scope the lock to the open
+	// file handle, so a second handle in the same process must be rejected.
 	f2, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer f2.Close()
-	err = syscall.Flock(int(f2.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
-	if err != syscall.EWOULDBLOCK {
-		t.Fatalf("second flock should return EWOULDBLOCK, got %v", err)
+	if err := lockStateFile(f2); err == nil {
+		t.Fatal("second lock should fail while the first is held")
 	}
 }

--- a/internal/app/state_file_windows.go
+++ b/internal/app/state_file_windows.go
@@ -2,7 +2,22 @@
 
 package app
 
-import "os"
+import (
+	"fmt"
+	"os"
 
-// lockStateFile is a no-op on Windows (unsupported platform).
-func lockStateFile(_ *os.File) error { return nil }
+	"golang.org/x/sys/windows"
+)
+
+// lockStateFile takes an exclusive non-blocking lock on f via LockFileEx,
+// mirroring the flock in state_file_unix.go. The caller must keep f open for
+// the lock to remain held; closing f (or process exit) releases the lock.
+func lockStateFile(f *os.File) error {
+	err := windows.LockFileEx(windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, new(windows.Overlapped))
+	if err == windows.ERROR_LOCK_VIOLATION {
+		return fmt.Errorf("another pi-web instance appears to be running (state file at %s is locked); exit it first, or remove the file if stale", f.Name())
+	}
+	return err
+}

--- a/internal/app/tailscale_test.go
+++ b/internal/app/tailscale_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,11 @@ import (
 
 func writeFakeTailscale(t *testing.T, dir, script string) string {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		// The fake CLI is a shell script; the code under test is
+		// platform-neutral exec.Command plumbing.
+		t.Skip("fake tailscale CLI requires a Unix shell")
+	}
 	binPath := filepath.Join(dir, "tailscale")
 	if err := os.WriteFile(binPath, []byte(script), 0755); err != nil {
 		t.Fatalf("write fake tailscale: %v", err)

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -70,7 +71,9 @@ func runInstall(ctx context.Context) error {
 // runRestart restarts the pi-web service so the freshly installed binary takes
 // over. The restart command is detached into its own session so it survives
 // this process being torn down by the service manager. A fallback timer exits
-// the process if the service manager does not replace us promptly.
+// the process if the service manager does not replace us promptly. On Windows
+// there is no service manager: the detached helper waits for this process to
+// exit (the fallback timer guarantees that) and then starts the new binary.
 func runRestart() error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
@@ -78,8 +81,10 @@ func runRestart() error {
 		cmd = exec.Command("sh", "-lc", darwinRestartScript)
 	case "linux":
 		cmd = exec.Command("systemctl", "--user", "restart", "pi-web.service")
+	case "windows":
+		cmd = exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", windowsRestartScript())
 	default:
-		return fmt.Errorf("restart is only supported on macOS and Linux")
+		return fmt.Errorf("restart is not supported on %s", runtime.GOOS)
 	}
 	detachSession(cmd)
 	cmd.Stdout = os.Stderr
@@ -91,6 +96,21 @@ func runRestart() error {
 	// instance), exit so the old process doesn't linger holding the port.
 	time.AfterFunc(5*time.Second, func() { os.Exit(0) })
 	return nil
+}
+
+// windowsRestartScript builds the PowerShell body of the detached restart
+// helper: wait for this process to release the port, then relaunch through the
+// hidden startup launcher written by install.ps1, falling back to the bare
+// executable for manual installs.
+func windowsRestartScript() string {
+	psQuote := func(s string) string { return "'" + strings.ReplaceAll(s, "'", "''") + "'" }
+	exe, _ := os.Executable()
+	home, _ := os.UserHomeDir()
+	launcher := filepath.Join(home, ".config", "pi-web", "pi-web-start.vbs")
+	return fmt.Sprintf(
+		"Wait-Process -Id %d -Timeout 30 -ErrorAction SilentlyContinue; "+
+			"if (Test-Path %s) { Start-Process wscript.exe -ArgumentList %s } else { Start-Process %s }",
+		os.Getpid(), psQuote(launcher), psQuote(`"`+launcher+`"`), psQuote(exe))
 }
 
 // darwinRestartScript mirrors the extension's `/pi-web restart`: re-bootstrap

--- a/internal/app/update_windows.go
+++ b/internal/app/update_windows.go
@@ -2,8 +2,18 @@
 
 package app
 
-import "os/exec"
+import (
+	"os/exec"
+	"syscall"
 
-// detachSession is a no-op on Windows; runRestart returns an error there before
-// the command is started.
-func detachSession(cmd *exec.Cmd) {}
+	"golang.org/x/sys/windows"
+)
+
+// detachSession detaches the restart helper from this process's console and
+// Ctrl+C group so it survives this process exiting mid-restart.
+func detachSession(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,
+		HideWindow:    true,
+	}
+}

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -1,6 +1,7 @@
 package files
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -163,7 +164,9 @@ func TestWalkScopedMaxDepth(t *testing.T) {
 func TestWalkScopedMaxEntries(t *testing.T) {
 	var seed []string
 	for i := 0; i < 30; i++ {
-		seed = append(seed, "f"+string(rune('a'+i))+".txt")
+		// Numeric names: 'a'+i runs past 'z' into characters like '|' that
+		// are invalid in Windows filenames.
+		seed = append(seed, fmt.Sprintf("f%02d.txt", i))
 	}
 	root := seedTree(t, seed...)
 	entries, err := WalkScoped(root, "", Options{MaxEntries: 7})

--- a/internal/server/auto_title_test.go
+++ b/internal/server/auto_title_test.go
@@ -80,7 +80,7 @@ func writeAutoTitleSession(t *testing.T, sessionsDir, userText, name string) str
 	}
 	id := "2026-06-03T00-00-00.000Z_test.jsonl"
 	var b strings.Builder
-	b.WriteString(`{"type":"session","version":3,"id":"test","cwd":"` + project + `"}` + "\n")
+	b.WriteString(`{"type":"session","version":3,"id":"test","cwd":` + jsonString(project) + `}` + "\n")
 	if userText != "" {
 		b.WriteString(`{"type":"message","message":{"role":"user","content":"` + userText + `"}}` + "\n")
 	}
@@ -212,7 +212,7 @@ func TestMaybeAutoTitleEachTurnUsesLatestMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 	id := "2026-06-03T00-00-00.000Z_each.jsonl"
-	content := `{"type":"session","version":3,"id":"e","cwd":"` + project + `"}` + "\n" +
+	content := `{"type":"session","version":3,"id":"e","cwd":` + jsonString(project) + `}` + "\n" +
 		`{"type":"message","message":{"role":"user","content":"first task"}}` + "\n" +
 		`{"type":"message","message":{"role":"user","content":"second different task"}}` + "\n"
 	if err := os.WriteFile(filepath.Join(project, id), []byte(content), 0o644); err != nil {
@@ -247,7 +247,7 @@ func TestMaybeAutoTitleReTitlesOwnAutoTitleAcrossRestart(t *testing.T) {
 	}
 	id := "2026-06-03T00-00-00.000Z_restart.jsonl"
 	// Prior auto-title marker + two user messages (a new turn since titling).
-	content := `{"type":"session","version":3,"id":"r","cwd":"` + project + `"}` + "\n" +
+	content := `{"type":"session","version":3,"id":"r","cwd":` + jsonString(project) + `}` + "\n" +
 		`{"type":"message","message":{"role":"user","content":"old task"}}` + "\n" +
 		`{"type":"session_info","name":"Old Task","autoTitle":true}` + "\n" +
 		`{"type":"message","message":{"role":"user","content":"brand new request"}}` + "\n"

--- a/internal/server/bench_test.go
+++ b/internal/server/bench_test.go
@@ -18,7 +18,7 @@ import (
 
 func generateLargeSessionContent(n int, cwd string) string {
 	var sb strings.Builder
-	sb.WriteString(`{"type":"session","version":3,"id":"bench-session-id","name":"Benchmark Session","timestamp":"2026-01-01T00:00:00Z","cwd":"` + cwd + `"}` + "\n")
+	sb.WriteString(`{"type":"session","version":3,"id":"bench-session-id","name":"Benchmark Session","timestamp":"2026-01-01T00:00:00Z","cwd":` + jsonString(cwd) + `}` + "\n")
 	for i := 0; i < n; i++ {
 		ts := fmt.Sprintf("2026-01-01T%02d:%02d:%02dZ", i/3600, (i/60)%60, i%60)
 		if i%2 == 0 {

--- a/internal/server/btw_test.go
+++ b/internal/server/btw_test.go
@@ -91,8 +91,13 @@ func TestHandleNewBtwThenGet(t *testing.T) {
 	dir := t.TempDir()
 	s := &Server{db: db, sessionsDir: dir}
 
-	// Create a new btw session for parent "parent-1".
-	body := bytes.NewBufferString(`{"path":"` + dir + `","parent":"parent-1"}`)
+	// Create a new btw session for parent "parent-1". Marshal the body so the
+	// Windows temp path's backslashes stay valid JSON.
+	raw, err := json.Marshal(map[string]string{"path": dir, "parent": "parent-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := bytes.NewBuffer(raw)
 	req := httptest.NewRequest(http.MethodPost, "/api/btw/new", body)
 	w := httptest.NewRecorder()
 	s.handleNewBtw(w, req)

--- a/internal/server/chat_queue_test.go
+++ b/internal/server/chat_queue_test.go
@@ -43,7 +43,7 @@ func writeQueueTestSession(t *testing.T, sessionsDir string) string {
 		t.Fatal(err)
 	}
 	id := "2026-06-22T01-00-00.000Z_q.jsonl"
-	body := `{"type":"session","version":3,"id":"q","cwd":"` + project + `"}` + "\n"
+	body := `{"type":"session","version":3,"id":"q","cwd":` + jsonString(project) + `}` + "\n"
 	if err := os.WriteFile(filepath.Join(project, id), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/chat_test.go
+++ b/internal/server/chat_test.go
@@ -618,7 +618,9 @@ func TestHandleNewSessionPreinitializesWorker(t *testing.T) {
 		sessionsDir: root,
 		chatSender:  fake,
 	}
-	req := httptest.NewRequest(http.MethodPost, "/api/new-session", strings.NewReader(`{"path":"/tmp/test-project"}`))
+	// A real absolute path: "/tmp/..." is not absolute on Windows.
+	projectPath := filepath.Join(root, "test-project")
+	req := httptest.NewRequest(http.MethodPost, "/api/new-session", strings.NewReader(`{"path":`+jsonString(projectPath)+`}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	s.handleNewSession(w, req)
@@ -653,7 +655,7 @@ func TestHandleNewSessionPreinitializesWorker(t *testing.T) {
 	}
 
 	// Verify file was created
-	projectDir := filepath.Join(root, sessions.EncodeProjectName("/tmp/test-project"))
+	projectDir := filepath.Join(root, sessions.EncodeProjectName(projectPath))
 	entries, err := os.ReadDir(projectDir)
 	if err != nil {
 		t.Fatalf("expected project dir to exist: %v", err)
@@ -669,7 +671,8 @@ func TestHandleNewSessionCopiesSourceModelAndThinking(t *testing.T) {
 	fake := &fakeSender{state: workers.WorkerStatus{State: workers.WorkerStateIdle, ModelProvider: "openai", Model: "gpt-5", ThinkingLevel: "high"}}
 	s := &Server{sessionsDir: root, chatSender: fake}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/new-session", strings.NewReader(`{"path":"/tmp/test-project","sourceSessionId":"source.jsonl"}`))
+	projectPath := filepath.Join(root, "test-project")
+	req := httptest.NewRequest(http.MethodPost, "/api/new-session", strings.NewReader(`{"path":`+jsonString(projectPath)+`,"sourceSessionId":"source.jsonl"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	s.handleNewSession(w, req)
@@ -693,7 +696,7 @@ func TestHandleNewSessionCopiesSourceModelAndThinking(t *testing.T) {
 	if modelID, thinkingID := fake.modelSessionID(), fake.thinkingSessionID(); modelID != "" || thinkingID != "" {
 		t.Fatalf("new session initialization should not append visible setting changes, got setModel=%q setThinking=%q", modelID, thinkingID)
 	}
-	projectDir := filepath.Join(root, sessions.EncodeProjectName("/tmp/test-project"))
+	projectDir := filepath.Join(root, sessions.EncodeProjectName(projectPath))
 	data, err := os.ReadFile(filepath.Join(projectDir, id))
 	if err != nil {
 		t.Fatal(err)
@@ -710,7 +713,7 @@ func TestHandleNewSessionCopiesSourceModelAndThinking(t *testing.T) {
 func TestHandleNewSessionWithoutChatSender(t *testing.T) {
 	root := t.TempDir()
 	s := &Server{sessionsDir: root}
-	req := httptest.NewRequest(http.MethodPost, "/api/new-session", strings.NewReader(`{"path":"/tmp/no-sender"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/new-session", strings.NewReader(`{"path":`+jsonString(filepath.Join(root, "no-sender"))+`}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	s.handleNewSession(w, req)

--- a/internal/server/fork_clone_test.go
+++ b/internal/server/fork_clone_test.go
@@ -24,7 +24,7 @@ func writeTreeSessionFile(t *testing.T, root, project, name string) string {
 	if err := os.MkdirAll(cwd, 0755); err != nil {
 		t.Fatal(err)
 	}
-	content := `{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":"` + cwd + `"}` + "\n" +
+	content := `{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":` + jsonString(cwd) + `}` + "\n" +
 		`{"type":"message","id":"a1b2c3d4","parentId":null,"timestamp":"2026-05-06T00:00:01.000Z","message":{"role":"user","content":"hello"}}` + "\n" +
 		`{"type":"message","id":"b2c3d4e5","parentId":"a1b2c3d4","timestamp":"2026-05-06T00:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Hi!"}]}}` + "\n" +
 		`{"type":"message","id":"c3d4e5f6","parentId":"b2c3d4e5","timestamp":"2026-05-06T00:00:03.000Z","message":{"role":"user","content":"how are you?"}}` + "\n" +

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 
 	"pi-web/internal/sessions"
@@ -178,7 +177,7 @@ func writeSessionWithCWD(t *testing.T, dir, name, cwd string) string {
 		t.Fatal(err)
 	}
 	path := filepath.Join(dir, name)
-	content := `{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":"` + strings.ReplaceAll(cwd, `"`, `\"`) + `"}` + "\n" +
+	content := `{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":` + jsonString(cwd) + `}` + "\n" +
 		`{"type":"message","id":"aaaaaaaa","parentId":null,"timestamp":"2026-05-06T00:00:01.000Z","message":{"role":"user","content":"hello","timestamp":1778025601000}}` + "\n"
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)

--- a/internal/server/pagination_test.go
+++ b/internal/server/pagination_test.go
@@ -29,7 +29,7 @@ func writeSessionWithNMessages(t *testing.T, root, project, name string, n int) 
 		t.Fatal(err)
 	}
 	var b strings.Builder
-	b.WriteString(`{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":"` + cwd + `"}` + "\n")
+	b.WriteString(`{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":` + jsonString(cwd) + `}` + "\n")
 	for i := 0; i < n; i++ {
 		fmt.Fprintf(&b, `{"type":"message","id":"id%06d","parentId":null,"timestamp":"2026-05-06T00:00:%02d.000Z","message":{"role":"user","content":"m%d"}}`+"\n", i, i%60, i)
 	}

--- a/internal/server/projects_test.go
+++ b/internal/server/projects_test.go
@@ -155,6 +155,10 @@ func TestHandleUpdateProject_FilterToggle(t *testing.T) {
 
 func TestHandleUpdateProject(t *testing.T) {
 	s := &Server{db: newProjectPrefsDB(t), now: time.Now}
+	// Real absolute paths: register/enable normalize and reject paths like
+	// "/a", which is not absolute on Windows.
+	pathA := filepath.Join(t.TempDir(), "a")
+	pathProj := filepath.Join(t.TempDir(), "proj")
 
 	post := func(path, action string) *httptest.ResponseRecorder {
 		body, _ := json.Marshal(map[string]string{"path": path, "action": action})
@@ -164,26 +168,26 @@ func TestHandleUpdateProject(t *testing.T) {
 		return w
 	}
 
-	if w := post("/a", "enable"); w.Code != http.StatusOK {
+	if w := post(pathA, "enable"); w.Code != http.StatusOK {
 		t.Fatalf("enable status = %d", w.Code)
 	}
-	if !enabledSet(t, s)["/a"] {
-		t.Fatal("/a should be enabled")
+	if !enabledSet(t, s)[pathA] {
+		t.Fatalf("%s should be enabled", pathA)
 	}
 
-	if w := post("/a", "disable"); w.Code != http.StatusOK {
+	if w := post(pathA, "disable"); w.Code != http.StatusOK {
 		t.Fatalf("disable status = %d", w.Code)
 	}
-	if enabledSet(t, s)["/a"] {
-		t.Fatal("/a should be disabled")
+	if enabledSet(t, s)[pathA] {
+		t.Fatalf("%s should be disabled", pathA)
 	}
 
 	// register stores the path with source=registered and enabled.
-	if w := post("/home/user/proj", "register"); w.Code != http.StatusOK {
+	if w := post(pathProj, "register"); w.Code != http.StatusOK {
 		t.Fatalf("register status = %d", w.Code)
 	}
 	var source string
-	if err := s.db.QueryRow("SELECT source FROM project_prefs WHERE project_path = ?", "/home/user/proj").Scan(&source); err != nil {
+	if err := s.db.QueryRow("SELECT source FROM project_prefs WHERE project_path = ?", pathProj).Scan(&source); err != nil {
 		t.Fatal(err)
 	}
 	if source != "registered" {
@@ -191,18 +195,18 @@ func TestHandleUpdateProject(t *testing.T) {
 	}
 
 	// remove deletes the row.
-	if w := post("/home/user/proj", "remove"); w.Code != http.StatusOK {
+	if w := post(pathProj, "remove"); w.Code != http.StatusOK {
 		t.Fatalf("remove status = %d", w.Code)
 	}
 	var count int
-	if err := s.db.QueryRow("SELECT COUNT(*) FROM project_prefs WHERE project_path = ?", "/home/user/proj").Scan(&count); err != nil {
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM project_prefs WHERE project_path = ?", pathProj).Scan(&count); err != nil {
 		t.Fatal(err)
 	}
 	if count != 0 {
 		t.Fatal("removed project should be gone")
 	}
 
-	if w := post("/a", "bogus"); w.Code != http.StatusBadRequest {
+	if w := post(pathA, "bogus"); w.Code != http.StatusBadRequest {
 		t.Fatalf("unknown action status = %d, want 400", w.Code)
 	}
 }
@@ -272,15 +276,18 @@ func TestHandleApiProjects(t *testing.T) {
 
 func TestNormalizeProjectPath(t *testing.T) {
 	home, _ := os.UserHomeDir()
+	// Platform-absolute fixtures: "/abs/path" is not absolute on Windows.
+	abs := filepath.Join(t.TempDir(), "abs", "path")
+	spaced := filepath.Join(t.TempDir(), "spaced")
 	cases := []struct {
 		in      string
 		want    string
 		wantErr bool
 	}{
-		{"/abs/path", "/abs/path", false},
-		{"/abs/path/", "/abs/path", false},
+		{abs, abs, false},
+		{abs + string(filepath.Separator), abs, false},
 		{"~/proj", filepath.Join(home, "proj"), false},
-		{"  /spaced  ", "/spaced", false},
+		{"  " + spaced + "  ", spaced, false},
 		{"relative/path", "", true},
 		{"", "", true},
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -29,6 +29,9 @@ func newTestServer(t *testing.T) *Server {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	// Close the server's sqlite handle before TempDir cleanup: Windows cannot
+	// delete a file that is still open.
+	t.Cleanup(s.Shutdown)
 	return s
 }
 
@@ -90,6 +93,7 @@ func TestCustomThemesPublicWhenAuthEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	t.Cleanup(s.Shutdown)
 	mux := http.NewServeMux()
 	s.Register(mux)
 

--- a/internal/server/session_test_helpers_test.go
+++ b/internal/server/session_test_helpers_test.go
@@ -1,10 +1,18 @@
 package server
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+// jsonString renders s as a JSON string literal (quotes included) so Windows
+// paths with backslashes stay valid inside string-built JSON fixtures.
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
 
 func writeSessionFile(t *testing.T, root, project, name string) string {
 	t.Helper()
@@ -17,7 +25,7 @@ func writeSessionFile(t *testing.T, root, project, name string) string {
 	if err := os.MkdirAll(cwd, 0755); err != nil {
 		t.Fatal(err)
 	}
-	content := `{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":"` + cwd + `"}` + "\n" +
+	content := `{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":` + jsonString(cwd) + `}` + "\n" +
 		`{"type":"message","id":"aaaaaaaa","parentId":null,"timestamp":"2026-05-06T00:00:01.000Z","message":{"role":"user","content":"hello","timestamp":1778025601000}}` + "\n"
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)

--- a/internal/sessions/session.go
+++ b/internal/sessions/session.go
@@ -595,8 +595,24 @@ func sessionHeaderKey(raw map[string]any) string {
 func cleanProjectName(dirName string) string {
 	s := strings.TrimPrefix(dirName, "--")
 	s = strings.TrimSuffix(s, "--")
+	if win, ok := decodeWindowsBody(s); ok {
+		return win
+	}
 	s = decodeProjectBody(s)
 	return s
+}
+
+// decodeWindowsBody reverses the Windows dash encoding (see
+// EncodeProjectName): both : and \ became -, so a drive letter is always
+// followed by two dashes. C--Users-me → C:\Users\me. Paths with literal
+// hyphens decode wrongly, exactly like the legacy Unix encoding; callers
+// recover via the session-header cwd (see resolveLocation).
+func decodeWindowsBody(s string) (string, bool) {
+	if len(s) >= 3 && s[1] == '-' && s[2] == '-' &&
+		(('A' <= s[0] && s[0] <= 'Z') || ('a' <= s[0] && s[0] <= 'z')) {
+		return s[:1] + `:\` + strings.ReplaceAll(s[3:], "-", `\`), true
+	}
+	return "", false
 }
 
 // EncodeProjectName converts an absolute filesystem path into a safe
@@ -605,8 +621,22 @@ func cleanProjectName(dirName string) string {
 //
 //	/home/user/my-project → --home_-user_-my-project--
 //	/home/user/_cache    → --home_-user_-__cache--
+//
+// Windows-shaped paths (drive letter or backslashes) instead mirror pi's own
+// encoding (dist/core/session-manager.js: strip one leading separator, then
+// map every /, \ and : to -), because the escape-based scheme would leave
+// : and \ in the name — both invalid in Windows directory names.
+//
+//	C:\Users\me\proj → --C--Users-me-proj--
 func EncodeProjectName(path string) string {
 	s := strings.TrimSpace(path)
+	if isWindowsPath(s) {
+		if len(s) > 0 && (s[0] == '/' || s[0] == '\\') {
+			s = s[1:]
+		}
+		s = strings.NewReplacer("/", "-", `\`, "-", ":", "-").Replace(s)
+		return "--" + s + "--"
+	}
 	s = strings.Trim(s, "/")
 	// Escape _ first, then /.  Order matters: we must double _ before we
 	// introduce any new _ in the / escape sequence.
@@ -615,12 +645,26 @@ func EncodeProjectName(path string) string {
 	return "--" + s + "--"
 }
 
+// isWindowsPath reports whether path is Windows-shaped: a drive letter
+// ("C:...") or any backslash separator. Keying off the path's shape rather
+// than runtime.GOOS keeps the encoding deterministic and testable everywhere.
+func isWindowsPath(path string) bool {
+	if len(path) >= 2 && path[1] == ':' &&
+		(('A' <= path[0] && path[0] <= 'Z') || ('a' <= path[0] && path[0] <= 'z')) {
+		return true
+	}
+	return strings.Contains(path, `\`)
+}
+
 // DecodeProjectName reverses EncodeProjectName.  It accepts both the
 // new escape-based encoding and the legacy encoding (where - meant /)
 // so that existing session directories continue to work.
 func DecodeProjectName(dirName string) string {
 	s := strings.TrimPrefix(dirName, "--")
 	s = strings.TrimSuffix(s, "--")
+	if win, ok := decodeWindowsBody(s); ok {
+		return win
+	}
 	s = decodeProjectBody(s)
 	if s != "" && !strings.HasPrefix(s, "/") {
 		s = "/" + s

--- a/internal/sessions/session_test.go
+++ b/internal/sessions/session_test.go
@@ -27,6 +27,12 @@ func TestEncodeProjectName(t *testing.T) {
 		{"/Users/setkyar/my-project", "--Users_-setkyar_-my-project--"},
 		{"/Users/setkyar/_cache", "--Users_-setkyar_-__cache--"},
 		{"/a/_b/_c", "--a_-__b_-__c--"},
+		// Windows-shaped paths mirror pi's encoding (/, \ and : all map to -)
+		// so the result is a valid Windows directory name.
+		{`C:\Users\me\proj`, "--C--Users-me-proj--"},
+		{`c:\work`, "--c--work--"},
+		{`C:/Users/me/proj`, "--C--Users-me-proj--"},
+		{`\\server\share\proj`, "---server-share-proj--"},
 	}
 	for _, tt := range tests {
 		got := EncodeProjectName(tt.input)
@@ -51,6 +57,11 @@ func TestDecodeProjectName(t *testing.T) {
 		{"--Users-setkyar--", "/Users/setkyar"},
 		{"--home-user-project--", "/home/user/project"},
 		{"--a-b-c-d--", "/a/b/c/d"},
+		// Windows dash encoding: drive letter followed by two dashes
+		// (both : and \ became -).
+		{"--C--Users-me-proj--", `C:\Users\me\proj`},
+		{"--c--work--", `c:\work`},
+		{"--C--my_app--", `C:\my_app`},
 	}
 	for _, tt := range tests {
 		got := DecodeProjectName(tt.input)
@@ -146,7 +157,9 @@ func TestListRecentLocationsReturnsNewestBoundedLocations(t *testing.T) {
 	base := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
 
 	for i := 0; i < 15; i++ {
-		project := filepath.Join("/tmp", fmt.Sprintf("project%02d", i))
+		// A plain literal, not filepath.Join: on Windows Join would produce
+		// backslash paths and the assertions below expect /tmp/projectNN.
+		project := fmt.Sprintf("/tmp/project%02d", i)
 		dir := filepath.Join(tmp, EncodeProjectName(project))
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			t.Fatalf("mkdir project dir: %v", err)
@@ -203,8 +216,10 @@ func TestListRecentLocationsRecoversLegacyHyphenatedPaths(t *testing.T) {
 func TestResolveLocationReturnsDecodedPathWhenOnDisk(t *testing.T) {
 	tmp := t.TempDir()
 
-	// Create a real project directory so os.Stat succeeds.
-	realPath := filepath.Join(tmp, "my-project")
+	// Create a real project directory so os.Stat succeeds. Hyphen-free name:
+	// on Windows the dash encoding can't round-trip literal hyphens, and this
+	// test exercises the decode-only path (no session file to recover from).
+	realPath := filepath.Join(tmp, "myproject")
 	if err := os.MkdirAll(realPath, 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +274,11 @@ func TestCreateSessionFile(t *testing.T) {
 	if !strings.Contains(string(data), `"type":"session"`) {
 		t.Fatalf("missing session header: %s", string(data))
 	}
-	if !strings.Contains(string(data), `"cwd":"`+projectPath+`"`) {
+	wantCwd, err := json.Marshal(projectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"cwd":`+string(wantCwd)) {
 		t.Fatalf("missing cwd: %s", string(data))
 	}
 }
@@ -682,7 +701,13 @@ func TestParseFileUsesHeaderCwdAsProject(t *testing.T) {
 		t.Fatal(err)
 	}
 	path := filepath.Join(root, "s.jsonl")
-	content := `{"type":"session","timestamp":"2026-05-08T10:00:00Z","cwd":"` + cwd + `"}` + "\n"
+	// json.Marshal the cwd: Windows paths contain backslashes, which are
+	// invalid JSON when concatenated raw.
+	cwdJSON, err := json.Marshal(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := `{"type":"session","timestamp":"2026-05-08T10:00:00Z","cwd":` + string(cwdJSON) + `}` + "\n"
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -698,7 +723,11 @@ func TestParseFileUsesHeaderCwdAsProject(t *testing.T) {
 func TestParseFileDeduplicatesRepeatedSessionHeader(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "session.jsonl")
-	header := `{"type":"session","id":"sid","timestamp":"2026-05-08T10:00:00Z","cwd":"` + root + `"}`
+	rootJSON, err := json.Marshal(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := `{"type":"session","id":"sid","timestamp":"2026-05-08T10:00:00Z","cwd":` + string(rootJSON) + `}`
 	content := header + "\n" +
 		header + "\n" +
 		`{"type":"message","id":"u1","parentId":"sid","timestamp":"2026-05-08T10:00:01Z","message":{"role":"user","content":"hello"}}` + "\n"
@@ -724,7 +753,11 @@ func TestParseFileLeavesChatEnabledWhenCwdExists(t *testing.T) {
 		t.Fatal(err)
 	}
 	path := filepath.Join(root, "session.jsonl")
-	content := `{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":"` + cwd + `"}` + "\n"
+	cwdJSON, err := json.Marshal(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := `{"type":"session","version":3,"id":"sid","timestamp":"2026-05-06T00:00:00.000Z","cwd":` + string(cwdJSON) + `}` + "\n"
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Part 1 of 2 for #94 (Windows support). Go core + CI/release only; the installer/auto-start/docs follow in the stacked PR.

## Changes

- **State-file locking**: `lockStateFile` on Windows is now an exclusive non-blocking `LockFileEx` (via `golang.org/x/sys/windows`, promoted to a direct dependency) instead of a no-op, so concurrent instances can't corrupt `pi-web-state.json`. The lock test now exercises `lockStateFile` itself and runs on all platforms (previously `//go:build !windows`).
- **Self-update restart**: `runRestart()` gains a Windows branch. There's no service manager to lean on, so a detached hidden PowerShell helper waits for this process to exit (guaranteed within 5s by the existing fallback timer), then relaunches via the launcher that `install.ps1` writes (next PR), falling back to the bare executable for manual installs. `detachSession` on Windows now actually detaches (`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`).
- **CI**: new `windows-latest` job running `go test` + `go vet` on a real Windows toolchain (frontend build only to satisfy `//go:embed`; the full check suite stays on ubuntu).
- **Release**: add `windows/arm64` binaries — pi itself ships Windows ARM64 support, and the existing build step already handles the `.exe` suffix.

## Testing

- `make check` passes
- `GOOS=windows GOARCH=amd64|arm64 go build ./...` and `GOOS=windows go vet ./...` clean
- Not yet smoke-tested on a real Windows machine (tracked in #94)