### PR TITLE
fix(extension): auto-start must not kill a running server (restart storm, #112)

### DIFF
--- a/.pi/extensions/pi-web.ts
+++ b/.pi/extensions/pi-web.ts
@@ -203,7 +203,9 @@ export function openBrowser(pi: ExtensionAPI, url: string): Promise<void> {
 async function healthCheck(host: string, port: string): Promise<boolean> {
   try {
     const res = await fetch(`http://${host}:${port}`, {
-      signal: AbortSignal.timeout(1000),
+      // 1s was tight enough that a busy machine reported a healthy server as
+      // down. A false negative here is expensive: it triggers service restarts.
+      signal: AbortSignal.timeout(4000),
     });
     // 401/403 means pi-web is running with auth enabled.
     return res.ok || res.status === 401 || res.status === 403;
@@ -218,7 +220,17 @@ function windowsLauncher(): string {
   return join(homedir(), ".config", "pi-web", "pi-web-start.vbs");
 }
 
-async function startPiWeb(pi: ExtensionAPI): Promise<void> {
+// startPiWeb must only ever *start* the service. It used to run
+// `launchctl kickstart -k`, which SIGTERMs a running instance (pi-web exits 0
+// on SIGTERM). This function is reached from the opportunistic load-time check
+// that every pi process runs, so one transient health-check failure killed a
+// healthy server, which then made every other concurrent check fail and kickstart
+// too -- a self-sustaining restart storm. Killing is left to /pi-web restart.
+async function startPiWeb(
+  pi: ExtensionAPI,
+  host = "127.0.0.1",
+  port = "31415",
+): Promise<void> {
   if (process.platform === "win32") {
     const launcher = windowsLauncher();
     if (!existsSync(launcher)) {
@@ -233,7 +245,11 @@ async function startPiWeb(pi: ExtensionAPI): Promise<void> {
   if (process.platform === "darwin") {
     await pi.exec("sh", [
       "-lc",
-      `plist="$HOME/Library/LaunchAgents/com.pi-web.plist"; if [ ! -f "$plist" ]; then exit 127; fi; launchctl bootstrap "gui/$(id -u)" "$plist" 2>/dev/null || launchctl load "$plist" 2>/dev/null || true; launchctl kickstart -k "gui/$(id -u)/com.pi-web" 2>/dev/null || launchctl start com.pi-web`,
+      `plist="$HOME/Library/LaunchAgents/com.pi-web.plist"; if [ ! -f "$plist" ]; then exit 127; fi; ` +
+        `launchctl bootstrap "gui/$(id -u)" "$plist" 2>/dev/null || launchctl load "$plist" 2>/dev/null || true; ` +
+        // Something already bound to the port is not "not running"; leave it alone.
+        `if nc -z '${host}' '${port}' 2>/dev/null; then exit 0; fi; ` +
+        `launchctl start com.pi-web 2>/dev/null || true`,
     ]);
     return;
   }
@@ -318,8 +334,13 @@ async function ensurePiWebRunning(
 ): Promise<boolean> {
   if (await healthCheck(host, port)) return true;
 
+  // Confirm before touching a service other processes may be using: concurrent
+  // pi starts amplify a single slow response into restarts of a healthy server.
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  if (await healthCheck(host, port)) return true;
+
   try {
-    await startPiWeb(pi);
+    await startPiWeb(pi, host, port);
   } catch {
     return false;
   }
@@ -825,7 +846,7 @@ export default function (pi: ExtensionAPI) {
           return;
         }
         try {
-          await startPiWeb(pi);
+          await startPiWeb(pi, host, port);
           let started = false;
           for (let i = 0; i < 10; i++) {
             await new Promise((resolve) => setTimeout(resolve, 300));


### PR DESCRIPTION
## Problem

`.pi/extensions/pi-web.ts` starts the server opportunistically on **every extension load** — once per `pi` process, including the `pi --mode rpc` workers that pi-web itself spawns. When the health check failed, `startPiWeb()` ran:

```sh
launchctl kickstart -k "gui/$(id -u)/com.pi-web"
```

`-k` **stops the running instance first**. pi-web handles `SIGTERM` and exits `0`, so launchd records a successful exit and the kill is invisible in `last exit code` — it looks like a voluntary quit, not a kill.

The kill briefly takes the port down, so every *other* `pi` process starting in that window fails its own health check and issues its own `kickstart -k`. Each restart manufactures more failures, and because pi-web's own RPC workers load this extension, the server ends up being restarted by its own children.

Observed on a macOS 15.8 / arm64 host, beta.36, ~200 sessions, load average 40–59:

```
runs = 582          last exit code = 0        #62 exits in 14 minutes
```

with intermittent `502`s from `tailscale serve`, which is what made the phone PWA unreachable. Bursts came and went depending on how many `pi` processes were starting; overnight, with nothing starting, zero restarts.

The confusing part for diagnosis: **a manually started `pi-web` is immune**, because `kickstart -k` addresses the launchd *job*, not a hand-run process. That reliably sends you hunting through launchd environment, `stdin`, `ThrottleInterval` and plist churn instead of here. Full write-up with A/B evidence in #112.

## Change

One file, `.pi/extensions/pi-web.ts`:

- **`startPiWeb()` can no longer kill.** If something is already bound to the port it is not "not running", so it exits without touching the job; otherwise plain `launchctl start` (no `-k`).
- **`ensurePiWebRunning()` confirms before acting.** A second check 1.5 s later, because one failed fetch is not proof that a server other processes are using is dead.
- **Health-check timeout 1 s → 4 s.** A healthy server answers in ~3 ms measured; since 401/403 already count as up, the only way to fail is a timeout — precisely the transient state a loaded machine produces.

`/pi-web restart` keeps `kickstart -k`. An explicit user request to restart should still kill; only the implicit, load-time path needed the kill removed.

## Verification

```
npm run test:extensions   →  Test Files 2 passed (2), Tests 46 passed (46)
```

All markers asserted by `internal/app/extension_static_test.go` (`pi.registerCommand("pi-web"|"remote"|"refresh")`, `Usage: /pi-web …`, `launchctl`, `systemctl`, `import("qrcode")`) are present. `go test ./internal/app/` could not run in my environment — it fails at `web/assets_embed.go:8: pattern all:dist: no matching files found` because the frontend `dist` isn't checked in; I verified those markers by inspection instead.

A/B against the live launchd job on the reporting machine (`state = running`, child pid 6326):

| command run | `runs` | child pid | tailnet |
|---|---|---|---|
| patched start path | 1 (unchanged) | 6326 (unchanged) | 200 |
| `launchctl kickstart -k` (beta.36 behaviour) | 2 (+1) | replaced within 2 s | recovered |

The reporting machine has run this patch since it was written; no further restarts.

## Not in this PR

Findings 2 and 3 from #112 are separate and untouched here: the `serveRuleConflict` false alarm in `tailscaleServeRuleState` (`internal/app/tailscale.go:120`, which looks for the port as a JSON **key** and so matches `TCP[port] == {"HTTPS": true}` — zero strings — instead of `Web["<host>:<port>"].Handlers[*].Proxy`), and `Main()` returning normally after `SIGTERM` so the shutdown cause is indistinguishable from a clean exit. Happy to send either as a follow-up if useful.
