### PR TITLE
fix(chat): report running while a send is spawning its worker (steer/queue E2E flake)

### DIFF
--- a/e2e/tests/steer-queue.spec.ts
+++ b/e2e/tests/steer-queue.spec.ts
@@ -312,6 +312,12 @@ test.describe("steer / queue (stubbed pi)", () => {
     });
     const items = await queueThree(page, textarea, testInfo, "enter");
 
+    // The stub echoes the steered message into the JSONL immediately, and the
+    // chip auto-clears on the resulting reload (reconcileSteersAgainstEntries)
+    // — often faster than the assertions below can run. Stall the cleanup so
+    // the steer row is reliably observable, like the other steer-row tests.
+    const release = await suspendChipCleanup(page);
+
     // Skip ahead to the third item.
     await page.keyboard.press("ArrowDown");
     await page.keyboard.press("ArrowDown");
@@ -324,6 +330,8 @@ test.describe("steer / queue (stubbed pi)", () => {
     // The first two are still queued (in order).
     const queuedTexts = await page.locator(".pi-queue-item:not(.pi-queue-item--steer) .pi-queue-item-text").allTextContents();
     expect(queuedTexts).toEqual([items[0], items[1]]);
+
+    await release();
 
     // The sent message also reaches the conversation as a "Stub reply".
     await expect(page.locator("#messages")).toContainText(`Stub reply: ${items[2]}`, {

--- a/internal/workers/manager.go
+++ b/internal/workers/manager.go
@@ -74,6 +74,14 @@ type Manager struct {
 	creating map[string]*createCall
 	factory  Factory
 
+	// pendingSends counts Send calls that have been accepted but whose prompt
+	// has not been acked yet. Spawning a worker (process start + switch_session
+	// + get_state) can take seconds, and the worker only reports Running once
+	// Prompt lands — without this, Status dips to idle mid-send, letting the
+	// queue drainer dispatch queued items into a run that is still starting and
+	// making status polls fire a spurious idle transition.
+	pendingSends map[string]int
+
 	idleTTL    time.Duration
 	reaperStop chan struct{}
 	reaperDone chan struct{}
@@ -97,12 +105,13 @@ func NewManager(factory Factory) *Manager {
 // idle TTL. A non-positive ttl disables reaping.
 func NewManagerWithTTL(factory Factory, ttl time.Duration) *Manager {
 	m := &Manager{
-		workers:    make(map[string]ChatWorker),
-		creating:   make(map[string]*createCall),
-		factory:    factory,
-		idleTTL:    ttl,
-		reaperStop: make(chan struct{}),
-		reaperDone: make(chan struct{}),
+		workers:      make(map[string]ChatWorker),
+		creating:     make(map[string]*createCall),
+		factory:      factory,
+		pendingSends: make(map[string]int),
+		idleTTL:      ttl,
+		reaperStop:   make(chan struct{}),
+		reaperDone:   make(chan struct{}),
 	}
 	if ttl > 0 {
 		go m.reapLoop()
@@ -154,6 +163,19 @@ func (m *Manager) reapOnce(now time.Time) {
 }
 
 func (m *Manager) Send(ctx context.Context, sessionID, sessionPath string, chat chat.Request) error {
+	m.mu.Lock()
+	m.pendingSends[sessionID]++
+	m.mu.Unlock()
+	defer func() {
+		// By the time Prompt returns (acked), the worker itself reports
+		// Running, so the pending mark and the worker status overlap and the
+		// session never observably dips to idle mid-send.
+		m.mu.Lock()
+		if m.pendingSends[sessionID]--; m.pendingSends[sessionID] <= 0 {
+			delete(m.pendingSends, sessionID)
+		}
+		m.mu.Unlock()
+	}()
 	worker, err := m.workerFor(sessionID, sessionPath)
 	if err != nil {
 		return err
@@ -190,12 +212,20 @@ func (m *Manager) Snapshot() []WorkerSnapshot {
 
 func (m *Manager) Status(sessionID string) WorkerStatus {
 	m.mu.Lock()
+	pending := m.pendingSends[sessionID] > 0
 	worker := m.workers[sessionID]
 	m.mu.Unlock()
 	if worker == nil {
+		if pending {
+			return WorkerStatus{State: WorkerStateRunning}
+		}
 		return WorkerStatus{State: WorkerStateIdle}
 	}
-	return worker.Status()
+	status := worker.Status()
+	if pending && status.State == WorkerStateIdle {
+		status.State = WorkerStateRunning
+	}
+	return status
 }
 
 func (m *Manager) SetModel(ctx context.Context, sessionID, sessionPath, provider, modelID string) error {

--- a/internal/workers/manager_test.go
+++ b/internal/workers/manager_test.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -124,6 +125,48 @@ func TestManagerReportsMissingWorkerIdle(t *testing.T) {
 	}
 }
 
+func TestManagerStatusReportsRunningWhileSendSpawnsWorker(t *testing.T) {
+	spawnStarted := make(chan struct{})
+	releaseSpawn := make(chan struct{})
+	manager := NewManager(func(string, string) (ChatWorker, error) {
+		close(spawnStarted)
+		<-releaseSpawn
+		return &fakeChatWorker{}, nil
+	})
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- manager.Send(context.Background(), "a.jsonl", "/tmp/a.jsonl", chat.Request{Message: "hi"})
+	}()
+	<-spawnStarted
+	// The worker is still spawning: without the pending-send mark this would
+	// report idle and the queue drainer would dispatch queued items into the
+	// still-starting run.
+	if status := manager.Status("a.jsonl"); status.State != WorkerStateRunning {
+		t.Fatalf("status during worker spawn = %q, want running", status.State)
+	}
+	close(releaseSpawn)
+	if err := <-sendDone; err != nil {
+		t.Fatal(err)
+	}
+	// The worker's own Running status has taken over by the time the pending
+	// mark is released — no observable idle dip.
+	if status := manager.Status("a.jsonl"); status.State != WorkerStateRunning {
+		t.Fatalf("status after prompt ack = %q, want running", status.State)
+	}
+}
+
+func TestManagerStatusIdleAfterFailedSend(t *testing.T) {
+	manager := NewManager(func(string, string) (ChatWorker, error) {
+		return nil, errors.New("spawn failed")
+	})
+	if err := manager.Send(context.Background(), "a.jsonl", "/tmp/a.jsonl", chat.Request{Message: "hi"}); err == nil {
+		t.Fatal("Send should surface the spawn error")
+	}
+	if status := manager.Status("a.jsonl"); status.State != WorkerStateIdle {
+		t.Fatalf("status after failed send = %q, want idle", status.State)
+	}
+}
+
 func TestManagerEvictsErroredWorker(t *testing.T) {
 	created := 0
 	factory := func(sessionID, sessionPath string) (ChatWorker, error) {
@@ -234,9 +277,9 @@ func (runningReapable) GetState(ctx context.Context) (WorkerStatus, error) {
 	return WorkerStatus{State: WorkerStateRunning}, nil
 }
 func (runningReapable) GetCommands(ctx context.Context) ([]SlashCommand, error) { return nil, nil }
-func (runningReapable) Status() WorkerStatus                  { return WorkerStatus{State: WorkerStateRunning} }
-func (runningReapable) Close() error                          { return nil }
-func (runningReapable) IdleSince(now time.Time) time.Duration { return time.Hour }
+func (runningReapable) Status() WorkerStatus                                    { return WorkerStatus{State: WorkerStateRunning} }
+func (runningReapable) Close() error                                            { return nil }
+func (runningReapable) IdleSince(now time.Time) time.Duration                   { return time.Hour }
 
 type erroredWorker struct{}
 
@@ -262,7 +305,7 @@ type inspectableWorker struct {
 	status    WorkerStatus
 }
 
-func (w *inspectableWorker) Prompt(context.Context, chat.Request) error    { return nil }
+func (w *inspectableWorker) Prompt(context.Context, chat.Request) error     { return nil }
 func (w *inspectableWorker) SetModel(context.Context, string, string) error { return nil }
 func (w *inspectableWorker) SetThinkingLevel(context.Context, string) error { return nil }
 func (w *inspectableWorker) Abort(context.Context) error                    { return nil }


### PR DESCRIPTION
Fixes #98.

## Root cause

`POST /api/chat` returns 202 and runs `chatSender.Send` in a goroutine. `workers.Manager.Send` first spawns the worker (process start + `switch_session` + `get_state` — seconds under parallel CI load) and only `worker.Prompt()` flips the worker status to Running. For that whole spawn window `Manager.Status()` reported **idle** even though a run was in flight, causing:

1. **The queue drainer stole queued items** (the Mobile Chrome `toHaveCount(1) got 0` failure in run 29111916570, and a real product bug): queueing a message kicks the drainer, which saw idle, popped the just-queued item, and dispatched it into the still-starting run — "Queue for later" silently behaved like "send now". The panel never showed the item because `enqueueQueued`'s add→list round-trip already saw an empty queue.
2. **Steer chips were dropped** (the iPad `_screenshots` failure in run 29113390457): status polls saw running (800ms recent-JSONL-activity fallback) then dipped to idle during spawn → spurious `pi-worker-done` → `steer-queue.js` reset `activeRun`, so the next mid-run send pushed no steer chip.

## Fix

- `workers.Manager` now counts in-flight sends and `Status()` reports Running from the moment a `Send` is accepted until the prompt is acked — by which point the worker's own Running status has taken over, so the session never observably dips to idle mid-send. Failed sends (spawn error) fall back to idle so the drainer's tick can retry.
- The Enter skip-ahead e2e test now uses `suspendChipCleanup` before asserting the steer row (the retry failure in run 29111916570): the stub echoes the steer into the JSONL instantly and the chip auto-clears on the resulting reload, so asserting it without the stall races the reload round-trip — the same pattern every other steer-row test already uses.

## Verification

- New unit tests: `TestManagerStatusReportsRunningWhileSendSpawnsWorker` (fails on the old code) and `TestManagerStatusIdleAfterFailedSend`.
- `cd e2e && npx playwright test tests/steer-queue.spec.ts --project="Mobile Chrome" --project="iPad" --repeat-each=10` → 300 passed.
- `npx playwright test tests/_screenshots.spec.ts --project="iPad" --grep "@screenshots" --repeat-each=10` → 10 passed.
- `make check` passes.