### PR TITLE
fix(web): resume terminal with session id

### DIFF
--- a/e2e/lib/chat.ts
+++ b/e2e/lib/chat.ts
@@ -1,0 +1,42 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Suspend the browser-local cleanup that removes steer chips when the session
+ * reloads. The stub pi echoes a steer immediately, so a normal reload can
+ * remove the chip before a screenshot or assertion observes it.
+ *
+ * Returns a release callback that reenables cleanup and replays a reload event.
+ */
+export async function suspendSteerChipCleanup(
+  page: Page,
+): Promise<() => Promise<void>> {
+  await page.evaluate(() => {
+    const w = window as Window & {
+      __piSuspendChipCleanup?: boolean;
+      __piOriginalDispatch?: typeof window.dispatchEvent;
+    };
+    if (w.__piOriginalDispatch) {
+      w.__piSuspendChipCleanup = true;
+      return;
+    }
+    w.__piSuspendChipCleanup = true;
+    const original = window.dispatchEvent.bind(window);
+    w.__piOriginalDispatch = original;
+    window.dispatchEvent = function (event: Event) {
+      if (
+        w.__piSuspendChipCleanup &&
+        (event.type === "pi-session-reload" || event.type === "pi-worker-done")
+      ) {
+        return true;
+      }
+      return original(event);
+    };
+  });
+  return async () => {
+    await page.evaluate(() => {
+      const w = window as Window & { __piSuspendChipCleanup?: boolean };
+      w.__piSuspendChipCleanup = false;
+      window.dispatchEvent(new Event("pi-session-reload"));
+    });
+  };
+}

--- a/e2e/tests/_screenshots.spec.ts
+++ b/e2e/tests/_screenshots.spec.ts
@@ -5,6 +5,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { test, expect, collapseScratchpad } from "../lib/test";
+import { suspendSteerChipCleanup } from "../lib/chat";
 import {
   buildSession,
   realWorkingDir,
@@ -39,19 +40,11 @@ test.describe("@screenshots queue + steer panel @screenshots", () => {
     await expect(page.locator("#pi-chat-send")).toHaveText("Steer");
 
     // ── 1. Steer chip mid-flight ─────────────────────────────────────────────
-    // The chip clears the moment pi echoes the user entry back via SSE reload
-    // (steer-queue.js's reconcileSteersAgainstEntries) — which in stub-pi is
-    // ~50ms. Stall the /api/session refetch that the SSE 'reload' triggers so
-    // the chip stays on screen long enough to capture.
-    let stallReloads = true;
-    await page.route("**/api/session?**", async (route) => {
-      while (stallReloads) await new Promise((r) => setTimeout(r, 100));
-      try {
-        await route.continue();
-      } catch {
-        /* route may already be handled if the page navigated away */
-      }
-    });
+    // The stub echoes the steer immediately. Suspend the browser-local cleanup
+    // event instead of stalling the refetch: the reload event is dispatched
+    // after the refetch resolves, so route interception cannot prevent the
+    // chip from being removed before the assertion observes it.
+    const releaseSteerCleanup = await suspendSteerChipCleanup(page);
     await textarea.fill("focus on the integration tests first");
     await page.locator("#pi-chat-send").click();
     await expect(page.locator(".pi-queue-item.pi-queue-item--steer")).toBeVisible();
@@ -59,8 +52,7 @@ test.describe("@screenshots queue + steer panel @screenshots", () => {
       path: path.join(SHOT_DIR, "01-steer-in-flight.png"),
       animations: "disabled",
     });
-    stallReloads = false;
-    await page.unroute("**/api/session?**");
+    await releaseSteerCleanup();
     // Let the deferred reload finish before moving on so subsequent shots see
     // a clean steer-cleared state.
     await expect(page.locator(".pi-queue-item.pi-queue-item--steer")).toHaveCount(0, {

--- a/e2e/tests/steer-queue.spec.ts
+++ b/e2e/tests/steer-queue.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, collapseScratchpad } from "../lib/test";
+import { suspendSteerChipCleanup } from "../lib/chat";
 import {
   buildSession,
   realWorkingDir,
@@ -51,50 +52,6 @@ test.describe("steer / queue (stubbed pi)", () => {
     return { textarea };
   }
 
-  // Blocks the chip auto-clear pipeline until released. steer-queue.js wires
-  // its cleanup off `pi-session-reload` (FIFO pop on new user entries) and
-  // `pi-worker-done` (full sweep at run-end). For events fired at the
-  // window target, listeners fire in registration order regardless of the
-  // capture flag, so an add-on capture listener can't reliably preempt the
-  // already-installed steer-queue listener.
-  //
-  // Instead we monkey-patch `window.dispatchEvent` to swallow the cleanup
-  // events while suspended. The SPA's emitter (live-events.js) calls
-  // `windowImpl.dispatchEvent(...)` which goes through our patched function,
-  // so no listeners ever see the event. Release flips the flag and replays
-  // a fresh `pi-session-reload` so the chip's normal downstream cleanup can
-  // still run.
-  async function suspendChipCleanup(page) {
-    await page.evaluate(() => {
-      const w = window as Window & {
-        __piSuspendChipCleanup?: boolean;
-        __piOriginalDispatch?: typeof window.dispatchEvent;
-      };
-      if (w.__piOriginalDispatch) {
-        w.__piSuspendChipCleanup = true;
-        return;
-      }
-      w.__piSuspendChipCleanup = true;
-      const original = window.dispatchEvent.bind(window);
-      w.__piOriginalDispatch = original;
-      window.dispatchEvent = function (event: Event) {
-        if (
-          w.__piSuspendChipCleanup &&
-          (event.type === "pi-session-reload" || event.type === "pi-worker-done")
-        ) {
-          return true;
-        }
-        return original(event);
-      };
-    });
-    return async () => {
-      await page.evaluate(() => {
-        const w = window as Window & { __piSuspendChipCleanup?: boolean };
-        w.__piSuspendChipCleanup = false;
-        window.dispatchEvent(new Event("pi-session-reload"));
-      });
-    };
-  }
 
   test("steering shows a panel row and delivers the message", async ({
     page,
@@ -110,7 +67,7 @@ test.describe("steer / queue (stubbed pi)", () => {
     });
 
     const steerMsg = `steer-${testInfo.workerIndex}-${Date.now()}`;
-    const release = await suspendChipCleanup(page);
+    const release = await suspendSteerChipCleanup(page);
     await textarea.fill(steerMsg);
     await page.locator("#pi-chat-send").click();
 
@@ -142,7 +99,7 @@ test.describe("steer / queue (stubbed pi)", () => {
     });
 
     const steerMsg = `fast-steer-${testInfo.workerIndex}-${Date.now()}`;
-    const release = await suspendChipCleanup(page);
+    const release = await suspendSteerChipCleanup(page);
     await textarea.fill(steerMsg);
     await page.locator("#pi-chat-send").click();
 
@@ -173,7 +130,7 @@ test.describe("steer / queue (stubbed pi)", () => {
     });
 
     const steerMsg = `dismiss-${testInfo.workerIndex}-${Date.now()}`;
-    const release = await suspendChipCleanup(page);
+    const release = await suspendSteerChipCleanup(page);
     await textarea.fill(steerMsg);
     await page.locator("#pi-chat-send").click();
 
@@ -316,7 +273,7 @@ test.describe("steer / queue (stubbed pi)", () => {
     // chip auto-clears on the resulting reload (reconcileSteersAgainstEntries)
     // — often faster than the assertions below can run. Stall the cleanup so
     // the steer row is reliably observable, like the other steer-row tests.
-    const release = await suspendChipCleanup(page);
+    const release = await suspendSteerChipCleanup(page);
 
     // Skip ahead to the third item.
     await page.keyboard.press("ArrowDown");

--- a/internal/ui/export_html_test.go
+++ b/internal/ui/export_html_test.go
@@ -184,11 +184,11 @@ func TestResumeButtonShowsToastWithoutChangingButtonText(t *testing.T) {
 	if !strings.Contains(src, `Copied`) || !strings.Contains(liveSessionCss, `.toast-notice`) {
 		t.Fatalf("resume copy should show an accent-colored toast notification")
 	}
-	if !strings.Contains(src, `document.body.dataset.sessionUuid`) {
-		t.Fatalf("resume copy should read real session UUID from body data attribute")
+	if !strings.Contains(src, `sessionUUID || sessionId`) {
+		t.Fatalf("resume copy should use the session UUID and fall back to the session file id")
 	}
-	if !strings.Contains(src, `resumeSessionArg`) {
-		t.Fatalf("resume copy should derive UUID-only session argument")
+	if strings.Contains(src, `document.body.dataset.sessionUuid`) {
+		t.Fatalf("resume copy should not depend on a missing SPA body data attribute")
 	}
 }
 

--- a/web/src/components/session/SessionHeader.svelte
+++ b/web/src/components/session/SessionHeader.svelte
@@ -6,7 +6,7 @@
   import { showToast } from '../../shared/toast.js';
   import { copyToClipboard } from '../../shared/clipboard.js';
   import { sessionTitle, setSessionTitle } from '../../session/session-title.svelte.js';
-  let { title = 'Session', cwd = '', sessionId = '' } = $props();
+  let { title = 'Session', cwd = '', sessionId = '', sessionUUID = '' } = $props();
 
   // The title prop seeds the shared store (and re-seeds it on session switch);
   // renames/auto-titling update the store, which this component renders and
@@ -37,7 +37,8 @@
     const newBtn = document.getElementById('new-btn');
 
     const onResume = () => {
-      const resumeSessionArg = document.body.dataset.sessionUuid;
+      const resumeSessionArg = sessionUUID || sessionId;
+      if (!resumeSessionArg) return;
       const command = 'pi --session ' + resumeSessionArg;
       copyText(command, () => showResumeCopiedNotice(command));
     };

--- a/web/src/components/session/SessionShell.svelte
+++ b/web/src/components/session/SessionShell.svelte
@@ -34,6 +34,7 @@
     sessionModel,
     contentRuntime,
     sessionId = '',
+    sessionUUID = '',
     title = 'Session',
     scratchpad = '',
     cwd = '',
@@ -143,7 +144,7 @@
   });
 </script>
 
-<SessionHeader {title} {cwd} {sessionId} />
+<SessionHeader {title} {cwd} {sessionId} {sessionUUID} />
 
 <CommandMenu {sessionId} {runningSessionIds} />
 

--- a/web/src/routes/SessionPage.svelte
+++ b/web/src/routes/SessionPage.svelte
@@ -35,6 +35,7 @@
   let showLoading = $state(false);
   let error = $state('');
   let sessionId = $state('');
+  let sessionUUID = $state('');
   let title = $state('Session');
   let payloadBase64 = $state('');
   let scratchpad = $state('');
@@ -69,6 +70,7 @@
         });
         if (!active) return;
         sessionId = state.sessionId;
+        sessionUUID = state.sessionUUID;
         title = state.title;
         document.title = title;
         cwd = state.cwd;
@@ -136,6 +138,7 @@
     {sessionModel}
     {contentRuntime}
     {sessionId}
+    {sessionUUID}
     {title}
     {scratchpad}
     {cwd}

--- a/web/src/routes/session-page-data.js
+++ b/web/src/routes/session-page-data.js
@@ -75,6 +75,7 @@ export function buildSessionPageState({
   const entries = Array.isArray(data?.entries) ? data.entries : [];
   const header = data?.header || {};
   const cwd = header.cwd || '';
+  const sessionUUID = data?.sessionUUID || data?.SessionUUID || header.id || '';
   const title = data?.name || sessionId;
   const leafId = newestLeaf(entries);
   const total = Number.isInteger(data?.total) ? data.total : entries.length;
@@ -89,6 +90,7 @@ export function buildSessionPageState({
   const provider = data?.modelProvider || data?.ModelProvider || '';
   return {
     sessionId,
+    sessionUUID,
     title,
     entries,
     cwd,

--- a/web/src/routes/session-page-data.test.js
+++ b/web/src/routes/session-page-data.test.js
@@ -39,7 +39,7 @@ describe('session-page-data', () => {
       btoaImpl,
       data: {
         name: 'Title',
-        header: { cwd: '/tmp/project' },
+        header: { cwd: '/tmp/project', id: '019-session-uuid' },
         entries: [{ id: 'a' }, { id: 'b' }],
         total: 5,
         from: 3,
@@ -50,6 +50,7 @@ describe('session-page-data', () => {
     });
 
     expect(state.title).toBe('Title');
+    expect(state.sessionUUID).toBe('019-session-uuid');
     expect(state.cwd).toBe('/tmp/project');
     expect(state.scratchpad).toBe('notes');
     expect(state.chatAvailable).toBe(false);


### PR DESCRIPTION
## Summary
- fix the Resume via Terminal command so it no longer copies `pi --session undefined`
- pass the session UUID through the SPA session page and fall back to the session file ID
- add regression coverage for UUID propagation

## Tests
- `make test`
- `make build`