### PR TITLE
feat(windows): PowerShell installer, Run-key auto-start, extension + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,18 @@ jobs:
       - name: Go vet
         run: go vet ./...
 
+      - name: Parse-check PowerShell installer
+        shell: pwsh
+        run: |
+          $errs = $null
+          foreach ($f in 'install.ps1', 'uninstall.ps1') {
+            [System.Management.Automation.Language.Parser]::ParseFile($f, [ref]$null, [ref]$errs) | Out-Null
+            if ($errs.Count -gt 0) {
+              $errs | ForEach-Object { Write-Error "${f}: $($_.Message)" }
+              exit 1
+            }
+          }
+
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest

--- a/.pi/extensions/pi-web.ts
+++ b/.pi/extensions/pi-web.ts
@@ -16,6 +16,7 @@ import {
   accessSync,
   chmodSync,
   constants as fsConstants,
+  existsSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -211,7 +212,24 @@ async function healthCheck(host: string, port: string): Promise<boolean> {
   }
 }
 
+// windowsLauncher is the hidden startup launcher written by install.ps1; it
+// loads ~/.config/pi-web/env and starts pi-web without a console window.
+function windowsLauncher(): string {
+  return join(homedir(), ".config", "pi-web", "pi-web-start.vbs");
+}
+
 async function startPiWeb(pi: ExtensionAPI): Promise<void> {
+  if (process.platform === "win32") {
+    const launcher = windowsLauncher();
+    if (!existsSync(launcher)) {
+      throw new Error(
+        "pi-web launcher not found; reinstall with: pi install npm:@ygncode/pi-web@beta",
+      );
+    }
+    await pi.exec("wscript.exe", [launcher]);
+    return;
+  }
+
   if (process.platform === "darwin") {
     await pi.exec("sh", [
       "-lc",
@@ -226,11 +244,18 @@ async function startPiWeb(pi: ExtensionAPI): Promise<void> {
   }
 
   throw new Error(
-    "auto-start is only supported on macOS launchd or Linux systemd user services",
+    "auto-start is only supported on macOS launchd, Linux systemd user services, or the Windows launcher",
   );
 }
 
 async function stopPiWeb(pi: ExtensionAPI): Promise<void> {
+  if (process.platform === "win32") {
+    // No service manager on Windows; the Run-key launcher only starts pi-web,
+    // so stopping means killing the process directly (the pkill counterpart).
+    await pi.exec("taskkill", ["/IM", "pi-web.exe", "/F"]).catch(() => {});
+    return;
+  }
+
   if (process.platform === "darwin") {
     await pi.exec("sh", [
       "-lc",
@@ -250,6 +275,12 @@ async function stopPiWeb(pi: ExtensionAPI): Promise<void> {
 }
 
 async function restartPiWeb(pi: ExtensionAPI): Promise<void> {
+  if (process.platform === "win32") {
+    await stopPiWeb(pi);
+    await startPiWeb(pi);
+    return;
+  }
+
   if (process.platform === "darwin") {
     await pi.exec("sh", [
       "-lc",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm downloads](https://img.shields.io/npm/dw/@ygncode/pi-web?label=downloads/wk&color=2ea043&cacheSeconds=86400)](https://www.npmjs.com/package/@ygncode/pi-web)
 [![license MIT](https://img.shields.io/npm/l/@ygncode/pi-web?label=license&color=0a7bbb&cacheSeconds=86400)](LICENSE)
 [![Telegram](https://img.shields.io/badge/Telegram-Join-26A5E4?logo=telegram&logoColor=white)](https://t.me/+NJvFOTTa0wNjNTc9)
-![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-555)
+![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-555)
 
 **English** · [Español](user-docs/readme/README.es.md) · [Français](user-docs/readme/README.fr.md) · [Deutsch](user-docs/readme/README.de.md) · [中文](user-docs/readme/README.zh.md) · [日本語](user-docs/readme/README.ja.md) · [Bahasa Indonesia](user-docs/readme/README.id.md) · [Bahasa Melayu](user-docs/readme/README.ms.md) · [Tiếng Việt](user-docs/readme/README.vi.md) · [ไทย](user-docs/readme/README.th.md) · [Filipino](user-docs/readme/README.fil.md) · [မြန်မာ](user-docs/readme/README.my.md) · [ភាសាខ្មែរ](user-docs/readme/README.km.md) · [ລາວ](user-docs/readme/README.lo.md)
 
@@ -98,6 +98,7 @@ The `pi install npm:@ygncode/pi-web@beta` command sets this up automatically:
 |----|-----------|
 | macOS | launchd plist at `~/Library/LaunchAgents/com.pi-web.plist` |
 | Linux | systemd user service at `~/.config/systemd/user/pi-web.service` |
+| Windows | `HKCU` Run-key entry launching a hidden starter in `~/.config/pi-web/` |
 
 To set a token for remote access, create `~/.config/pi-web/env`:
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,230 @@
+# pi-web installer for Windows — downloads the binary and sets up auto-start.
+#
+# Standalone (no pi required):
+#   irm https://raw.githubusercontent.com/ygncode/pi-web/main/install.ps1 | iex
+#
+# Via pi package (also registers /web, /remote commands):
+#   pi install npm:@ygncode/pi-web@beta
+#
+# Updates are handled by re-running the same command.
+#
+# Auto-start model (the Windows counterpart of install.sh's launchd/systemd
+# setup, kept admin-free): a HKCU Run-key entry launches pi-web-start.vbs at
+# login, which runs pi-web-start.ps1 without a console window; the .ps1 loads
+# ~/.config/pi-web/env (PI_WEB_TOKEN, PATH, ...) and starts the binary hidden.
+# Requires the pi CLI plus a bash for pi's shell tool (Git Bash is enough —
+# see pi's docs/windows.md).
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$Repo = 'ygncode/pi-web'
+if ($env:PI_WEB_INSTALL_DIR) {
+  $InstallDir = $env:PI_WEB_INSTALL_DIR
+} else {
+  # No sudo-writable /usr/local/bin equivalent on Windows; the pi agent bin
+  # dir works for both npm-lifecycle and standalone installs without elevation.
+  $InstallDir = Join-Path $HOME '.pi\agent\bin'
+}
+$Binary = Join-Path $InstallDir 'pi-web.exe'
+$VersionFile = Join-Path $HOME '.pi\agent\pi-web-version'
+$ConfigDir = Join-Path $HOME '.config\pi-web'
+$EnvFile = Join-Path $ConfigDir 'env'
+$LauncherPs1 = Join-Path $ConfigDir 'pi-web-start.ps1'
+$LauncherVbs = Join-Path $ConfigDir 'pi-web-start.vbs'
+$RunKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+
+function Info($msg) { Write-Host "-> $msg" }
+function Warn($msg) { Write-Host "!  $msg" -ForegroundColor Yellow }
+
+function Get-Arch {
+  $arch = "$env:PROCESSOR_ARCHITECTURE"
+  # An x64 PowerShell on ARM64 reports AMD64; prefer the OS architecture.
+  try { $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString() } catch {}
+  switch -Regex ($arch) {
+    '^(ARM64|Arm64)$' { return 'arm64' }
+    '^(AMD64|X64|x64)$' { return 'amd64' }
+    default { throw "Unsupported architecture: $arch" }
+  }
+}
+
+function Get-PackageTag {
+  # When running as an npm lifecycle script, install the binary that matches
+  # the npm package version so pinned installs stay pinned (see install.sh).
+  if ($env:npm_package_name -eq '@ygncode/pi-web' -and $env:npm_package_version) {
+    return 'v' + $env:npm_package_version.TrimStart('v')
+  }
+  return $null
+}
+
+function Get-LatestTag {
+  try {
+    $rel = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest"
+    if ($rel.tag_name) { return $rel.tag_name }
+  } catch {}
+  # /latest ignores prereleases. Fall back to the newest release of any type
+  # (GitHub orders by creation date; install.sh sorts by semver instead).
+  $rels = @(Invoke-RestMethod "https://api.github.com/repos/${Repo}/releases?per_page=1")
+  if ($rels.Count -gt 0 -and $rels[0].tag_name) { return $rels[0].tag_name }
+  throw "Could not determine latest release tag from $Repo."
+}
+
+function Get-InstalledVersion {
+  if (Test-Path $Binary) {
+    try {
+      $v = & $Binary -version 2>$null
+      if ($v) { return "$v".Trim() }
+    } catch {}
+  }
+  # Binary missing or not runnable (e.g. partial install); fall back to the
+  # version file.
+  if (Test-Path $VersionFile) { return (Get-Content $VersionFile -First 1) }
+  return $null
+}
+
+function Get-Binary($arch, $tag) {
+  $asset = "pi-web-windows-$arch.exe"
+  $url = "https://github.com/$Repo/releases/download/$tag/$asset"
+  Info "Downloading pi-web $tag (windows-$arch)..."
+  Info "  $url"
+  $tmpDir = Join-Path ([IO.Path]::GetTempPath()) ('pi-web-' + [IO.Path]::GetRandomFileName())
+  New-Item -ItemType Directory -Path $tmpDir | Out-Null
+  $dest = Join-Path $tmpDir 'pi-web.exe'
+  Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+  return $dest
+}
+
+function Stop-PiWeb {
+  # Stop the running instance before swapping the binary. Skipped for in-place
+  # self-updates: pi-web spawned this script (via `pi install`) and restarts
+  # itself afterward (see internal/app/update.go).
+  Get-Process -Name 'pi-web' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+  Start-Sleep -Seconds 1
+}
+
+function Install-Binary($src, $tag) {
+  New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+  # A running executable cannot be overwritten on Windows, but it can be
+  # renamed: move the old binary aside, move the new one into place, then try
+  # to delete the leftover (harmlessly fails while the old process still runs;
+  # the next install removes it).
+  $old = "$Binary.old"
+  Remove-Item $old -Force -ErrorAction SilentlyContinue
+  if (Test-Path $Binary) { Move-Item $Binary $old -Force }
+  Move-Item $src $Binary -Force
+  Remove-Item $old -Force -ErrorAction SilentlyContinue
+
+  New-Item -ItemType Directory -Force -Path (Split-Path $VersionFile) | Out-Null
+  Set-Content -Path $VersionFile -Value $tag
+  Info "pi-web $tag installed to $Binary"
+}
+
+function Set-EnvFileVar($file, $key, $value) {
+  $lines = @()
+  if (Test-Path $file) { $lines = @(Get-Content $file) }
+  $found = $false
+  $lines = @($lines | ForEach-Object {
+    if ($_ -match ('^' + [regex]::Escape($key) + '=')) { $found = $true; "$key=$value" } else { $_ }
+  })
+  if (-not $found) { $lines += "$key=$value" }
+  Set-Content -Path $file -Value $lines
+}
+
+function Initialize-EnvFile {
+  New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
+  if (-not (Test-Path $EnvFile)) { New-Item -ItemType File -Path $EnvFile | Out-Null }
+
+  $hasToken = Select-String -Path $EnvFile -Pattern '^PI_WEB_TOKEN=' -Quiet
+  if (-not $env:PI_WEB_TOKEN -and -not $hasToken) {
+    $bytes = New-Object byte[] 16
+    [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
+    $token = -join ($bytes | ForEach-Object { $_.ToString('x2') })
+    Set-EnvFileVar $EnvFile 'PI_WEB_TOKEN' $token
+    Info "Generated PI_WEB_TOKEN in $EnvFile"
+    Warn "Use this token when opening pi-web from another device: $token"
+  }
+
+  # Persist PI_CODING_AGENT_DIR so auto-started pi-web finds the right sessions.
+  if ($env:PI_CODING_AGENT_DIR) { Set-EnvFileVar $EnvFile 'PI_CODING_AGENT_DIR' $env:PI_CODING_AGENT_DIR }
+
+  # The Run-key launcher starts with the login default environment. Preserve
+  # the install-time PATH so pi-web can find `pi` for browser chat.
+  Set-EnvFileVar $EnvFile 'PATH' $env:Path
+}
+
+function Initialize-Autostart {
+  New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
+
+  $ps1 = @"
+# Generated by pi-web install.ps1 — starts pi-web hidden with the environment
+# from the env file (PI_WEB_TOKEN, PATH, ...). Regenerated on every install.
+`$envFile = '$EnvFile'
+if (Test-Path `$envFile) {
+  foreach (`$line in Get-Content `$envFile) {
+    if (`$line -match '^\s*#' -or `$line -notmatch '=') { continue }
+    `$name, `$value = `$line -split '=', 2
+    Set-Item -Path ('Env:' + `$name) -Value `$value
+  }
+}
+Start-Process -FilePath '$Binary' -WindowStyle Hidden
+"@
+  Set-Content -Path $LauncherPs1 -Value $ps1
+
+  # wscript runs the PowerShell launcher with window style 0 so login does not
+  # flash a console window.
+  $vbs = 'CreateObject("WScript.Shell").Run "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File ""' + $LauncherPs1 + '""", 0, False'
+  Set-Content -Path $LauncherVbs -Value $vbs
+
+  Set-ItemProperty -Path $RunKey -Name 'pi-web' -Value ('wscript.exe "' + $LauncherVbs + '"')
+  Info 'Windows auto-start configured (Run key + hidden launcher)'
+}
+
+function Start-PiWeb {
+  Start-Process -FilePath 'wscript.exe' -ArgumentList ('"' + $LauncherVbs + '"')
+}
+
+function Main {
+  Write-Host ''
+  Info 'pi-web installer (Windows)'
+  Write-Host ''
+
+  $arch = Get-Arch
+
+  $tag = Get-PackageTag
+  if ($tag) { Info "Using pi-web package version $tag." } else { $tag = Get-LatestTag }
+
+  $installed = Get-InstalledVersion
+  if ((Test-Path $Binary) -and $installed -eq $tag) {
+    Info "Already up-to-date ($tag)."
+    Write-Host ''
+    return
+  }
+  if ($installed) { Info "Update available: $installed -> $tag" }
+
+  $tmpBinary = Get-Binary $arch $tag
+
+  $inplace = [bool]$env:PI_WEB_INPLACE_UPDATE
+  if ((Test-Path $Binary) -and -not $inplace) { Stop-PiWeb }
+
+  Install-Binary $tmpBinary $tag
+
+  # In-place self-update: pi-web triggered this and restarts itself afterward.
+  # Skip env/auto-start setup so we don't kill the npm process running this
+  # script or clobber the launcher's PATH.
+  if ($inplace) {
+    Info "Binary updated to $tag; pi-web will restart to apply it."
+    Write-Host ''
+    return
+  }
+
+  Initialize-EnvFile
+  Initialize-Autostart
+
+  Info 'pi-web will listen on localhost; if Tailscale is running, it will publish HTTPS with Tailscale Serve.'
+  Start-PiWeb
+
+  Info "Done! pi-web $tag is ready."
+  Write-Host ''
+}
+
+Main

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     ]
   },
   "scripts": {
-    "postinstall": "bash install.sh",
-    "preuninstall": "bash uninstall.sh",
+    "postinstall": "node scripts/run-lifecycle.mjs install",
+    "preuninstall": "node scripts/run-lifecycle.mjs uninstall",
     "test:extensions": "vitest run --config tests/extensions/vitest.config.ts"
   },
   "dependencies": {

--- a/scripts/run-lifecycle.mjs
+++ b/scripts/run-lifecycle.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// npm lifecycle dispatcher: npm runs scripts through cmd.exe on Windows, where
+// `bash install.sh` is unavailable. Route to the PowerShell port there and to
+// the bash scripts everywhere else.
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const action = process.argv[2];
+if (action !== 'install' && action !== 'uninstall') {
+  console.error('usage: run-lifecycle.mjs install|uninstall');
+  process.exit(2);
+}
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const result =
+  process.platform === 'win32'
+    ? spawnSync(
+        'powershell.exe',
+        ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', join(root, `${action}.ps1`)],
+        { stdio: 'inherit' },
+      )
+    : spawnSync('bash', [join(root, `${action}.sh`)], { stdio: 'inherit' });
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,80 @@
+# pi-web uninstaller for Windows — removes binary, auto-start, and runtime
+# state. Triggered as npm preuninstall hook when `pi remove npm:@ygncode/pi-web@beta`
+# is run. The npm package directory itself is removed by npm after this script.
+#
+# Kept intact (survives uninstall — preserves data for reinstall):
+#   - ~/.pi/agent/pi-web.sqlite          (settings, scratchpads, project prefs)
+#   - ~/.pi/agent/pi-web-memory.sqlite   (memory skill data)
+#   - ~/.config/pi-web/env               (PI_WEB_TOKEN, PATH, etc.)
+#   - ~/.pi/agent/sessions/              (session files)
+
+$ErrorActionPreference = 'Continue'
+
+if ($env:PI_WEB_INSTALL_DIR) {
+  $Binary = Join-Path $env:PI_WEB_INSTALL_DIR 'pi-web.exe'
+} else {
+  $Binary = Join-Path $HOME '.pi\agent\bin\pi-web.exe'
+}
+$ConfigDir = Join-Path $HOME '.config\pi-web'
+$RunKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+
+function Info($msg) { Write-Host "-> $msg" }
+function Skip($msg) { Write-Host "   (skipped) $msg" }
+
+Write-Host ''
+Info 'pi-web uninstaller (Windows)'
+Write-Host ''
+
+# Stop running instance
+$proc = Get-Process -Name 'pi-web' -ErrorAction SilentlyContinue
+if ($proc) {
+  Info 'Stopping running pi-web instance...'
+  $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+  Start-Sleep -Seconds 1
+}
+
+# Remove binary (and any leftover from a previous swap)
+if (Test-Path $Binary) {
+  Info "Removing binary: $Binary"
+  Remove-Item $Binary -Force -ErrorAction SilentlyContinue
+} else {
+  Skip "binary not found at $Binary"
+}
+Remove-Item "$Binary.old" -Force -ErrorAction SilentlyContinue
+
+# Remove version file
+$versionFile = Join-Path $HOME '.pi\agent\pi-web-version'
+if (Test-Path $versionFile) {
+  Info "Removing version file: $versionFile"
+  Remove-Item $versionFile -Force
+} else {
+  Skip 'version file not found'
+}
+
+# Remove runtime state
+$stateFile = Join-Path $HOME '.pi\agent\pi-web\pi-web-state.json'
+if (Test-Path $stateFile) {
+  Info "Removing state file: $stateFile"
+  Remove-Item $stateFile -Force
+} else {
+  Skip 'state file not found'
+}
+$stateDir = Join-Path $HOME '.pi\agent\pi-web'
+if ((Test-Path $stateDir) -and -not (Get-ChildItem $stateDir)) {
+  Remove-Item $stateDir -Force
+}
+
+# Clean up stale npm temp dirs
+$temps = @(Get-Item (Join-Path $HOME '.pi\agent\npm\node_modules\@ygncode\.pi-web-*') -ErrorAction SilentlyContinue)
+foreach ($t in $temps) { Remove-Item $t.FullName -Recurse -Force -ErrorAction SilentlyContinue }
+if ($temps.Count -gt 0) { Info "Cleaned up $($temps.Count) stale npm temp dir(s)" }
+
+# Remove auto-start (Run key + hidden launcher; the env file is kept)
+Remove-ItemProperty -Path $RunKey -Name 'pi-web' -ErrorAction SilentlyContinue
+Remove-Item (Join-Path $ConfigDir 'pi-web-start.ps1') -Force -ErrorAction SilentlyContinue
+Remove-Item (Join-Path $ConfigDir 'pi-web-start.vbs') -Force -ErrorAction SilentlyContinue
+Info 'Removed Windows auto-start (Run key + launcher)'
+
+Info 'pi-web service and binary removed.'
+Info 'Data preserved: ~/.pi/agent/pi-web.sqlite, ~/.pi/agent/pi-web-memory.sqlite, ~/.config/pi-web/env'
+Write-Host ''

--- a/user-docs/en/install.md
+++ b/user-docs/en/install.md
@@ -23,9 +23,10 @@
 
 ## Requirements
 
-- [Go](https://go.dev) 1.25+
+- [Go](https://go.dev) 1.25+ (only for building from source)
 - `pi` on your `PATH` for browser chat/model switching
 - Optional: `gh` for sharing
+- On Windows: pi needs a bash shell for its shell tool — [Git for Windows](https://git-scm.com/download/win) is enough (see pi's Windows docs)
 
 ## Install
 
@@ -37,10 +38,10 @@ pi install npm:@ygncode/pi-web@beta
 
 This single command:
 - Installs the npm pi package under pi's package directory
-- Runs the package `postinstall` script (`bash install.sh`)
+- Runs the package `postinstall` script (`install.sh`, or `install.ps1` on Windows)
 - Downloads the matching pi-web binary for your package version and platform from GitHub Releases
-- Installs it to `~/.pi/agent/bin/pi-web`
-- Sets up auto-start on login (launchd on macOS, systemd on Linux)
+- Installs it to `~/.pi/agent/bin/pi-web` (`pi-web.exe` on Windows)
+- Sets up auto-start on login (launchd on macOS, systemd on Linux, a Run-key launcher on Windows)
 - Registers the `/web`, `/remote`, `/refresh`, `/pi-web token`, and `/pi-web set-token` pi commands
 
 Session auto-titling is built into pi-web (not the extension) and configured on the `/settings` page. It's on by default: pi-web names sessions automatically using a free built-in word heuristic (no AI), re-titling on every new message. You can switch to titling once per session, and/or pick a model to write smarter titles instead of the heuristic.
@@ -64,11 +65,19 @@ pi install npm:@ygncode/pi-web@beta
 
 ### Quick install (no build tools needed)
 
+macOS / Linux:
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/ygncode/pi-web/main/install.sh | bash
 ```
 
-This downloads the latest pi-web binary, installs it to `/usr/local/bin`, and sets up auto-start on login. No Go, Node, or pi required.
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/ygncode/pi-web/main/install.ps1 | iex
+```
+
+This downloads the latest pi-web binary, installs it to `/usr/local/bin` (`~/.pi/agent/bin` on Windows), and sets up auto-start on login. No Go, Node, or pi required.
 
 ### Download binary
 
@@ -90,6 +99,14 @@ chmod +x pi-web
 # Linux (arm64)
 curl -L -o pi-web https://github.com/ygncode/pi-web/releases/latest/download/pi-web-linux-arm64
 chmod +x pi-web
+```
+
+```powershell
+# Windows (x64)
+irm -OutFile pi-web.exe https://github.com/ygncode/pi-web/releases/latest/download/pi-web-windows-amd64.exe
+
+# Windows (ARM64)
+irm -OutFile pi-web.exe https://github.com/ygncode/pi-web/releases/latest/download/pi-web-windows-arm64.exe
 ```
 
 Then move it to your PATH:
@@ -122,13 +139,13 @@ by hand, run `npm --prefix web install && npm --prefix web run build` before
 pi remove npm:@ygncode/pi-web@beta
 ```
 
-This runs the package `preuninstall` script (`bash uninstall.sh`), which stops
-the running instance and removes:
+This runs the package `preuninstall` script (`uninstall.sh`, or `uninstall.ps1`
+on Windows), which stops the running instance and removes:
 
 - the pi-web binary (`~/.pi/agent/bin/pi-web`, or `/usr/local/bin/pi-web` for standalone installs)
 - the version file (`~/.pi/agent/pi-web-version`)
 - the runtime state file (`~/.pi/agent/pi-web/pi-web-state.json`)
-- the auto-start config (launchd plist on macOS, systemd user service on Linux)
+- the auto-start config (launchd plist on macOS, systemd user service on Linux, Run-key entry + launcher scripts on Windows)
 
 Your data is preserved so a later reinstall picks up where you left off:
 `~/.pi/agent/pi-web.sqlite`, `~/.pi/agent/pi-web-memory.sqlite`, your session
@@ -235,3 +252,26 @@ journalctl --user -u pi-web.service -f
 
 > For the service to start at boot (before login), use a system service instead:
 > copy `init/pi-web.service` to `/etc/systemd/system/` and use `sudo systemctl`.
+
+### Windows
+
+The installer configures this automatically, without needing admin rights: a
+`pi-web` entry under `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`
+launches `~/.config/pi-web/pi-web-start.vbs` at login, which starts the binary
+hidden (no console window) after loading `~/.config/pi-web/env`
+(`PI_WEB_TOKEN`, `PATH`, ...).
+
+To manage it by hand:
+
+```powershell
+# Start / stop
+wscript.exe "$HOME\.config\pi-web\pi-web-start.vbs"
+taskkill /IM pi-web.exe /F
+
+# Remove auto-start
+Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'pi-web'
+```
+
+There is no service supervision on Windows: if pi-web crashes it stays down
+until the next login (launchd/systemd restart it automatically on the other
+platforms).


### PR DESCRIPTION
Part 2 of 2 for #94, **stacked on #95** (base is `windows-go-core`; retarget to `main` once #95 merges). Completes the Windows install story.

## Changes

- **`install.ps1`** — full port of `install.sh`: arch detection (amd64/arm64), pinned-or-latest release download, rename-aside binary swap (a running exe can't be overwritten on Windows), token/env setup in `~/.config/pi-web/env`, and the `PI_WEB_INPLACE_UPDATE` self-update path. Also works standalone: `irm .../install.ps1 | iex`.
- **Auto-start without admin rights** — a `HKCU` Run-key entry launches `pi-web-start.vbs` at login, which runs a hidden PowerShell launcher that loads the env file and starts the binary with no console window. This is the closest admin-free counterpart to launchd/systemd; the trade-off (no crash supervision) is documented.
- **`uninstall.ps1`** — mirrors `uninstall.sh` including the keep-data policy (sqlite DBs, env file, sessions survive reinstall).
- **npm lifecycle dispatcher** — `scripts/run-lifecycle.mjs` routes postinstall/preuninstall to bash or PowerShell per platform; npm runs scripts through cmd.exe on Windows, where `bash install.sh` fails outright.
- **Extension** — `/web` auto-start and `/pi-web start|stop|restart` get win32 branches (launcher for start, `taskkill` for stop).
- **CI** — the Windows job parse-checks both `.ps1` scripts (no `pwsh` available locally, so CI is the syntax gate).
- **Docs** — README badge + auto-start table row; install guide gets PowerShell quick-install, Windows binary downloads, an auto-start section, and the Git Bash prerequisite for pi.

## Not included

- Translation regeneration (`scripts/build_readmes.py` / `scripts/build_userdocs.py`) — deferred until the English text is final; the scripts are non-incremental (~100+ `pi` calls).
- Real-Windows smoke test (tracked in #94): installer end-to-end, login auto-start, `pi --mode rpc` through the npm `pi.cmd` shim.

## Testing

- `make check` passes (includes extension tests over `pi-web.ts` and the `install.sh` in-place update test, which is unaffected)
- PowerShell syntax validated by the new CI parse-check step